### PR TITLE
Mediated credential egress: Phase 0 contract and test skeletons

### DIFF
--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -1,0 +1,221 @@
+# Plan: Mediated Credential Egress
+
+Status: draft for review
+Version: v3.2 (review findings 1–5 incorporated)
+
+## Goal
+
+Not a single raw secret is available to the agent container — including short-lived derived credentials like GitHub App installation tokens. Today, providers like `codex-oauth` materialize a usable access token into the container as a file bundle; a prompt-injected agent can exfiltrate it for its lifetime. Target state: credentials are injected into outbound requests by a trusted sidecar at the network edge, while the broker keeps doing what it does today — policy, refresh, audit. On that choke point we add per-request audit, quotas, and mid-run revocation.
+
+The invariant is a bright line, CI-enforced: inspect the container — filesystem, env, process args — and find zero secret material. No "small accepted exposures": exceptions accumulate and erode. Capabilities that cannot be mediated (git-SSH, file-native-TLS tools) are disallowed in mediated mode, not excepted.
+
+The feature is optional and per-grant: "off" is exactly today's system, not a degraded mode.
+
+## Two guarantees, deliberately decoupled
+
+The plan delivers two properties that defend different threats and must not gate each other:
+
+| Guarantee | Threat defeated | Depends on | Ships in |
+|---|---|---|---|
+| **Credential non-possession** — no token in the container | credential theft / exfiltration | egressd + broker identity-split only | Phases 1–3 |
+| **Egress default-deny** — agent cannot reach arbitrary hosts | data exfiltration (source, prompts) | enforcement outside the agent's privilege domain | Phase 5, independently |
+
+Non-possession stands alone: with no token in the container, direct reach to an API host yields 401. Egress-deny is defense-in-depth against a different attack. Each gets its own CI smoke test; the achievable guarantee must never wait on the hard one.
+
+## Architecture
+
+### 1. Broker: materialization modes + generic injection capability
+
+Each capability grant gets a materialization mode:
+
+- **`file-bundle`** — current behavior (auth files written into the container via `/v1/files` + `broker-auth-files`). Stays supported as the dev/fallback path; its conformance tests remain required in CI for as long as the path exists.
+- **`header-inject`** — the broker never releases the secret to the agent's identity. Only the egress sidecar's identity may fetch injectable material; the agent's identity requesting the same capability receives routing config only (base URL, allowed hosts) — no secret.
+
+Modes are mutually exclusive per grant, enforced broker-side: no hybrid where a sidecar runs but bundles are also written ("cost of both paths, guarantee of neither").
+
+The make-or-break lever: **header-inject is a provider-agnostic capability** — the sidecar asks "give me the injectable headers for (host, method, path)" and the broker returns headers. This is a **new endpoint** (e.g. `POST /v1/injection/headers`), not a reuse of the existing `/v1/headers`: that endpoint is a compatibility surface that returns secret-bearing headers *to the caller*, which is precisely the access model header-inject must invert. The response shape may mirror `/v1/headers`, but the new endpoint is callable only by egress-role identities (see identity model below) and its material is never obtainable by an agent identity. Existing `/v1/headers` remains unchanged for direct-mode compatibility. It is not a codex-shaped endpoint. Built this way, `token` / `headers` / `codex-oauth` / Anthropic / GitHub App all become config-only for egressd; new providers are broker plugins with zero sidecar changes. Pinned in Phase 0 with a conformance test before any implementation.
+
+**Identity model — roles and pairing, not just two tokens.** Today's broker identities are agent token hashes plus provider grants; reusing that shape for the sidecar would produce "two bearer tokens with the same grants," which loses the load-bearing property. The broker config gains:
+
+- a **role** per identity: `agent` or `egress`. Only `egress`-role identities may call `/v1/injection/headers`; only `agent`-role identities may hold capability grants.
+- a **pairing** (audience): each `egress` identity is bound to exactly one agent identity. An injection request is authorized only if the caller's role is `egress` **and** the referenced capability is granted to the caller's paired agent. Agent A's sidecar cannot fetch material for agent B's grants, and no single identity can both run the workload and fetch secrets.
+
+Both rules are enforced broker-side and pinned by the identity-split conformance test (Phase 0).
+
+The broker remains the single refresh-token writer; refresh logic is unchanged — only *who may fetch the derived credential* changes. Protocol changes go in `protocol/broker.md`, pinned by conformance tests before implementation.
+
+### 2. Egress sidecar (`egressd`)
+
+A small trusted reverse proxy (Go, consistent with gateway/producer style) running alongside the agent — one service in `compose.agent.yaml` locally, one container in the AgentRun Pod in k8s (see §6 on placement).
+
+- **Own broker identity, distinct from the agent's** — a separate bearer token locally; a projected ServiceAccount token validated via TokenReview in k8s. This is load-bearing: compromise of the agent container yields an identity that cannot obtain credentials. Built in from the first spike, pinned by an identity-split conformance test — never retrofitted.
+- Listens on localhost; routes to configured upstreams; fetches injectable headers from brokerd on demand, caches until expiry, injects the header, re-originates TLS to pinned upstream hostnames.
+- Passes SSE/streaming responses through cleanly (required for LLM APIs).
+- **Fail closed**: if the broker is unreachable or a grant is revoked, requests fail — never fall back to cached-stale-beyond-TTL, never fall back to writing a bundle.
+- Never logs header values or token material, including on error paths.
+- Makes the `broker-auth-files-refresher` plugin unnecessary for injected providers — freshness becomes the sidecar's cache policy.
+- **Placement-agnostic contract**: the injector protocol and grant descriptors reference egressd only by URL. Nothing in the contract assumes same-Pod/localhost, so placement can change later (see §6) as config, not rework.
+
+**Review tier: trusted core.** egressd terminates TLS and injects credentials; its failure modes (request smuggling, upstream-host confusion / SSRF, SSE frame handling, header leakage on error paths) are invisible to functional tests. It gets line-by-line review alongside the broker changes — not "any code that passes."
+
+### 3. Routing vs. enforcement
+
+"All traffic through the sidecar" is two separate things:
+
+- **Routing** — credentialed API traffic is pointed at egressd via base-URL/proxy config. DNS, brokerd, and the event-webhook callback always go direct (they are the allowlist).
+- **Enforcement** — what stops the agent bypassing egressd and calling upstreams directly. This is the hard part (§7), and it is what separates non-possession (routing alone suffices) from exfil control (needs enforcement).
+
+Routing without enforcement still delivers non-possession. It does not deliver egress control. Stated so nobody reads "traffic goes through the sidecar" as a property compose actually has.
+
+### 4. Runtime wiring
+
+`runtime/core/bootstrap.py` keys off what it's given, keeping the image mode-agnostic:
+
+- Mediated grant → write `ANTHROPIC_BASE_URL` / Codex `config.toml` (`model_providers.*.base_url`, `chatgpt_base_url`) pointing at the sidecar; write **no** auth files.
+- Direct grant → today's behavior exactly (bundles / host-seeded `~/.codex`, `.agents/<name>/auth/claude`).
+
+**Non-secret placeholders are allowed where a CLI demands one.** Some CLIs refuse to start without a syntactically present API key or auth file. Mediated mode may write a fixed, obviously-non-secret placeholder (e.g. `NVT-PLACEHOLDER-NOT-A-KEY`) to satisfy the parser. Two conditions, both test-enforced: (1) the placeholder value is a documented constant carrying zero secret entropy, allowlisted by the non-possession smoke test; (2) a conformance test proves the placeholder is inert upstream — a direct (sidecar-bypassing) request presenting it is rejected by the provider, so possession of the placeholder grants nothing. egressd strips or replaces the placeholder header on injection; it must never be forwarded alongside the real credential.
+
+### 5. git-over-HTTPS mediation (its own phase — highest-risk surface)
+
+To honor the zero-secrets bright line for git, the token must be injected, not handed to git (the credential-helper path necessarily passes the token through agent-owned process memory, so it cannot satisfy the invariant):
+
+- **GitHub App is mediatable** because the repo is in the URL (`/repos/owner/name/...`, `github.com/owner/repo.git`) → egressd extracts scope, fetches a per-repo installation token, injects `Authorization`. The REST half is already broker-mediated via `/v1/http/request`.
+- **git-HTTPS forces egressd to be a TLS-terminating proxy** with a per-agent CA. Only the **CA certificate** enters the agent trust store; the **CA private key lives exclusively in egressd** and is itself subject to the zero-secrets invariant (a key in the container would let the agent impersonate any upstream to itself and harvest injected credentials). A hostile root agent deleting the CA cert or setting `GIT_SSL_NO_VERIFY` is self-DoS, not a bypass — it breaks the agent's own git and still yields no token.
+- **Mediated bootstrap scrubs pre-existing git auth state**: existing credential helpers are unset (`credential.helper` cleared at system/global scope), `http.extraHeader` and `url.*.insteadOf` rewrites are removed, and `~/.git-credentials` / credential caches are absent. Otherwise stale local credentials — seeded homes, leftover helper config — silently violate the zero-secret invariant while all injection tests pass. The non-possession smoke test asserts this scrubbed state explicitly.
+- **Interim honesty**: until Phase 5 lands, git mediation delivers non-possession only. The CA-deletion analysis is complete on its own (no CA → broken git, still no token), but "the agent cannot reach github.com directly at all" is a Phase-5 enforcement property — this doc must not be read as implying it holds at Phase-4 time.
+- **git-SSH and file-native-TLS tools are disallowed in mediated mode.** Force HTTPS remotes.
+
+This is a distinct phase because TLS termination is the single highest-risk surface in the design — it never rides along with the LLM-API work.
+
+### 6. Placement decision (resolved)
+
+**Same-Pod/localhost for Phases 1–4; own-Pod is the declared candidate for Phase-5 enforcement in k8s.**
+
+Same-Pod is right for the non-possession phases: localhost keeps the plaintext agent→egressd hop inside the netns, wiring is symmetric with compose, lifecycle is trivial. But same-Pod has a structural consequence for enforcement: host-side NetworkPolicy sees one endpoint, so it must allow the union of agent+sidecar destinations — the agent can always *reach* upstream hosts directly (credential-less, but reachable). And in-netns iptables live where the agent can gain NET_ADMIN. Kata does not fix this — inside the guest, the agent can still flush guest iptables; enforcement must live **outside the agent's privilege domain**.
+
+Own-Pod egressd flips it: the agent Pod's NetworkPolicy ("egress only to egressd Pod + DNS + broker + callback") is enforced at the CNI on the host side, beyond the agent's reach even with full privileges in its netns — the one clean enforcement story available today. Costs: heavier lifecycle (two Pods per run, pairing), and the plaintext hop crosses the CNI (mitigate with same-node affinity; it carries no credentials either way, since the agent has none).
+
+Because the contract is placement-agnostic (§2), this is a Phase-5 evaluation — own-Pod vs. deprivileged-dind — not a Phase-1 commitment.
+
+### 7. Egress enforcement — the hard problem, stated honestly
+
+Enforcement requires distinguishing the sidecar from the agent at the network layer. With same-Pod placement, NetworkPolicy cannot (it selects Pods, not containers; verified: the agent joins the dind netns via `network_mode: service:docker` locally, same-Pod in k8s).
+
+The in-netns layer is iptables:
+
+- **`-m owner --uid-owner` in OUTPUT** — allow the sidecar's UID out, deny the agent's UID — covers locally-generated traffic.
+- **FORWARD-chain deny is also required**: traffic from containers spawned *inside* dind traverses FORWARD in the shared netns with no socket owner, so owner-match never sees it. Without the FORWARD rules, dind workloads bypass enforcement while all tests on agent-local traffic pass. This is a named Phase-5 spike item.
+- Rules installed by a NET_ADMIN init step before the agent starts, in both backends. NetworkPolicy remains a coarse outer fence in k8s.
+
+**Unstated precondition, now explicit**: in-netns enforcement only holds where the agent cannot obtain NET_ADMIN in that netns. Today it can — the agent controls a privileged dind daemon (`privileged: true` in `compose.agent.yaml`) and can `docker run --privileged --net container:…` to flush the rules. Therefore:
+
+- Enforcement is a real control via **own-Pod egressd + CNI-enforced NetworkPolicy** (k8s), or with **dind deprivileged/relocated** (either backend).
+- Under today's compose + `danger-full-access` + per-agent privileged dind, egress-deny is a speed bump, not a control — a **documented gap**, acceptable under the local trust model ("you trust yourself"), not an implicit one.
+- This inverts the naive asymmetry: compose is the hard side for enforcement, k8s the tractable side. Non-possession, by contrast, is clean in both.
+
+**Compose decision (resolved): accept the documented gap.** Non-possession still holds locally, and the platform's real autonomous exposure is operator mode — that is where enforcement must be real. Deprivileging/relocating dind is tracked as an independent workstream that, when it lands, upgrades compose egress-deny from speed bump to control; it is not a prerequisite for anything in this plan.
+
+### 8. Explicitly out of scope
+
+- git-SSH, file-native-TLS binaries: disallowed in mediated mode, not mediated.
+- **agentd is untouched.** It is session I/O and explicitly not a security boundary; egressd belongs with broker/operator/runtime wiring. Architectural invariant, not a preference.
+
+## Configuration surface (optionality)
+
+| Layer | Knob | Default |
+|---|---|---|
+| Broker | per-grant `materialization: file-bundle \| header-inject` | `file-bundle` |
+| Operator | AgentRun/AgentSchedule spec `egress: mediated \| direct`, defaultable via Helm values | opt-in; flip default to `mediated` once smoke tests are in CI |
+| Compose | `agent-init MEDIATED=1` profile adding the sidecar (+ iptables when enforcement lands), skipping bundles | `direct` |
+
+When `direct`, the operator renders exactly today's Pod — no sidecar, no NetworkPolicy, no iptables. Both paths stay conformance-tested for as long as both are supported; bundle-path tests (`broker_auth_files` etc.) do not decay while the path remains the documented fallback.
+
+**Mode mismatch fails admission — both directions, no downgrade.** The run-level `egress` mode and per-grant `materialization` must agree, validated at AgentSchedule admission (and mirrored in compose `agent-init`):
+
+- `egress: direct` + any `header-inject` grant → **admission failure** (the grant's secret would be unfetchable, or worse, an implementation might "helpfully" materialize it as a bundle).
+- `egress: mediated` + any `file-bundle` grant → **admission failure** (a bundle written into a supposedly zero-secret container silently breaks the invariant).
+
+Silent downgrade or ignore in either direction would violate risk #2 (silent fallback). The error is loud, names the offending grant, and the operator surfaces it on the AgentRun status.
+
+## Phases
+
+### Phase 0 — Contract and tests first
+
+Before any implementation is delegated; human-reviewed — this is where the security thinking lives.
+
+- Injection protocol doc in `protocol/` — the new `/v1/injection/headers` endpoint (distinct from compatibility `/v1/headers`), the identity role/pairing model (`agent` vs `egress`, one-to-one pairing), materialization modes, admission mismatch rules, and the placeholder convention; placement-agnostic (egressd referenced by URL only).
+- Identity-split conformance test: mediated grant → the paired `egress` identity gets injectable material; the `agent` identity requesting the same capability gets routing config only, no secret; an `egress` identity paired to a *different* agent is refused.
+- Admission conformance test: `direct` run × `header-inject` grant and `mediated` run × `file-bundle` grant both fail admission loudly — no downgrade path exists.
+- Placeholder-inertness test: where a CLI requires a syntactic key, the placeholder constant carries no entropy, is allowlisted by the non-possession test, and is rejected upstream when presented without sidecar injection.
+- Two separate smoke tests: **(a) non-possession** — boot mediated → assert zero secret material anywhere in the container (filesystem, env, process args), for all providers, including scrubbed git credential state (no helpers, no `http.extraHeader`, no stored credentials); **(b) egress-denied** — assert direct egress to upstream hosts is refused. Both mode-aware (skip *visibly* for direct runs so a misconfigured default can't pass silently). Split so (a) lands independent of the hard §7 work.
+
+### Phase 1 — Spike egressd against Codex, API-key mode
+
+Timeboxed and minimal. Build egressd, the identity role/pairing split, and bootstrap redirection using Codex with `model_providers.*.base_url` pointed at the sidecar and a plain bearer key injected from the broker (`token`-provider shape). This validates the entire chain — grant descriptor, identity split, header injection, TLS re-origination, SSE passthrough — on the simple auth mode of the provider actually in use. Separate `egress`-role broker identity from day one. Establish here whether Codex needs a syntactic placeholder key to start, and if so wire the placeholder convention (§4) including the inertness test. Run inside a crude deny-all netns as an *instrument*, not a control: any hardcoded-host call fails loudly, enumerating the real endpoint set Codex needs.
+
+**Scope guard**: nothing beyond what Phase 2 needs to render its verdict — no operator work, no polish, no second provider.
+
+### Phase 2 — ChatGPT-plan flow as the go/no-go gate
+
+Switch the working harness to the plan-auth path (`codex-oauth` grant in `header-inject` mode, `chatgpt_base_url` redirection). Required spike outputs:
+
+1. Does `chatgpt_base_url` cover every host the plan-auth flow touches? The deny-all instrument from Phase 1 answers this empirically.
+2. Does Codex pin certs on those hosts? Pinning defeats localhost TLS re-origination → design changes.
+
+Test refresh deterministically with broker-issued artificially short-lived tokens; verify the true SSE guarantee — new requests use the refreshed token, in-flight streams complete on the old one.
+
+**Go/no-go**: if plan-auth can't be redirected, plan-auth Codex stays on bundles and we reassess — API-key-mode Codex mediation (Phase 1's result) ships independently either way, so the fallback still retires file bundles for any agent runnable on an API key.
+
+### Phase 3 — Operator + compose wiring (non-possession ships)
+
+AgentRun controller conditionally adds the egressd container, its identity Secret, and config; compose gets the sidecar behind the profile flag; bootstrap generates redirected config for mediated grants. Phase-0 non-possession + identity-split tests land in CI here — from now on, later phases cannot regress the core property. (No enforcement yet — routing + non-possession only, per §3.)
+
+### Phase 4 — git-over-HTTPS mediation
+
+Per-agent CA, egressd TLS termination, repo-scope extraction, GitHub App token injection. Its own phase for its own risk surface. Delivers non-possession for git tokens; the reachability half waits for Phase 5 (§5 interim note).
+
+### Phase 5 — Egress enforcement + audit + quotas + revocation
+
+May split into two PRs (enforcement; observability/control) even as one phase.
+
+- **Enforcement**: evaluate own-Pod egressd + NetworkPolicy vs. deprivileged-dind as the k8s control (§6); iptables owner-match **plus FORWARD-chain deny** where in-netns rules apply; state the NET_ADMIN precondition and the compose gap explicitly. Egress-denied smoke test lands in CI here.
+- **Per-request audit** appended to the broker's `audit.jsonl` (agent, capability, host, method, path class, status).
+- **Per-grant request-count quotas** at the sidecar (spend quotas deferred — they need provider-response parsing, which couples the generic proxy to each provider).
+- **Revocation**: broker revokes grant → sidecar's next fetch fails → agent loses API access within one cache TTL, without killing the Pod.
+- **Anthropic as the provider-agnosticism proof**: adding `ANTHROPIC_BASE_URL` + a grant must be config-only with zero egressd changes — landing it *is* the test that the injector contract stayed provider-agnostic. If it requires sidecar code, that's a contract regression, not a feature.
+- Then flip the operator default to `mediated`.
+
+## PR sequence
+
+One phase per PR. This is load-bearing: line-by-line review of the trusted core is only realistic on phase-sized diffs; the Phase-2 gate must be able to stop the train before wiring investment; and the Phase-3 CI ratchet only protects later phases if phases merge sequentially. The constraint is on *merging*, not starting — Phase 0 can be reviewed while the Phase-1 spike runs against a draft of the contract.
+
+| PR | Contents | Merge gate |
+|---|---|---|
+| 1 | Phase 0: protocol doc + conformance/smoke test skeletons | human review of the contract — slowest, most careful |
+| 2 | Phase 1: egressd + identity split + Codex API-key mode | trusted-core review; timeboxed spike result |
+| 3 | Phase 2: ChatGPT-plan flow + refresh/SSE tests | **go/no-go decision recorded in the PR** |
+| 4 | Phase 3: operator + compose wiring; non-possession tests → CI | conformance green in CI |
+| 5 | Phase 4: git-HTTPS mediation (CA, TLS termination) | trusted-core review — highest-risk surface, deliberately alone |
+| 6a | Phase 5: enforcement (own-Pod evaluation, iptables + FORWARD deny) | egress-denied test → CI |
+| 6b | Phase 5: audit, quotas, revocation, Anthropic proof; flip operator default | both smoke tests green |
+
+## Division of labor
+
+- **Spec + tests (Phase 0)**: written up front, human-reviewed. Once the contract and suites are pinned, implementation is "any code that passes."
+- **Implementation**: delegated to the coding agent, one phase per PR. Phase-sized diffs keep review readable; the spikes suit an agent well (empirical trial-and-error against the Codex config surface under deny-all).
+- **Review focuses where tests can't reach**: secret handling in error paths/logs, fail-closed behavior when the broker is down, identity checks enforced broker-side (not sidecar politeness), no mode mixing both auth paths.
+- **Trusted core, line-by-line review**: broker identity/materialization changes and egressd itself — not test-trusting.
+
+## Key risks
+
+1. **ChatGPT-plan flow not redirectable or cert-pinned** — main empirical risk; front-loaded into Phases 1–2 with explicit fallback (plan-auth Codex stays on bundles; API-key-mode Codex mediation ships regardless).
+2. **Silent fallback to bundles on error** — defeats the property while everything looks fine; countered by fail-closed design, broker-side mutual exclusion, and the non-possession CI test.
+3. **Two-path rot** — the fallback suite decaying; countered by keeping both suites required in CI.
+4. **Identity split retrofitted late** — countered by making it a Phase-1 requirement + pinned conformance test.
+5. **Enforcement mistaken for shipped where the agent can flush it** — countered by stating the NET_ADMIN precondition, the FORWARD-chain requirement, and marking compose egress-deny a documented gap, not an implicit control.
+6. **Phase-1 scope creep delaying the go/no-go verdict** — countered by the explicit timebox and "only what Phase 2 needs" scope guard.
+
+## End state
+
+Agent containers hold zero credentials for mediated providers (LLM APIs, GitHub REST, git-HTTPS); the broker decides *whether* (grants, quotas), the sidecar handles *how* (injection at the edge); every credentialed request is audited; a grant is revocable mid-run within one cache TTL. Where enforcement lives outside the agent's privilege domain (own-Pod egressd + CNI policy, or deprivileged dind), a static default-deny makes the sidecar the only way out; where it does not (today's compose), non-possession still holds and egress-deny is a documented gap. All optional per grant, with today's behavior the untouched default until the smoke tests say otherwise.

--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -52,6 +52,7 @@ A small trusted reverse proxy (Go, consistent with gateway/producer style) runni
 - Listens on localhost; routes to configured upstreams; fetches injectable headers from brokerd on demand, caches until expiry, injects the header, re-originates TLS to pinned upstream hostnames.
 - Passes SSE/streaming responses through cleanly (required for LLM APIs).
 - **Fail closed**: if the broker is unreachable or a grant is revoked, requests fail — never fall back to cached-stale-beyond-TTL, never fall back to writing a bundle.
+- **The egressd↔broker channel is TLS, non-negotiable.** egressd shares the agent's network namespace, and this is the one leg that carries real credentials in flight; over plain HTTP (today's local brokerd on `:7347`), an agent that gains netns privileges (§7: privileged dind allows this today) could sniff tokens and sidestep non-possession entirely. The localhost agent→egressd hop needs no such protection (it carries no credentials — the agent has none to send), and the egressd→upstream leg is TLS by nature; the broker leg is the gap and must be closed from Phase 1.
 - Never logs header values or token material, including on error paths.
 - Makes the `broker-auth-files-refresher` plugin unnecessary for injected providers — freshness becomes the sidecar's cache policy.
 - **Placement-agnostic contract**: the injector protocol and grant descriptors reference egressd only by URL. Nothing in the contract assumes same-Pod/localhost, so placement can change later (see §6) as config, not rework.
@@ -215,6 +216,8 @@ One phase per PR. This is load-bearing: line-by-line review of the trusted core 
 4. **Identity split retrofitted late** — countered by making it a Phase-1 requirement + pinned conformance test.
 5. **Enforcement mistaken for shipped where the agent can flush it** — countered by stating the NET_ADMIN precondition, the FORWARD-chain requirement, and marking compose egress-deny a documented gap, not an implicit control.
 6. **Phase-1 scope creep delaying the go/no-go verdict** — countered by the explicit timebox and "only what Phase 2 needs" scope guard.
+7. **Credentials sniffed in flight on the egressd↔broker leg** — the one network path carrying real secrets through the shared netns; countered by requiring TLS on that channel from Phase 1 (§2).
+8. **Secret-returning API endpoints reachable through a grant** — an allowed API that mints/returns credentials in a response body delivers a secret into the container legitimately; countered by excluding credential-minting endpoints from grant path-classes as a standing policy rule.
 
 ## End state
 

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -143,6 +143,18 @@ Agent or egress role. Returns non-secret routing metadata for a capability.
 This is the only injection surface an `agent` identity may call, and its
 response never contains secret material — pinned by conformance test.
 
+Authorization mirrors the scoping of `/v1/injection/headers`:
+
+- An `agent` caller must itself hold a `header-inject` grant for the
+  requested capability.
+- An `egress` caller is authorized against its paired agent's grants; an
+  egress identity whose paired agent does not hold the grant is denied.
+- Capabilities not granted (including unknown capabilities) deny with the
+  standard error shape.
+- `file-bundle` grants deny. Routing is a mediated-mode surface; a
+  direct-mode grant has no sidecar to route to, and answering would let
+  routing act as a probe across materialization modes.
+
 Request:
 
 ```json

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -1,0 +1,206 @@
+# Injection Protocol (Mediated Credential Egress)
+
+Status: draft contract (Phase 0 of `docs/mediated-egress-plan.md`).
+Implementation begins in Phase 1. The conformance tests referenced at the
+bottom pin this contract before any implementation exists.
+
+This protocol delivers credential **non-possession**: for mediated grants, no
+provider credential — API key, OAuth access/refresh token, installation token —
+is ever available to the agent container. Credentials are injected into
+outbound requests by `egressd`, a trusted reverse proxy running alongside the
+agent, which fetches injectable material from `brokerd` under an identity the
+agent does not hold.
+
+```text
+agent    holds no credentials; sends requests to egressd over localhost
+egressd  trusted sidecar; fetches injectable headers, injects, re-originates TLS
+brokerd  policy, refresh, audit; releases injectable material to egress
+         identities only
+```
+
+## Relationship To Existing Broker Endpoints
+
+`/v1/token`, `/v1/headers`, and `/v1/files` (see `protocol/broker.md`) are
+compatibility endpoints: they return secret-bearing material **to the
+caller**. This protocol inverts that access model — the workload identity can
+never obtain the secret. `/v1/headers` is explicitly *not* the semantic anchor
+for injection; it remains unchanged for direct-mode compatibility.
+
+## Identity Model: Roles And Pairing
+
+Broker identities gain a `role`. Reusing plain agent identities for the
+sidecar would produce two bearer tokens with the same powers, which loses the
+non-possession property.
+
+```yaml
+agents:
+  - id: frontend
+    token-sha256: sha256:<hash>
+    role: agent            # default when omitted (backwards compatible)
+    grants:
+      - provider: codex-main
+        materialization: header-inject
+  - id: frontend-egress
+    token-sha256: sha256:<hash>
+    role: egress
+    paired-agent: frontend
+```
+
+Rules, all enforced broker-side:
+
+- `role` omitted means `agent`. Existing configs remain valid.
+- `egress` identities hold no grants. A config listing grants on an `egress`
+  identity is a validation error, not an ignored field.
+- Each `egress` identity is paired to exactly one agent identity via
+  `paired-agent`. Missing or unknown `paired-agent` is a validation error.
+- `egress` identities may call only `/health` and `/v1/injection/*`.
+  Secret-bearing endpoints (`/v1/token`, `/v1/headers`, `/v1/files`,
+  `/v1/http/request`) deny `egress` callers.
+- `agent` identities may not call `/v1/injection/headers`.
+- An injection request is authorized only when the caller's role is `egress`
+  **and** the requested capability is granted to the caller's paired agent.
+  Agent A's sidecar cannot fetch material for agent B's grants.
+- Kubernetes deployments replace bearer tokens with projected ServiceAccount
+  tokens validated via TokenReview; the role and pairing semantics are
+  unchanged.
+
+## Materialization Modes
+
+Each grant carries a materialization mode:
+
+- `file-bundle` (default) — current behavior; the agent identity may call the
+  compatibility endpoints per `protocol/broker.md`.
+- `header-inject` — zero-possession; only the paired egress identity may
+  obtain the credential, via `/v1/injection/headers`.
+
+Modes are mutually exclusive per grant, enforced broker-side:
+
+- A `header-inject` grant denies `/v1/token`, `/v1/headers`, and `/v1/files`
+  for that provider and agent.
+- A `file-bundle` grant denies `/v1/injection/headers` for that provider and
+  the paired egress identity.
+
+Run-level admission (normative here, enforced by the operator's
+AgentSchedule admission and by compose `agent-init` from plan Phase 3):
+
+- run `egress: direct` with any `header-inject` grant fails admission.
+- run `egress: mediated` with any `file-bundle` grant fails admission.
+- There is no downgrade path in either direction. The error names the
+  offending grant.
+
+## Endpoints
+
+### POST /v1/injection/headers
+
+Egress role only.
+
+Request:
+
+```json
+{
+  "capability": "codex-main",
+  "host": "chatgpt.com",
+  "method": "POST",
+  "path": "/backend-api/responses"
+}
+```
+
+Requires `Authorization: Bearer ...` (an `egress`-role identity).
+
+Response:
+
+```json
+{
+  "ok": true,
+  "headers": {
+    "authorization": "Bearer ..."
+  },
+  "expires_at": "2026-07-05T12:00:00Z",
+  "strip_request_headers": ["authorization"]
+}
+```
+
+Rules:
+
+- The endpoint is provider-agnostic. The broker maps `capability` to a
+  provider; the provider computes injectable headers for
+  `(host, method, path)`. `egressd` contains no provider-specific logic —
+  new providers are broker plugins with zero sidecar changes.
+- Response header names are lowercased.
+- `expires_at` is the cache ceiling. `egressd` must not serve cached material
+  past it and must not fall back to stale material when a refetch fails
+  (fail closed).
+- `strip_request_headers` lists caller-supplied request headers `egressd`
+  must remove before injection (placeholder scrub, see below).
+- Denials use the same `{"ok":false,"error":"...","message":"..."}` shape and
+  status conventions as `protocol/broker.md`. Denial reasons include
+  role mismatch, missing pairing, capability not granted to the paired agent,
+  host not allowed for the capability, and materialization mode mismatch.
+
+### POST /v1/injection/routing
+
+Agent or egress role. Returns non-secret routing metadata for a capability.
+This is the only injection surface an `agent` identity may call, and its
+response never contains secret material — pinned by conformance test.
+
+Request:
+
+```json
+{"capability": "codex-main"}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "hosts": ["chatgpt.com", "auth.openai.com"],
+  "placeholder": "NVT-PLACEHOLDER-NOT-A-KEY"
+}
+```
+
+The local base URL the agent's tooling points at (the `egressd` listen
+address) is composed by runtime bootstrap, not returned by the broker.
+
+## Placeholder Convention
+
+Some CLIs refuse to start without a syntactically present key. Mediated mode
+may satisfy them with the fixed constant:
+
+```text
+NVT-PLACEHOLDER-NOT-A-KEY
+```
+
+Rules:
+
+- The constant is documented here, carries zero secret entropy, and is
+  allowlisted by the non-possession smoke test.
+- A conformance test proves the placeholder is inert: a direct
+  (sidecar-bypassing) upstream request presenting it is rejected.
+- `egressd` strips or replaces the placeholder header on injection
+  (`strip_request_headers`); it is never forwarded alongside the real
+  credential.
+
+## Transport Requirements
+
+The `egressd -> brokerd` leg is the one network path that carries real
+credentials in flight, and `egressd` shares the agent's network namespace. In
+mediated deployments this leg must use TLS or a transport unreachable from
+the agent's network namespace. Serving `/v1/injection/headers` over plaintext
+HTTP on a network reachable from the agent netns is a conformance failure for
+mediated mode. The `agent -> egressd` localhost hop needs no such protection:
+it carries no credentials, because the agent has none.
+
+## Audit
+
+Every injection request appends one JSONL audit entry: request id,
+capability, egress identity id, paired agent id, host, method, path class,
+allow/deny result, denial reason, and expiry metadata. Header values and
+token material are never logged, on any path including errors.
+
+## Stability
+
+The stable contract is the JSON shapes and authorization rules documented
+here, pinned by `tests/broker/injection_conformance_test.go` and the mediated
+smoke tests in `tests/runtime/`. Broker and sidecar implementations may be
+replaced as long as the black-box suites keep passing.

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -1,0 +1,355 @@
+package broker_test
+
+// Phase 0 skeletons for the mediated credential egress injection contract
+// (protocol/injection.md, docs/mediated-egress-plan.md).
+//
+// Every test here is skipped pending its implementation phase. The bodies are
+// written against the intended black-box behavior so the contract is
+// reviewable as code and unskipping is the only change needed when the
+// implementation lands (plan Phase 1 for the broker side).
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+const injectionPending = "pending Phase 1 (docs/mediated-egress-plan.md): /v1/injection endpoints and identity roles not implemented"
+
+// nvtPlaceholder is the documented zero-entropy placeholder constant from
+// protocol/injection.md.
+const nvtPlaceholder = "NVT-PLACEHOLDER-NOT-A-KEY"
+
+type roleGrant struct {
+	Provider        string
+	Repositories    []string
+	Materialization string
+}
+
+type roleIdentity struct {
+	Token       string
+	Role        string
+	PairedAgent string
+	Grants      []roleGrant
+}
+
+// writeRoleIdentities writes an agents config using the role/pairing schema
+// from protocol/injection.md. It mirrors writeAgents but supports role,
+// paired-agent, and per-grant materialization fields.
+func (f *brokerFixture) writeRoleIdentities(identities map[string]roleIdentity) {
+	f.t.Helper()
+	var builder strings.Builder
+	builder.WriteString("agents:\n")
+	for id, identity := range identities {
+		builder.WriteString("  - id: ")
+		builder.WriteString(id)
+		builder.WriteString("\n")
+		hash := sha256.Sum256([]byte(identity.Token))
+		builder.WriteString(fmt.Sprintf("    token-sha256: sha256:%x\n", hash[:]))
+		if identity.Role != "" {
+			builder.WriteString("    role: ")
+			builder.WriteString(identity.Role)
+			builder.WriteString("\n")
+		}
+		if identity.PairedAgent != "" {
+			builder.WriteString("    paired-agent: ")
+			builder.WriteString(identity.PairedAgent)
+			builder.WriteString("\n")
+		}
+		if len(identity.Grants) == 0 {
+			builder.WriteString("    grants: []\n")
+			continue
+		}
+		builder.WriteString("    grants:\n")
+		for _, grant := range identity.Grants {
+			builder.WriteString("      - provider: ")
+			builder.WriteString(grant.Provider)
+			builder.WriteString("\n")
+			if grant.Materialization != "" {
+				builder.WriteString("        materialization: ")
+				builder.WriteString(grant.Materialization)
+				builder.WriteString("\n")
+			}
+			if len(grant.Repositories) > 0 {
+				builder.WriteString("        repositories:\n")
+				for _, repo := range grant.Repositories {
+					builder.WriteString("          - ")
+					builder.WriteString(repo)
+					builder.WriteString("\n")
+				}
+			}
+		}
+	}
+	tmp := f.agents + ".tmp"
+	if err := os.WriteFile(tmp, []byte(builder.String()), 0o600); err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.Rename(tmp, f.agents); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// postJSONWithToken performs a raw HTTP POST against the broker, returning
+// status code and decoded body. Injection conformance is pinned at the HTTP
+// layer, not through brokerctl: brokerctl is the agent-side client and must
+// never grow an injection command.
+func (f *brokerFixture) postJSONWithToken(token, path string, payload map[string]any) (int, map[string]any) {
+	f.t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	request, err := http.NewRequest(http.MethodPost, f.url+path, bytes.NewReader(body))
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var decoded map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		f.t.Fatalf("decode %s response: %v", path, err)
+	}
+	return response.StatusCode, decoded
+}
+
+// mediatedIdentities is the standard fixture layout for injection tests:
+// one agent with a header-inject grant, its paired egress identity, a second
+// unrelated agent, and an egress identity paired to that second agent.
+func mediatedIdentities() map[string]roleIdentity {
+	return map[string]roleIdentity{
+		"frontend": {
+			Token: "frontend-token",
+			Role:  "agent",
+			Grants: []roleGrant{
+				{Provider: "codex-main", Materialization: "header-inject"},
+			},
+		},
+		"frontend-egress": {
+			Token:       "frontend-egress-token",
+			Role:        "egress",
+			PairedAgent: "frontend",
+		},
+		"backend": {
+			Token:  "backend-token",
+			Role:   "agent",
+			Grants: []roleGrant{},
+		},
+		"backend-egress": {
+			Token:       "backend-egress-token",
+			Role:        "egress",
+			PairedAgent: "backend",
+		},
+	}
+}
+
+func injectionRequest() map[string]any {
+	return map[string]any{
+		"capability": "codex-main",
+		"host":       "chatgpt.com",
+		"method":     "POST",
+		"path":       "/backend-api/responses",
+	}
+}
+
+// TestInjectionRequiresEgressRole pins the core identity split: the paired
+// egress identity obtains injectable headers; the agent identity holding the
+// grant itself is refused. This is the load-bearing non-possession property.
+func TestInjectionRequiresEgressRole(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("egress identity denied: status=%d body=%v", status, body)
+	}
+	headers, ok := body["headers"].(map[string]any)
+	if !ok || len(headers) == 0 {
+		t.Fatalf("expected injectable headers, got %v", body)
+	}
+
+	status, body = f.postJSONWithToken("frontend-token", "/v1/injection/headers", injectionRequest())
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("agent identity must not obtain injectable headers: status=%d body=%v", status, body)
+	}
+}
+
+// TestInjectionDeniesUnpairedEgressIdentity pins pairing: an egress identity
+// paired to a different agent cannot fetch material for this agent's grants.
+func TestInjectionDeniesUnpairedEgressIdentity(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("backend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("egress identity paired to another agent must be denied: status=%d body=%v", status, body)
+	}
+}
+
+// TestEgressRoleCannotCallSecretBearingEndpoints pins the role restriction in
+// the other direction: egress identities are injection-only and must be
+// denied on every compatibility endpoint that returns secrets to the caller.
+func TestEgressRoleCannotCallSecretBearingEndpoints(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	calls := []struct {
+		path    string
+		payload map[string]any
+	}{
+		{"/v1/token", map[string]any{"provider": "fork-app", "target": "github.com/my-user/my-repo", "purpose": "git-push"}},
+		{"/v1/headers", map[string]any{"provider": "header-provider", "target": "github.com/my-user/my-repo"}},
+		{"/v1/files", map[string]any{"provider": "codex-main"}},
+		{"/v1/http/request", map[string]any{"provider": "fork-app", "method": "GET", "url": "https://api.github.com/repos/my-user/my-repo/pulls/123"}},
+	}
+	for _, call := range calls {
+		status, body := f.postJSONWithToken("frontend-egress-token", call.path, call.payload)
+		if status == http.StatusOK || body["ok"] == true {
+			t.Fatalf("egress identity must be denied on %s: status=%d body=%v", call.path, status, body)
+		}
+	}
+}
+
+// TestAgentRoleReceivesRoutingConfigOnly pins /v1/injection/routing: agents
+// may discover hosts and the placeholder constant, and the response never
+// contains secret material.
+func TestAgentRoleReceivesRoutingConfigOnly(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/injection/routing", map[string]any{"capability": "codex-main"})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("agent identity denied routing config: status=%d body=%v", status, body)
+	}
+	if body["placeholder"] != nvtPlaceholder {
+		t.Fatalf("expected documented placeholder constant, got %v", body["placeholder"])
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The routing response must never carry credential material. The fixture's
+	// canonical codex auth file uses a JWT access token; assert no fragment of
+	// it appears.
+	if strings.Contains(string(raw), "eyJ") {
+		t.Fatalf("routing response appears to contain token material: %s", raw)
+	}
+}
+
+// TestHeaderInjectGrantExcludesFileBundle pins materialization mutual
+// exclusion: a header-inject grant makes the compatibility file endpoint deny
+// for that provider and agent. No hybrid mode exists.
+func TestHeaderInjectGrantExcludesFileBundle(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/files", map[string]any{"provider": "codex-main"})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("file bundle must be denied for header-inject grant: status=%d body=%v", status, body)
+	}
+}
+
+// TestFileBundleGrantExcludesInjection pins the reverse direction: a
+// file-bundle grant (the default) denies injection for the paired egress
+// identity.
+func TestFileBundleGrantExcludesInjection(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	identities := mediatedIdentities()
+	identities["frontend"] = roleIdentity{
+		Token: "frontend-token",
+		Role:  "agent",
+		Grants: []roleGrant{
+			{Provider: "codex-main", Materialization: "file-bundle"},
+		},
+	}
+	f.writeRoleIdentities(identities)
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("injection must be denied for file-bundle grant: status=%d body=%v", status, body)
+	}
+}
+
+// TestEgressIdentityWithGrantsIsConfigError pins config validation: grants on
+// an egress identity are a validation error, not an ignored field — the
+// degeneration into "two tokens with the same grants" must be unrepresentable.
+func TestEgressIdentityWithGrantsIsConfigError(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(map[string]roleIdentity{
+		"frontend": {
+			Token: "frontend-token",
+			Role:  "agent",
+			Grants: []roleGrant{
+				{Provider: "codex-main", Materialization: "header-inject"},
+			},
+		},
+		"frontend-egress": {
+			Token:       "frontend-egress-token",
+			Role:        "egress",
+			PairedAgent: "frontend",
+			Grants: []roleGrant{
+				{Provider: "codex-main", Materialization: "header-inject"},
+			},
+		},
+	})
+
+	// The live-reloaded config must reject the invalid identity: its token
+	// must not authenticate.
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("egress identity carrying grants must be rejected: status=%d body=%v", status, body)
+	}
+}
+
+// TestInjectionAuditOmitsSecretValues pins the audit rule: injection requests
+// are audited with metadata only; header values never appear in the audit
+// log on allow or deny paths.
+func TestInjectionAuditOmitsSecretValues(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("injection denied: status=%d body=%v", status, body)
+	}
+	headers, ok := body["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers in response, got %v", body)
+	}
+
+	audit, err := os.ReadFile(f.audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(audit, []byte("injection")) {
+		t.Fatalf("expected an injection audit entry, audit log: %s", audit)
+	}
+	for name, value := range headers {
+		text, ok := value.(string)
+		if !ok || text == "" {
+			continue
+		}
+		if bytes.Contains(audit, []byte(text)) {
+			t.Fatalf("audit log contains injected header value for %q", name)
+		}
+	}
+}

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -251,6 +251,57 @@ func TestAgentRoleReceivesRoutingConfigOnly(t *testing.T) {
 	}
 }
 
+// TestRoutingDeniesUngrantedCapability pins routing authorization: an agent
+// identity without a header-inject grant for the capability is denied,
+// including for unknown capabilities.
+func TestRoutingDeniesUngrantedCapability(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	for _, capability := range []string{"codex-main", "no-such-capability"} {
+		status, body := f.postJSONWithToken("backend-token", "/v1/injection/routing", map[string]any{"capability": capability})
+		if status == http.StatusOK || body["ok"] == true {
+			t.Fatalf("ungranted capability %q must deny routing: status=%d body=%v", capability, status, body)
+		}
+	}
+}
+
+// TestRoutingDeniesWrongPairedEgress pins routing scoping for egress callers:
+// an egress identity is authorized against its paired agent's grants only.
+func TestRoutingDeniesWrongPairedEgress(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("backend-egress-token", "/v1/injection/routing", map[string]any{"capability": "codex-main"})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("egress identity paired to an ungranted agent must deny routing: status=%d body=%v", status, body)
+	}
+}
+
+// TestRoutingDeniesFileBundleGrant pins the materialization rule for routing:
+// a file-bundle grant is a direct-mode grant with no sidecar to route to, so
+// routing denies rather than acting as a cross-mode probe.
+func TestRoutingDeniesFileBundleGrant(t *testing.T) {
+	t.Skip(injectionPending)
+	f := newBrokerFixture(t)
+	identities := mediatedIdentities()
+	identities["frontend"] = roleIdentity{
+		Token: "frontend-token",
+		Role:  "agent",
+		Grants: []roleGrant{
+			{Provider: "codex-main", Materialization: "file-bundle"},
+		},
+	}
+	f.writeRoleIdentities(identities)
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/injection/routing", map[string]any{"capability": "codex-main"})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("file-bundle grant must deny routing: status=%d body=%v", status, body)
+	}
+}
+
 // TestHeaderInjectGrantExcludesFileBundle pins materialization mutual
 // exclusion: a header-inject grant makes the compatibility file endpoint deny
 // for that provider and agent. No hybrid mode exists.

--- a/tests/runtime/mediated_admission_test.go
+++ b/tests/runtime/mediated_admission_test.go
@@ -1,0 +1,62 @@
+package runtime_test
+
+// Phase 0 skeletons for the run-level admission rules of mediated credential
+// egress (protocol/injection.md "Materialization Modes";
+// docs/mediated-egress-plan.md configuration surface).
+//
+// The run-level egress mode and every grant's materialization must agree,
+// and a mismatch fails admission loudly in both directions — there is no
+// downgrade or ignore path. This is one of the two main protections against
+// silent-fallback (plan risk 2): without it, a direct run could quietly
+// materialize a header-inject grant as a bundle, or a mediated run could
+// quietly write bundles into a supposedly zero-secret container.
+//
+// The rule is enforced at two surfaces, both pinned here:
+//   - operator: AgentSchedule admission (HTTP submission endpoint) rejects
+//     the work item; the error names the offending grant and is surfaced on
+//     the AgentRun status
+//   - compose: `agent-init` validation exits non-zero naming the offending
+//     grant before any container starts
+//
+// Skipped pending plan Phase 3 (operator/compose wiring), where admission
+// gains the egress mode field. Bodies document the required assertions.
+
+import "testing"
+
+const admissionPending = "pending Phase 3 (docs/mediated-egress-plan.md): egress mode admission not implemented"
+
+// TestAdmissionRejectsDirectRunWithHeaderInjectGrant pins the first
+// direction: egress mode `direct` combined with any `header-inject` grant
+// fails admission.
+//
+// Phase 3 wiring for this skeleton:
+//  1. Configure an agent whose broker grants include
+//     `materialization: header-inject`.
+//  2. Submit work with `egress: direct` via the operator admission endpoint;
+//     assert rejection (4xx), error message names the offending
+//     provider/grant, and no AgentRun Pod is created.
+//  3. Run compose `agent-init` without MEDIATED for the same agent; assert
+//     non-zero exit naming the offending grant and no containers started.
+//  4. Assert in both surfaces that no bundle was materialized as a
+//     "helpful" downgrade.
+func TestAdmissionRejectsDirectRunWithHeaderInjectGrant(t *testing.T) {
+	t.Skip(admissionPending)
+}
+
+// TestAdmissionRejectsMediatedRunWithFileBundleGrant pins the second
+// direction: egress mode `mediated` combined with any `file-bundle` grant
+// fails admission.
+//
+// Phase 3 wiring for this skeleton:
+//  1. Configure an agent whose broker grants include a `file-bundle`
+//     (or defaulted) materialization.
+//  2. Submit work with `egress: mediated` via the operator admission
+//     endpoint; assert rejection (4xx), error message names the offending
+//     provider/grant, and no AgentRun Pod is created.
+//  3. Run compose `agent-init MEDIATED=1` for the same agent; assert
+//     non-zero exit naming the offending grant and no containers started.
+//  4. Assert no hybrid run exists in either surface: a run must never start
+//     with a sidecar present while bundles are also written.
+func TestAdmissionRejectsMediatedRunWithFileBundleGrant(t *testing.T) {
+	t.Skip(admissionPending)
+}

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -1,0 +1,160 @@
+package runtime_test
+
+// Phase 0 skeletons for the mediated-mode smoke tests
+// (protocol/injection.md, docs/mediated-egress-plan.md).
+//
+// The plan defines two decoupled guarantees with one smoke test each:
+//
+//   (a) non-possession  - zero secret material in the agent container
+//                         (ships with plan Phase 3, operator/compose wiring)
+//   (b) egress-denied   - direct egress to upstream hosts is refused
+//                         (ships with plan Phase 5, enforcement)
+//
+// plus the placeholder-inertness test from the placeholder convention.
+// The tests are split so (a) lands and ratchets in CI independent of the
+// harder enforcement work. All are skipped pending their phase; bodies pin
+// the intended assertions. Both smoke tests are mode-aware by design: they
+// run against mediated agents and must skip *visibly* for direct-mode runs.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	nonPossessionPending = "pending Phase 3 (docs/mediated-egress-plan.md): mediated operator/compose wiring not implemented"
+	placeholderPending   = "pending Phase 1 (docs/mediated-egress-plan.md): egressd and placeholder convention not implemented"
+	egressDeniedPending  = "pending Phase 5 (docs/mediated-egress-plan.md): egress enforcement not implemented"
+)
+
+// mediatedPlaceholder is the documented zero-entropy constant from
+// protocol/injection.md. It is the only credential-shaped string allowed to
+// exist inside a mediated agent container.
+const mediatedPlaceholder = "NVT-PLACEHOLDER-NOT-A-KEY"
+
+// scanTreeForSecretMaterial walks root and fails the test if any known secret
+// value appears in a regular file. Phase 3 points this at an export of the
+// mediated agent container filesystem (state dir, home, git config, env
+// snapshots) with the real fixture secrets as needles.
+func scanTreeForSecretMaterial(t *testing.T, root string, secrets []string) {
+	t.Helper()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !info.Mode().IsRegular() || info.Size() > 8*1024*1024 {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		text := string(content)
+		for _, secret := range secrets {
+			if secret == "" || secret == mediatedPlaceholder {
+				continue
+			}
+			if strings.Contains(text, secret) {
+				t.Errorf("secret material found in %s", path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// assertScrubbedGitState fails if the container's git configuration retains
+// any credential path: helpers, extraHeader injection, URL rewrites, or
+// stored credential files (protocol/injection.md, plan section 5).
+func assertScrubbedGitState(t *testing.T, home string) {
+	t.Helper()
+	forbiddenConfig := []string{"credential.helper", "http.extraheader", "insteadof"}
+	for _, name := range []string{".gitconfig", ".config/git/config"} {
+		path := filepath.Join(home, name)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		text := strings.ToLower(string(content))
+		for _, needle := range forbiddenConfig {
+			if strings.Contains(text, needle) {
+				t.Errorf("mediated git config %s retains %q", path, needle)
+			}
+		}
+	}
+	for _, name := range []string{".git-credentials", ".config/git/credentials"} {
+		if _, err := os.Stat(filepath.Join(home, name)); err == nil {
+			t.Errorf("mediated container retains stored git credentials: %s", name)
+		}
+	}
+}
+
+// TestMediatedNonPossession is smoke test (a): boot an agent in mediated
+// mode, then assert zero secret material anywhere the agent can read.
+//
+// Phase 3 wiring for this skeleton:
+//  1. Start broker + egressd fixtures with known fixture secrets.
+//  2. Boot the agent container in mediated mode (MEDIATED=1 / egress:
+//     mediated) with header-inject grants for all fixture providers.
+//  3. Export the container-visible state: agent home, NVT state dir, env
+//     (`/proc/1/environ` and shell env), process args (`ps axww`).
+//  4. Assert none of the fixture secrets appear (scanTreeForSecretMaterial
+//     over the export; direct checks over env and args).
+//  5. Assert git state is scrubbed (assertScrubbedGitState).
+//  6. Assert no auth bundles were materialized (no auth.json for mediated
+//     providers).
+//
+// Mode-awareness: for a direct-mode agent this test must skip loudly, never
+// pass silently — a misconfigured default that flips runs back to bundles
+// must not turn the suite green.
+func TestMediatedNonPossession(t *testing.T) {
+	t.Skip(nonPossessionPending)
+
+	exportRoot := t.TempDir() // Phase 3: replaced by the real container export
+	fixtureSecrets := []string{
+		// Phase 3: populated with the broker fixture's live values, e.g. the
+		// codex access/refresh tokens and static provider secrets.
+	}
+	scanTreeForSecretMaterial(t, exportRoot, fixtureSecrets)
+	assertScrubbedGitState(t, exportRoot)
+}
+
+// TestMediatedPlaceholderInert pins the placeholder convention: the constant
+// satisfies CLI syntax checks but grants nothing upstream.
+//
+// Phase 1 wiring for this skeleton:
+//  1. Start a fake upstream that accepts only the real fixture credential.
+//  2. Issue a direct request (bypassing egressd) presenting the placeholder
+//     as a bearer token; assert the upstream rejects it.
+//  3. Issue the same request through egressd; assert the upstream sees the
+//     real credential and never sees the placeholder
+//     (strip_request_headers behavior).
+func TestMediatedPlaceholderInert(t *testing.T) {
+	t.Skip(placeholderPending)
+
+	if mediatedPlaceholder != "NVT-PLACEHOLDER-NOT-A-KEY" {
+		t.Fatal("placeholder constant must match protocol/injection.md")
+	}
+}
+
+// TestMediatedEgressDenied is smoke test (b): direct egress from the agent
+// to upstream hosts is refused; egressd is the only way out.
+//
+// Phase 5 wiring for this skeleton:
+//  1. Boot a mediated agent with enforcement enabled.
+//  2. From the agent process: direct connections to the mediated upstream
+//     hosts must fail (connection refused/blocked, not 401).
+//  3. From a container spawned inside dind: the same connections must fail
+//     (FORWARD-chain coverage, plan section 7).
+//  4. The same requests through egressd succeed.
+//
+// Where enforcement is not a real control (today's compose privileged-dind
+// model), this test documents the gap by skipping with an explicit reason,
+// never by passing.
+func TestMediatedEgressDenied(t *testing.T) {
+	t.Skip(egressDeniedPending)
+}


### PR DESCRIPTION
## Summary

Phase 0 of the mediated credential egress plan (`docs/mediated-egress-plan.md`): the injection protocol contract and its conformance/smoke test skeletons, pinned **before any implementation exists**. Per the plan's division of labor, this is the human-reviewed PR where the security thinking lives — once this contract merges, implementation phases are "any code that passes."

## What's in this PR

**`protocol/injection.md`** — the normative contract:
- `POST /v1/injection/headers` — a new endpoint, deliberately not built on `/v1/headers` (which returns secrets *to the caller*, the access model being inverted)
- Identity role/pairing model: `agent` vs `egress` roles, one-to-one pairing, grants forbidden on egress identities (validation error, not ignored)
- Materialization modes (`file-bundle` | `header-inject`) with broker-enforced mutual exclusion, and run-level admission mismatch rules (fail loudly, no downgrade)
- `POST /v1/injection/routing` — the only injection surface an agent identity may call; never contains secret material
- Placeholder convention (`NVT-PLACEHOLDER-NOT-A-KEY`), transport requirement (TLS on the egressd↔broker leg), and audit rules

**`tests/broker/injection_conformance_test.go`** — 8 conformance skeletons pinning: identity split, pairing (cross-agent refusal), egress-role endpoint restrictions, routing-config-only for agents, materialization exclusion in both directions, config validation, and audit secrecy.

**`tests/runtime/mediated_smoke_test.go`** — the two decoupled guarantee smoke tests (non-possession → Phase 3; egress-denied → Phase 5) plus placeholder inertness (Phase 1), with wiring steps documented per skeleton.

**`docs/mediated-egress-plan.md`** — the last plan edits (risks 7–8; the bulk of the doc was committed previously).

All skeletons compile (`go vet` clean) and skip with phase-labeled reasons — unskipping is the only change needed as each phase lands.

## Review focus

This contract is what makes delegated implementation safe, so the highest-value review targets are:
1. The identity model rules — is "two tokens with the same grants" truly unrepresentable?
2. The mutual-exclusion and admission rules — any path to a silent hybrid/downgrade?
3. The test skeletons as contract-pins — do the assertions match the protocol text exactly?

## Next

Phase 1 (separate PR): egressd spike against Codex API-key mode, per the plan's PR sequence.