### PR TITLE
Mediated credential egress Phase 1: injection endpoints and egressd

### DIFF
--- a/.github/workflows/agentd.yml
+++ b/.github/workflows/agentd.yml
@@ -7,6 +7,7 @@ on:
       - "runtime/core/**"
       - "runtime/plugins/**"
       - "broker/**"
+      - "egressd/**"
       - "protocol/**"
       - "tests/agentd/**"
       - "tests/broker/**"
@@ -18,6 +19,7 @@ on:
       - "runtime/core/**"
       - "runtime/plugins/**"
       - "broker/**"
+      - "egressd/**"
       - "protocol/**"
       - "tests/agentd/**"
       - "tests/broker/**"
@@ -57,6 +59,9 @@ jobs:
       - name: Run broker conformance suite
         working-directory: tests/broker
         run: go test -v ./...
+      - name: Run egressd tests
+        working-directory: egressd
+        run: go vet ./... && go test -v ./...
       - name: Build runtime image
         run: docker build -t nvt-agent:test -f runtime/Dockerfile .
       - name: Build broker image

--- a/broker/core/agents.py
+++ b/broker/core/agents.py
@@ -10,6 +10,10 @@ from broker.core.config import fail, list_value, string_value
 from broker.plugins.github_app.provider import ProviderError
 
 
+VALID_ROLES = {"agent", "egress"}
+VALID_MATERIALIZATIONS = {"file-bundle", "header-inject"}
+
+
 class AgentRegistry:
     def __init__(self, path=None):
         raw_path = path or os.environ.get("NVT_BROKER_AGENTS_CONFIG", "")
@@ -17,6 +21,7 @@ class AgentRegistry:
         self.lock = threading.Lock()
         self.mtime_ns = None
         self.agents_by_hash = {}
+        self.agents_by_id = {}
         self.last_error = None
         self.reload_if_changed(force=True)
 
@@ -29,6 +34,7 @@ class AgentRegistry:
             except FileNotFoundError:
                 if force:
                     self.agents_by_hash = {}
+                    self.agents_by_id = {}
                 return
             if not force and self.mtime_ns == stat.st_mtime_ns:
                 return
@@ -39,6 +45,7 @@ class AgentRegistry:
                 print(f"broker agents config reload failed: {self.last_error}", file=sys.stderr)
                 return
             self.agents_by_hash = candidate
+            self.agents_by_id = {agent["id"]: agent for agent in candidate.values()}
             self.mtime_ns = stat.st_mtime_ns
             self.last_error = None
 
@@ -70,6 +77,15 @@ class AgentRegistry:
                 return
         raise ProviderError("provider-not-granted")
 
+    def grant(self, agent, provider_name):
+        for grant in agent["grants"]:
+            if grant["provider"] == provider_name:
+                return grant
+        return None
+
+    def by_id(self, agent_id):
+        return self.agents_by_id.get(agent_id)
+
     def _load_candidate(self):
         with self.path.open("r", encoding="utf-8") as file:
             data = yaml.safe_load(file) or {}
@@ -78,6 +94,8 @@ class AgentRegistry:
         output = {}
         seen_ids = set()
         seen_hashes = set()
+        roles_by_id = {}
+        pairings = []
         for index, raw in enumerate(list_value(data.get("agents"), "agents")):
             if not isinstance(raw, dict):
                 fail(f"agents[{index}] must be a YAML object")
@@ -95,16 +113,41 @@ class AgentRegistry:
             if token_hash in seen_hashes:
                 fail(f"duplicate token hash for agent: {agent_id}")
             seen_hashes.add(token_hash)
+            role = raw.get("role", "agent")
+            if role not in VALID_ROLES:
+                fail(f"agents[{index}].role must be one of: {', '.join(sorted(VALID_ROLES))}")
+            paired_agent = raw.get("paired-agent")
+            if role == "egress":
+                raw_grants = raw.get("grants")
+                if raw_grants not in (None, []):
+                    fail(f"agents[{index}] ({agent_id}): egress identities must not hold grants")
+                paired_agent = string_value(paired_agent, f"agents[{index}].paired-agent", required=True)
+                pairings.append((index, agent_id, paired_agent))
+                output[token_hash] = {"id": agent_id, "role": "egress", "paired_agent": paired_agent, "grants": []}
+                roles_by_id[agent_id] = "egress"
+                continue
+            if paired_agent is not None:
+                fail(f"agents[{index}] ({agent_id}): paired-agent is only valid for egress identities")
             grants = []
             for grant_index, grant in enumerate(list_value(raw.get("grants"), f"agents[{index}].grants")):
                 if not isinstance(grant, dict):
                     fail(f"agents[{index}].grants[{grant_index}] must be a YAML object")
                 provider = string_value(grant.get("provider"), f"agents[{index}].grants[{grant_index}].provider", required=True)
+                materialization = grant.get("materialization", "file-bundle")
+                if materialization not in VALID_MATERIALIZATIONS:
+                    fail(
+                        f"agents[{index}].grants[{grant_index}].materialization must be one of: "
+                        f"{', '.join(sorted(VALID_MATERIALIZATIONS))}"
+                    )
                 repositories = []
                 for repo_index, repo in enumerate(list_value(grant.get("repositories"), f"agents[{index}].grants[{grant_index}].repositories")):
                     if not isinstance(repo, str) or not repo:
                         fail(f"agents[{index}].grants[{grant_index}].repositories[{repo_index}] must be a non-empty string")
                     repositories.append(repo)
-                grants.append({"provider": provider, "repositories": repositories})
-            output[token_hash] = {"id": agent_id, "grants": grants}
+                grants.append({"provider": provider, "repositories": repositories, "materialization": materialization})
+            output[token_hash] = {"id": agent_id, "role": "agent", "paired_agent": None, "grants": grants}
+            roles_by_id[agent_id] = "agent"
+        for index, agent_id, paired_agent in pairings:
+            if roles_by_id.get(paired_agent) != "agent":
+                fail(f"agents[{index}] ({agent_id}): paired-agent must reference an agent-role identity")
         return output

--- a/broker/core/config.py
+++ b/broker/core/config.py
@@ -32,6 +32,16 @@ def list_value(value, field):
     return value
 
 
+def injection_hosts(config, name):
+    values = list_value(config.get("injection-hosts"), f"provider {name} config.injection-hosts")
+    output = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str) or not value:
+            fail(f"provider {name} config.injection-hosts[{index}] must be a non-empty string")
+        output.append(value)
+    return output
+
+
 def env_value(name):
     value = os.environ.get(name)
     if value is None:

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -1,4 +1,6 @@
 import json
+import os
+import ssl
 import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -10,6 +12,10 @@ from broker.plugins.github_app.provider import ProviderError
 
 
 MAX_REQUEST_BYTES = 1024 * 1024
+
+# Documented zero-entropy placeholder from protocol/injection.md. It is the
+# only credential-shaped value allowed inside a mediated agent container.
+INJECTION_PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 
 
 class Broker:
@@ -25,8 +31,27 @@ class Broker:
             raise ProviderError("provider-not-found")
         return provider
 
+    def authenticate_role(self, authorization, role):
+        identity = self.agents.authenticate(authorization)
+        if identity.get("role", "agent") != role:
+            raise ProviderError(
+                "role-not-allowed",
+                f"this endpoint requires a {role}-role identity",
+                403,
+            )
+        return identity
+
+    def ensure_not_header_inject(self, agent, provider_name):
+        grant = self.agents.grant(agent, provider_name)
+        if grant is not None and grant.get("materialization") == "header-inject":
+            raise ProviderError(
+                "materialization-mismatch",
+                f"grant for {provider_name} is header-inject; secret-bearing endpoints are disabled",
+                403,
+            )
+
     def http_request(self, request_id, payload, authorization):
-        agent = self.agents.authenticate(authorization)
+        agent = self.authenticate_role(authorization, "agent")
         provider_name = string_field(payload, "provider")
         method = string_field(payload, "method").upper()
         url = string_field(payload, "url")
@@ -52,8 +77,9 @@ class Broker:
         return {"ok": True, **result}
 
     def token(self, request_id, payload, authorization):
-        agent = self.agents.authenticate(authorization)
+        agent = self.authenticate_role(authorization, "agent")
         provider_name = string_field(payload, "provider")
+        self.ensure_not_header_inject(agent, provider_name)
         target = string_field(payload, "target")
         purpose = payload.get("purpose")
         provider = self.provider(provider_name)
@@ -72,7 +98,7 @@ class Broker:
         return {"ok": True, "token": token, "expires_at": expires_at}
 
     def identity(self, request_id, payload, authorization):
-        agent = self.agents.authenticate(authorization)
+        agent = self.authenticate_role(authorization, "agent")
         provider_name = string_field(payload, "provider")
         target = string_field(payload, "target")
         provider = self.provider(provider_name)
@@ -90,8 +116,9 @@ class Broker:
         return {"ok": True, **identity}
 
     def headers(self, request_id, payload, authorization):
-        agent = self.agents.authenticate(authorization)
+        agent = self.authenticate_role(authorization, "agent")
         provider_name = string_field(payload, "provider")
+        self.ensure_not_header_inject(agent, provider_name)
         target = string_field(payload, "target")
         provider = self.provider(provider_name)
         repo = provider.normalize_target(target)
@@ -108,8 +135,9 @@ class Broker:
         return {"ok": True, "headers": headers}
 
     def files(self, request_id, payload, authorization):
-        agent = self.agents.authenticate(authorization)
+        agent = self.authenticate_role(authorization, "agent")
         provider_name = string_field(payload, "provider")
+        self.ensure_not_header_inject(agent, provider_name)
         provider = self.provider(provider_name)
         self.agents.ensure_provider_grant(agent, provider_name)
         if not hasattr(provider, "files"):
@@ -125,6 +153,78 @@ class Broker:
             file_count=len(files),
         )
         return {"ok": True, "files": files, "expires_at": expires_at}
+
+    def _injection_grant(self, subject, capability):
+        grant = self.agents.grant(subject, capability)
+        if grant is None:
+            raise ProviderError("provider-not-granted", None, 403)
+        if grant.get("materialization") != "header-inject":
+            raise ProviderError(
+                "materialization-mismatch",
+                f"grant for {capability} is not header-inject",
+                403,
+            )
+        return grant
+
+    def _injection_provider(self, capability):
+        provider = self.provider(capability)
+        hosts = getattr(provider, "injection_hosts", None) or []
+        if not hosts or not hasattr(provider, "injection_headers"):
+            raise ProviderError(
+                "injection-not-supported",
+                f"provider {capability} does not support header injection",
+                403,
+            )
+        return provider, hosts
+
+    def injection_headers(self, request_id, payload, authorization):
+        identity = self.authenticate_role(authorization, "egress")
+        paired = self.agents.by_id(identity.get("paired_agent") or "")
+        if paired is None or paired.get("role", "agent") != "agent":
+            raise ProviderError("pairing-invalid", "egress identity has no valid paired agent", 403)
+        capability = string_field(payload, "capability")
+        host = string_field(payload, "host")
+        method = string_field(payload, "method").upper()
+        path = string_field(payload, "path")
+        self._injection_grant(paired, capability)
+        provider, hosts = self._injection_provider(capability)
+        if host not in hosts:
+            raise ProviderError("host-not-allowed", f"host {host} is not allowed for {capability}", 403)
+        headers, expires_at, strip = provider.injection_headers(host, method, path, paired["id"], self.audit, request_id)
+        self.audit.write(
+            request_id=request_id,
+            agent=identity["id"],
+            paired_agent=paired["id"],
+            provider=capability,
+            operation="injection.headers",
+            host=host,
+            method=method,
+            path=path,
+            allowed=True,
+            expires_at=expires_at,
+        )
+        return {"ok": True, "headers": headers, "expires_at": expires_at, "strip_request_headers": strip}
+
+    def injection_routing(self, request_id, payload, authorization):
+        identity = self.agents.authenticate(authorization)
+        if identity.get("role", "agent") == "egress":
+            subject = self.agents.by_id(identity.get("paired_agent") or "")
+            if subject is None or subject.get("role", "agent") != "agent":
+                raise ProviderError("pairing-invalid", "egress identity has no valid paired agent", 403)
+        else:
+            subject = identity
+        capability = string_field(payload, "capability")
+        self._injection_grant(subject, capability)
+        _, hosts = self._injection_provider(capability)
+        self.audit.write(
+            request_id=request_id,
+            agent=identity["id"],
+            paired_agent=subject["id"],
+            provider=capability,
+            operation="injection.routing",
+            allowed=True,
+        )
+        return {"ok": True, "hosts": hosts, "placeholder": INJECTION_PLACEHOLDER}
 
     def denied(self, request_id, payload, reason, message=None, authorization=None):
         agent_id = None
@@ -188,6 +288,14 @@ def make_handler(broker):
                     response = broker.files(request_id, payload, self.headers.get("authorization"))
                     self.write_json(200, response)
                     return
+                if self.path == "/v1/injection/headers":
+                    response = broker.injection_headers(request_id, payload, self.headers.get("authorization"))
+                    self.write_json(200, response)
+                    return
+                if self.path == "/v1/injection/routing":
+                    response = broker.injection_routing(request_id, payload, self.headers.get("authorization"))
+                    self.write_json(200, response)
+                    return
                 self.write_json(404, {"ok": False, "error": "not-found"})
             except ProviderError as error:
                 self.write_json(error.status, broker.denied(request_id, payload, error.reason, error.message, self.headers.get("authorization")))
@@ -221,6 +329,14 @@ def serve(bind, config_path=None, audit_path=None):
     broker = Broker(config_path, audit_path)
     host, port = parse_bind(bind)
     server = ThreadingHTTPServer((host, port), make_handler(broker))
+    cert = os.environ.get("NVT_BROKER_TLS_CERT")
+    key = os.environ.get("NVT_BROKER_TLS_KEY")
+    if bool(cert) != bool(key):
+        raise BrokerConfigError("NVT_BROKER_TLS_CERT and NVT_BROKER_TLS_KEY must be set together")
+    if cert and key:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=cert, keyfile=key)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
     server.serve_forever()
 
 

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -226,19 +226,31 @@ class Broker:
         )
         return {"ok": True, "hosts": hosts, "placeholder": INJECTION_PLACEHOLDER}
 
-    def denied(self, request_id, payload, reason, message=None, authorization=None):
+    def denied(self, request_id, payload, reason, message=None, authorization=None, operation=None):
         agent_id = None
         try:
             agent_id = self.agents.authenticate(authorization)["id"] if authorization else None
         except ProviderError:
             agent_id = None
+        provider = None
+        context = {}
+        if isinstance(payload, dict):
+            provider = payload.get("provider") or payload.get("capability")
+            # Denied entries must carry the request context the caller named
+            # (protocol/injection.md audit rules): denials are exactly the
+            # paths where audit matters most.
+            for key in ("host", "method", "path", "target"):
+                value = payload.get(key)
+                if isinstance(value, str) and value:
+                    context[key] = value
         self.audit.write(
             request_id=request_id,
             agent=agent_id,
-            provider=payload.get("provider") if isinstance(payload, dict) else None,
-            operation=payload.get("type") if isinstance(payload, dict) else None,
+            provider=provider if isinstance(provider, str) else None,
+            operation=operation,
             allowed=False,
             reason=reason,
+            **context,
         )
         return {"ok": False, "error": reason, "message": message or reason}
 
@@ -248,6 +260,12 @@ def string_field(payload, key):
     if not isinstance(value, str) or not value:
         raise ProviderError(f"{key}-required")
     return value
+
+
+def operation_from_path(path):
+    if isinstance(path, str) and path.startswith("/v1/"):
+        return path.removeprefix("/v1/").replace("/", ".")
+    return None
 
 
 def make_handler(broker):
@@ -298,9 +316,9 @@ def make_handler(broker):
                     return
                 self.write_json(404, {"ok": False, "error": "not-found"})
             except ProviderError as error:
-                self.write_json(error.status, broker.denied(request_id, payload, error.reason, error.message, self.headers.get("authorization")))
+                self.write_json(error.status, broker.denied(request_id, payload, error.reason, error.message, self.headers.get("authorization"), operation_from_path(self.path)))
             except Exception as error:
-                self.write_json(500, broker.denied(request_id, payload, "internal-error", str(error), self.headers.get("authorization")))
+                self.write_json(500, broker.denied(request_id, payload, "internal-error", str(error), self.headers.get("authorization"), operation_from_path(self.path)))
 
         def read_payload(self):
             length = int(self.headers.get("content-length") or "0")

--- a/broker/plugins/codex_oauth/provider.py
+++ b/broker/plugins/codex_oauth/provider.py
@@ -9,7 +9,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
-from broker.core.config import env_value, fail, list_value, string_value
+from broker.core.config import env_value, fail, injection_hosts, list_value, string_value
 from broker.plugins.github_app.provider import ProviderError
 
 
@@ -41,6 +41,7 @@ class CodexOAuthProvider:
             required=True,
         )
         self.extra_files = self._extra_files()
+        self.injection_hosts = injection_hosts(self.config, self.name)
         self.lock = threading.Lock()
 
     def _provider_value(self, key, default=None):
@@ -86,48 +87,57 @@ class CodexOAuthProvider:
             output.append({"name": name, "path": path, "mode": mode})
         return output
 
-    def files(self, agent_id, audit, request_id):
-        with self.lock:
-            auth = self._read_auth()
-            access_token = self._token(auth, "access_token")
+    def _fresh_auth(self, agent_id, audit, request_id, operation_prefix):
+        auth = self._read_auth()
+        access_token = self._token(auth, "access_token")
+        try:
+            exp = self._jwt_exp(access_token)
+        except ProviderError:
+            exp = 0
+        now = int(time.time())
+        refreshed = False
+        if exp - now <= self.refresh_margin_seconds:
+            refresh_persisted = False
             try:
+                refreshed_auth = self._refresh(auth)
+                self._write_auth(refreshed_auth)
+                refresh_persisted = True
+                access_token = self._token(refreshed_auth, "access_token")
                 exp = self._jwt_exp(access_token)
+                auth = refreshed_auth
+                refreshed = True
+                audit.write(
+                    request_id=request_id,
+                    agent=agent_id,
+                    provider=self.name,
+                    operation=f"{operation_prefix}.refresh",
+                    allowed=True,
+                    expires_at=rfc3339(exp),
+                )
             except ProviderError:
-                exp = 0
-            now = int(time.time())
-            refreshed = False
-            if exp - now <= self.refresh_margin_seconds:
-                refresh_persisted = False
-                try:
-                    refreshed_auth = self._refresh(auth)
-                    self._write_auth(refreshed_auth)
-                    refresh_persisted = True
-                    access_token = self._token(refreshed_auth, "access_token")
-                    exp = self._jwt_exp(access_token)
-                    auth = refreshed_auth
-                    refreshed = True
+                if refresh_persisted:
                     audit.write(
                         request_id=request_id,
                         agent=agent_id,
                         provider=self.name,
-                        operation="files.refresh",
+                        operation=f"{operation_prefix}.refresh",
                         allowed=True,
-                        expires_at=rfc3339(exp),
+                        expires_at=None,
+                        validation_error=True,
                     )
-                except ProviderError:
-                    if refresh_persisted:
-                        audit.write(
-                            request_id=request_id,
-                            agent=agent_id,
-                            provider=self.name,
-                            operation="files.refresh",
-                            allowed=True,
-                            expires_at=None,
-                            validation_error=True,
-                        )
-                    if exp <= now:
-                        raise
-                    print(f"codex-oauth provider {self.name}: refresh failed; serving current valid access token", flush=True)
+                if exp <= now:
+                    raise
+                print(f"codex-oauth provider {self.name}: refresh failed; serving current valid access token", flush=True)
+        return auth, access_token, exp, refreshed
+
+    def injection_headers(self, host, method, path, agent_id, audit, request_id):
+        with self.lock:
+            _auth, access_token, exp, _refreshed = self._fresh_auth(agent_id, audit, request_id, "injection")
+        return {"authorization": f"Bearer {access_token}"}, rfc3339(exp), ["authorization"]
+
+    def files(self, agent_id, audit, request_id):
+        with self.lock:
+            auth, _access_token, exp, refreshed = self._fresh_auth(agent_id, audit, request_id, "files")
             vended = json.loads(json.dumps(auth))
             tokens = vended.setdefault("tokens", {})
             if not isinstance(tokens, dict):

--- a/broker/plugins/static_token/provider.py
+++ b/broker/plugins/static_token/provider.py
@@ -1,6 +1,6 @@
 import fnmatch
 
-from broker.core.config import env_value, fail, list_value, string_value
+from broker.core.config import env_value, fail, injection_hosts, list_value, string_value
 from broker.plugins.github_app.provider import ProviderError
 from broker.plugins.static_target import normalize_target, target_mode
 
@@ -18,6 +18,7 @@ class StaticTokenProvider:
         self.target_mode = target_mode(self.config, self.name)
         self.allowed_repositories = self._allowed_strings("repositories")
         self.token = self._token()
+        self.injection_hosts = injection_hosts(self.config, self.name)
 
     def _allowed_strings(self, key):
         values = list_value(self.allow.get(key), f"provider {self.name} allow.{key}")
@@ -66,3 +67,6 @@ class StaticTokenProvider:
 
     def identity_for_repo(self, repo, effective_repositories):
         raise ProviderError("identity-not-supported", f"provider {self.name} does not support commit identity; use identity.mode=explicit")
+
+    def injection_headers(self, host, method, path, agent_id, audit, request_id):
+        return {"authorization": f"Bearer {self.token}"}, None, ["authorization"]

--- a/egressd/.golangci.yml
+++ b/egressd/.golangci.yml
@@ -1,0 +1,126 @@
+version: "2"
+run:
+  timeout: 5m
+  allow-parallel-runners: true
+
+linters:
+  default: all
+
+  disable:
+    - nonamedreturns
+    - arangolint
+    - ginkgolinter
+    - wsl
+    - wsl_v5
+    - lll
+    - paralleltest
+    - promlinter
+    - varnamelen
+    - nlreturn
+    - noinlineerr
+    - gomoddirectives
+    - depguard
+    - godox
+    # - godoclint
+    - exhaustruct
+    - funcorder
+    - gochecknoglobals
+    - ireturn
+    - mnd
+    - tagliatelle
+    - testpackage
+
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+
+    govet:
+      enable-all: true
+      # disable:
+      #   - fieldalignment
+
+    nakedret:
+      max-func-lines: 0
+
+    exhaustive:
+      default-signifies-exhaustive: false
+
+    goconst:
+      min-occurrences: 3
+
+    gocyclo:
+      min-complexity: 16
+
+    gocognit:
+      min-complexity: 20
+
+    cyclop:
+      max-complexity: 20
+      package-average: 10.0
+
+    funlen:
+      lines: 80
+      statements: 50
+
+    nestif:
+      min-complexity: 4
+
+    exhaustruct:
+      exclude:
+        - 'net/http\.Client'
+
+    gocritic:
+      settings:
+        captLocal:
+          paramsOnly: false
+        underef:
+          skipRecvDeref: false
+
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+        - name: error-return
+        - name: error-naming
+        - name: if-return
+        - name: increment-decrement
+        - name: var-declaration
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: empty-block
+        - name: unnecessary-stmt
+        - name: unreachable-code
+
+  exclusions:
+    generated: lax
+    warn-unused: true
+    rules:
+      - path: '_test\.go'
+        linters:
+          - funlen
+          - gosec
+          - gocognit
+          - exhaustruct
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+    - golines
+  exclusions:
+    generated: lax
+  settings:
+    golines:
+      max-len: 120

--- a/egressd/cmd/egressd/main.go
+++ b/egressd/cmd/egressd/main.go
@@ -1,0 +1,68 @@
+// Command egressd runs the credential-injecting egress proxy for mediated
+// agent runs (protocol/injection.md).
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/mirkoSekulic/nvt-agent/egressd/internal/egress"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("egressd: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	configPath := os.Getenv("NVT_EGRESSD_CONFIG")
+	if configPath == "" {
+		configPath = "/etc/nvt-egressd/config.json"
+	}
+	config, err := egress.LoadConfig(configPath)
+	if err != nil {
+		return err
+	}
+	token := os.Getenv("NVT_BROKER_TOKEN")
+	if token == "" {
+		return fmt.Errorf("NVT_BROKER_TOKEN is required (egress-role identity)")
+	}
+	brokerHTTP, err := brokerHTTPClient(config)
+	if err != nil {
+		return err
+	}
+	broker := &egress.BrokerClient{URL: config.BrokerURL, Token: token, Client: brokerHTTP}
+	transport := &http.Transport{ForceAttemptHTTP2: true}
+	errors := make(chan error, len(config.Routes))
+	for _, route := range config.Routes {
+		proxy := &egress.Proxy{Route: route, Broker: broker, Transport: transport}
+		server := &http.Server{Addr: route.Listen, Handler: proxy}
+		log.Printf("egressd: routing %s -> %s (capability %s)", route.Listen, route.Upstream, route.Capability)
+		go func() {
+			errors <- server.ListenAndServe()
+		}()
+	}
+	return <-errors
+}
+
+func brokerHTTPClient(config *egress.Config) (*http.Client, error) {
+	if config.BrokerCAFile == "" {
+		return http.DefaultClient, nil
+	}
+	pem, err := os.ReadFile(config.BrokerCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("read broker CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("broker CA file contains no certificates")
+	}
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}}
+	return &http.Client{Transport: transport}, nil
+}

--- a/egressd/go.mod
+++ b/egressd/go.mod
@@ -1,0 +1,3 @@
+module github.com/mirkoSekulic/nvt-agent/egressd
+
+go 1.25.0

--- a/egressd/internal/egress/broker.go
+++ b/egressd/internal/egress/broker.go
@@ -1,0 +1,85 @@
+package egress
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Material is one injectable-header response from the broker. Header values
+// are credentials: Material must never be logged or serialized.
+type Material struct {
+	Headers   map[string]string
+	Strip     []string
+	ExpiresAt time.Time // zero when the broker reported no expiry
+}
+
+// BrokerClient calls brokerd's injection endpoint under the egress-role
+// identity.
+type BrokerClient struct {
+	URL    string
+	Token  string
+	Client *http.Client
+}
+
+type injectionRequest struct {
+	Capability string `json:"capability"`
+	Host       string `json:"host"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+}
+
+type injectionResponse struct {
+	OK                  bool              `json:"ok"`
+	Error               string            `json:"error"`
+	Headers             map[string]string `json:"headers"`
+	ExpiresAt           string            `json:"expires_at"`
+	StripRequestHeaders []string          `json:"strip_request_headers"`
+}
+
+// FetchHeaders requests injectable headers for one (capability, host,
+// method, path). Any failure is returned as an error; callers must fail
+// closed rather than reuse stale material.
+func (b *BrokerClient) FetchHeaders(ctx context.Context, capability, host, method, path string) (*Material, error) {
+	body, err := json.Marshal(injectionRequest{
+		Capability: capability,
+		Host:       host,
+		Method:     method,
+		Path:       path,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode injection request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, b.URL+"/v1/injection/headers", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build injection request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+b.Token)
+	response, err := b.Client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("broker unreachable: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	var decoded injectionResponse
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decode injection response: %w", err)
+	}
+	if response.StatusCode != http.StatusOK || !decoded.OK {
+		// decoded.Error is a machine reason (e.g. provider-not-granted),
+		// never a header value; safe to wrap.
+		return nil, fmt.Errorf("broker denied injection: %s", decoded.Error)
+	}
+	material := &Material{Headers: decoded.Headers, Strip: decoded.StripRequestHeaders}
+	if decoded.ExpiresAt != "" {
+		expires, parseErr := time.Parse(time.RFC3339, decoded.ExpiresAt)
+		if parseErr != nil {
+			return nil, fmt.Errorf("broker returned invalid expires_at")
+		}
+		material.ExpiresAt = expires
+	}
+	return material, nil
+}

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -8,8 +8,11 @@ package egress
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
+	"strconv"
+	"strings"
 )
 
 // Placeholder is the documented zero-entropy constant from
@@ -87,9 +90,38 @@ func (c *Config) Validate() error {
 		if route.Capability == "" {
 			return fmt.Errorf("routes[%d].capability is required", index)
 		}
-		if route.Upstream == "" {
-			return fmt.Errorf("routes[%d].upstream is required", index)
+		if err := validateUpstream(route.Upstream); err != nil {
+			return fmt.Errorf("routes[%d].upstream: %w", index, err)
 		}
+	}
+	return nil
+}
+
+// validateUpstream enforces that the pinned re-origination target is a bare
+// host[:port]. Schemes, paths, userinfo, and malformed ports are rejected:
+// this value decides where credentials are sent, so upstream-host confusion
+// is an SSRF vector, not a formatting nit.
+func validateUpstream(upstream string) error {
+	if upstream == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if strings.Contains(upstream, "://") || strings.ContainsAny(upstream, "/\\@?# \t") {
+		return fmt.Errorf("must be a bare host[:port], got %q", upstream)
+	}
+	host := upstream
+	if strings.Contains(upstream, ":") {
+		split, port, err := net.SplitHostPort(upstream)
+		if err != nil {
+			return fmt.Errorf("invalid host:port %q", upstream)
+		}
+		number, err := strconv.Atoi(port)
+		if err != nil || number < 1 || number > 65535 {
+			return fmt.Errorf("invalid port in %q", upstream)
+		}
+		host = split
+	}
+	if host == "" {
+		return fmt.Errorf("empty host in %q", upstream)
 	}
 	return nil
 }

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -1,0 +1,95 @@
+// Package egress implements the trusted credential-injecting egress proxy
+// for mediated agent runs (protocol/injection.md). It receives plaintext
+// requests from the agent on localhost, fetches injectable headers from
+// brokerd under its own egress-role identity, injects them, and re-originates
+// TLS to the pinned upstream host. The agent never possesses a credential.
+package egress
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+)
+
+// Placeholder is the documented zero-entropy constant from
+// protocol/injection.md. Request headers carrying it are always stripped
+// before injection; it must never reach an upstream.
+const Placeholder = "NVT-PLACEHOLDER-NOT-A-KEY"
+
+// Route maps one local listener to one capability and upstream host.
+type Route struct {
+	// Listen is the local address, e.g. "127.0.0.1:8471".
+	Listen string `json:"listen"`
+	// Capability is the broker capability (provider name) whose injectable
+	// headers authorize this route.
+	Capability string `json:"capability"`
+	// Upstream is the pinned upstream host[:port]. TLS is re-originated to
+	// this host; the incoming request cannot choose a different one.
+	Upstream string `json:"upstream"`
+	// AllowInsecureUpstream permits a plain-HTTP upstream. Test/dev only.
+	AllowInsecureUpstream bool `json:"allow_insecure_upstream"`
+}
+
+// Config is the egressd configuration file shape.
+type Config struct {
+	// BrokerURL is the brokerd base URL. Must be https: the egressd-broker
+	// leg is the one network path carrying real credentials through the
+	// agent's network namespace (docs/mediated-egress-plan.md section 2).
+	BrokerURL string `json:"broker_url"`
+	// AllowInsecureBroker permits a plain-HTTP broker URL. Local dev only;
+	// a mediated deployment serving injection over plaintext reachable from
+	// the agent netns is a conformance failure.
+	AllowInsecureBroker bool `json:"allow_insecure_broker"`
+	// BrokerCAFile optionally pins a CA bundle for the broker TLS endpoint.
+	BrokerCAFile string  `json:"broker_ca_file"`
+	Routes       []Route `json:"routes"`
+}
+
+// LoadConfig reads and validates the configuration file.
+func LoadConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var config Config
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// Validate enforces the transport and route rules.
+func (c *Config) Validate() error {
+	parsed, err := url.Parse(c.BrokerURL)
+	if err != nil || parsed.Host == "" {
+		return fmt.Errorf("broker_url must be a valid URL")
+	}
+	switch parsed.Scheme {
+	case "https":
+	case "http":
+		if !c.AllowInsecureBroker {
+			return fmt.Errorf("broker_url must be https unless allow_insecure_broker is set (local dev only)")
+		}
+	default:
+		return fmt.Errorf("broker_url must be an http(s) URL")
+	}
+	if len(c.Routes) == 0 {
+		return fmt.Errorf("at least one route is required")
+	}
+	for index, route := range c.Routes {
+		if route.Listen == "" {
+			return fmt.Errorf("routes[%d].listen is required", index)
+		}
+		if route.Capability == "" {
+			return fmt.Errorf("routes[%d].capability is required", index)
+		}
+		if route.Upstream == "" {
+			return fmt.Errorf("routes[%d].upstream is required", index)
+		}
+	}
+	return nil
+}

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -30,6 +31,15 @@ var hopByHopHeaders = map[string]bool{
 	"Upgrade":             true,
 }
 
+// maxCacheEntries bounds the material cache under pathological request-path
+// cardinality; hitting it resets the cache, which only costs refetches.
+const maxCacheEntries = 256
+
+type cacheEntry struct {
+	material  *Material
+	fetchedAt time.Time
+}
+
 // Proxy serves one route: it injects broker-fetched headers into incoming
 // requests and forwards them to the pinned upstream.
 type Proxy struct {
@@ -38,9 +48,8 @@ type Proxy struct {
 	Transport http.RoundTripper
 	Now       func() time.Time
 
-	mu        sync.Mutex
-	cached    *Material
-	fetchedAt time.Time
+	mu    sync.Mutex
+	cache map[string]*cacheEntry
 }
 
 func (p *Proxy) now() time.Time {
@@ -50,31 +59,45 @@ func (p *Proxy) now() time.Time {
 	return time.Now()
 }
 
-// material returns valid injectable material, refetching when the cache is
-// stale. It fails closed: a fetch error is returned as-is, never masked by
-// stale material.
+// material returns valid injectable material for one (method, path),
+// refetching when the cache is stale. The cache is keyed by method and path
+// because that is the scope the broker authorized: reusing material across
+// paths would bypass provider method/path policy. It fails closed: fetch
+// errors and already-expired material are errors, never masked by stale or
+// unauthorized reuse.
 func (p *Proxy) material(ctx context.Context, method, path string) (*Material, error) {
+	key := method + " " + path
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.cached != nil && p.cacheValidLocked() {
-		return p.cached, nil
+	if entry, ok := p.cache[key]; ok {
+		if p.entryValidLocked(entry) {
+			return entry.material, nil
+		}
+		delete(p.cache, key)
 	}
-	p.cached = nil
 	material, err := p.Broker.FetchHeaders(ctx, p.Route.Capability, p.Route.Upstream, method, path)
 	if err != nil {
 		return nil, err
 	}
-	p.cached = material
-	p.fetchedAt = p.now()
+	if !material.ExpiresAt.IsZero() && !p.now().Before(material.ExpiresAt.Add(-expiryMargin)) {
+		return nil, fmt.Errorf("broker returned expired injection material")
+	}
+	if p.cache == nil {
+		p.cache = map[string]*cacheEntry{}
+	}
+	if len(p.cache) >= maxCacheEntries {
+		p.cache = map[string]*cacheEntry{}
+	}
+	p.cache[key] = &cacheEntry{material: material, fetchedAt: p.now()}
 	return material, nil
 }
 
-func (p *Proxy) cacheValidLocked() bool {
+func (p *Proxy) entryValidLocked(entry *cacheEntry) bool {
 	now := p.now()
-	if !p.cached.ExpiresAt.IsZero() {
-		return now.Before(p.cached.ExpiresAt.Add(-expiryMargin))
+	if !entry.material.ExpiresAt.IsZero() {
+		return now.Before(entry.material.ExpiresAt.Add(-expiryMargin))
 	}
-	return now.Before(p.fetchedAt.Add(defaultTTL))
+	return now.Before(entry.fetchedAt.Add(defaultTTL))
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -1,0 +1,177 @@
+package egress
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// expiryMargin is how long before broker-reported expiry cached material is
+// considered stale.
+const expiryMargin = 30 * time.Second
+
+// defaultTTL bounds cache reuse when the broker reports no expiry.
+const defaultTTL = 60 * time.Second
+
+// hopByHopHeaders are never forwarded in either direction (RFC 9110 §7.6.1).
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Proxy-Connection":    true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+// Proxy serves one route: it injects broker-fetched headers into incoming
+// requests and forwards them to the pinned upstream.
+type Proxy struct {
+	Route     Route
+	Broker    *BrokerClient
+	Transport http.RoundTripper
+	Now       func() time.Time
+
+	mu        sync.Mutex
+	cached    *Material
+	fetchedAt time.Time
+}
+
+func (p *Proxy) now() time.Time {
+	if p.Now != nil {
+		return p.Now()
+	}
+	return time.Now()
+}
+
+// material returns valid injectable material, refetching when the cache is
+// stale. It fails closed: a fetch error is returned as-is, never masked by
+// stale material.
+func (p *Proxy) material(ctx context.Context, method, path string) (*Material, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cached != nil && p.cacheValidLocked() {
+		return p.cached, nil
+	}
+	p.cached = nil
+	material, err := p.Broker.FetchHeaders(ctx, p.Route.Capability, p.Route.Upstream, method, path)
+	if err != nil {
+		return nil, err
+	}
+	p.cached = material
+	p.fetchedAt = p.now()
+	return material, nil
+}
+
+func (p *Proxy) cacheValidLocked() bool {
+	now := p.now()
+	if !p.cached.ExpiresAt.IsZero() {
+		return now.Before(p.cached.ExpiresAt.Add(-expiryMargin))
+	}
+	return now.Before(p.fetchedAt.Add(defaultTTL))
+}
+
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	material, err := p.material(r.Context(), r.Method, r.URL.Path)
+	if err != nil {
+		// err carries broker reasons only, never header values.
+		log.Printf("egressd %s: injection material unavailable: %v", p.Route.Capability, err)
+		writeError(w, http.StatusBadGateway, "egress-injection-unavailable")
+		return
+	}
+	outbound, err := p.buildOutbound(r, material)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "egress-request-invalid")
+		return
+	}
+	response, err := p.Transport.RoundTrip(outbound)
+	if err != nil {
+		log.Printf("egressd %s: upstream unreachable", p.Route.Capability)
+		writeError(w, http.StatusBadGateway, "egress-upstream-unreachable")
+		return
+	}
+	defer func() { _ = response.Body.Close() }()
+	copyResponse(w, response)
+}
+
+func (p *Proxy) buildOutbound(r *http.Request, material *Material) (*http.Request, error) {
+	scheme := "https"
+	if p.Route.AllowInsecureUpstream {
+		scheme = "http"
+	}
+	outbound, err := http.NewRequestWithContext(r.Context(), r.Method, scheme+"://"+p.Route.Upstream+r.URL.RequestURI(), r.Body)
+	if err != nil {
+		return nil, err
+	}
+	outbound.ContentLength = r.ContentLength
+	strip := map[string]bool{}
+	for _, name := range material.Strip {
+		strip[http.CanonicalHeaderKey(name)] = true
+	}
+	for name, values := range r.Header {
+		canonical := http.CanonicalHeaderKey(name)
+		if hopByHopHeaders[canonical] || strip[canonical] || canonical == "Host" {
+			continue
+		}
+		if containsPlaceholder(values) {
+			continue
+		}
+		outbound.Header[canonical] = values
+	}
+	for name, value := range material.Headers {
+		outbound.Header.Set(name, value)
+	}
+	outbound.Host = p.Route.Upstream
+	return outbound, nil
+}
+
+func containsPlaceholder(values []string) bool {
+	for _, value := range values {
+		if strings.Contains(value, Placeholder) {
+			return true
+		}
+	}
+	return false
+}
+
+func copyResponse(w http.ResponseWriter, response *http.Response) {
+	header := w.Header()
+	for name, values := range response.Header {
+		if hopByHopHeaders[http.CanonicalHeaderKey(name)] {
+			continue
+		}
+		header[name] = values
+	}
+	w.WriteHeader(response.StatusCode)
+	flusher, _ := w.(http.Flusher)
+	writer := io.Writer(w)
+	if flusher != nil {
+		writer = flushWriter{w: w, flusher: flusher}
+	}
+	_, _ = io.Copy(writer, response.Body)
+}
+
+// flushWriter flushes after every write so streaming responses (SSE) reach
+// the agent without buffering delays.
+type flushWriter struct {
+	w       io.Writer
+	flusher http.Flusher
+}
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	fw.flusher.Flush()
+	return n, err
+}
+
+func writeError(w http.ResponseWriter, status int, reason string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(`{"ok":false,"error":"` + reason + `"}`))
+}

--- a/egressd/internal/egress/proxy_test.go
+++ b/egressd/internal/egress/proxy_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -143,7 +144,7 @@ func (u *fakeUpstream) last(t *testing.T) upstreamRecord {
 	return u.records[len(u.records)-1]
 }
 
-func newTestProxy(t *testing.T, broker *fakeBroker, upstream *fakeUpstream) *httptest.Server {
+func newTestProxyWithHandle(t *testing.T, broker *fakeBroker, upstream *fakeUpstream) (*httptest.Server, *Proxy) {
 	t.Helper()
 	parsed, err := url.Parse(upstream.server.URL)
 	if err != nil {
@@ -161,6 +162,12 @@ func newTestProxy(t *testing.T, broker *fakeBroker, upstream *fakeUpstream) *htt
 	}
 	server := httptest.NewServer(proxy)
 	t.Cleanup(server.Close)
+	return server, proxy
+}
+
+func newTestProxy(t *testing.T, broker *fakeBroker, upstream *fakeUpstream) *httptest.Server {
+	t.Helper()
+	server, _ := newTestProxyWithHandle(t, broker, upstream)
 	return server
 }
 
@@ -257,9 +264,10 @@ func TestFailsClosedWhenBrokerDenies(t *testing.T) {
 	}
 }
 
-// TestNoStaleMaterialAfterExpiry pins the other half of fail-closed: expired
-// cached material is never reused; when the refetch fails, the request fails.
-func TestNoStaleMaterialAfterExpiry(t *testing.T) {
+// TestExpiredMaterialFromBrokerFailsClosed pins fail-closed at fetch time:
+// material that arrives already expired (or inside the safety margin) is an
+// error before the upstream is ever contacted.
+func TestExpiredMaterialFromBrokerFailsClosed(t *testing.T) {
 	broker := newFakeBroker(t)
 	broker.setExpiresAt(time.Now().UTC().Add(-time.Minute).Format(time.RFC3339))
 	upstream := newFakeUpstream(t)
@@ -270,10 +278,37 @@ func TestNoStaleMaterialAfterExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = response.Body.Close()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("already-expired material must fail closed, got %d", response.StatusCode)
+	}
+	upstream.mu.Lock()
+	defer upstream.mu.Unlock()
+	if len(upstream.records) != 0 {
+		t.Fatal("request reached upstream with expired material")
+	}
+}
+
+// TestNoStaleMaterialAfterExpiry pins the other half of fail-closed: expired
+// cached material is never reused; when the refetch fails, the request fails.
+func TestNoStaleMaterialAfterExpiry(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setExpiresAt(time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
+	upstream := newFakeUpstream(t)
+	proxy, handle := newTestProxyWithHandle(t, broker, upstream)
+
+	var offset atomic.Int64
+	handle.Now = func() time.Time { return time.Now().Add(time.Duration(offset.Load())) }
+
+	response, err := http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		t.Fatalf("first request should succeed (fresh fetch), got %d", response.StatusCode)
+		t.Fatalf("fresh material should succeed, got %d", response.StatusCode)
 	}
 
+	offset.Store(int64(2 * time.Hour))
 	broker.setFail(true)
 	response, err = http.Get(proxy.URL + "/")
 	if err != nil {
@@ -282,6 +317,47 @@ func TestNoStaleMaterialAfterExpiry(t *testing.T) {
 	_ = response.Body.Close()
 	if response.StatusCode != http.StatusBadGateway {
 		t.Fatalf("expired material must not be reused: got %d", response.StatusCode)
+	}
+}
+
+// TestCacheKeyedByMethodAndPath pins the cache scope: the broker authorizes
+// (capability, host, method, path), so material fetched for one method/path
+// must not be reused for another without re-asking the broker.
+func TestCacheKeyedByMethodAndPath(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setExpiresAt(time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	for _, request := range []struct{ method, path string }{
+		{http.MethodGet, "/a"},
+		{http.MethodGet, "/a"},
+		{http.MethodGet, "/b"},
+		{http.MethodPost, "/a"},
+	} {
+		req, err := http.NewRequest(request.method, proxy.URL+request.path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+	}
+	if calls := broker.callCount(); calls != 3 {
+		t.Fatalf("expected 3 broker fetches for 3 distinct (method, path) scopes, got %d", calls)
+	}
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	seen := map[string]bool{}
+	for _, request := range broker.requests {
+		seen[request["method"]+" "+request["path"]] = true
+	}
+	for _, scope := range []string{"GET /a", "GET /b", "POST /a"} {
+		if !seen[scope] {
+			t.Fatalf("broker never asked for scope %q; requests: %v", scope, broker.requests)
+		}
 	}
 }
 
@@ -357,6 +433,33 @@ func TestHopByHopHeadersNotForwarded(t *testing.T) {
 	record := upstream.last(t)
 	if record.header.Get("Proxy-Authorization") != "" {
 		t.Fatal("hop-by-hop header forwarded to upstream")
+	}
+}
+
+// TestConfigRejectsMalformedUpstream pins the SSRF guard on the pinned
+// re-origination target: only bare host[:port] values are accepted.
+func TestConfigRejectsMalformedUpstream(t *testing.T) {
+	invalid := []string{
+		"",
+		"https://chatgpt.com",
+		"chatgpt.com/path",
+		"user@chatgpt.com",
+		"chatgpt.com:notaport",
+		"chatgpt.com:0",
+		":8443",
+		"chatgpt.com ",
+		"chatgpt.com#frag",
+	}
+	for _, upstream := range invalid {
+		if err := validateUpstream(upstream); err == nil {
+			t.Errorf("upstream %q must be rejected", upstream)
+		}
+	}
+	valid := []string{"chatgpt.com", "chatgpt.com:443", "127.0.0.1:8080", "[::1]:8443"}
+	for _, upstream := range valid {
+		if err := validateUpstream(upstream); err != nil {
+			t.Errorf("upstream %q should validate: %v", upstream, err)
+		}
 	}
 }
 

--- a/egressd/internal/egress/proxy_test.go
+++ b/egressd/internal/egress/proxy_test.go
@@ -1,0 +1,378 @@
+package egress
+
+// Phase 1 proof of the generic injection path (docs/mediated-egress-plan.md):
+// agent request -> egressd -> broker /v1/injection/headers -> upstream
+// receives the injected Authorization. No real provider credential is
+// involved anywhere; the broker and upstream are fakes.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const realToken = "real-injected-token"
+
+type fakeBroker struct {
+	server    *httptest.Server
+	mu        sync.Mutex
+	calls     int
+	fail      bool
+	expiresAt string
+	requests  []map[string]string
+}
+
+func newFakeBroker(t *testing.T) *fakeBroker {
+	t.Helper()
+	broker := &fakeBroker{}
+	broker.server = httptest.NewServer(http.HandlerFunc(broker.handle))
+	t.Cleanup(broker.server.Close)
+	return broker
+}
+
+func (b *fakeBroker) handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/v1/injection/headers" {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	if r.Header.Get("Authorization") != "Bearer egress-role-token" {
+		http.Error(w, `{"ok":false,"error":"unauthorized"}`, http.StatusUnauthorized)
+		return
+	}
+	var payload map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	b.mu.Lock()
+	b.calls++
+	b.requests = append(b.requests, payload)
+	fail := b.fail
+	expiresAt := b.expiresAt
+	b.mu.Unlock()
+	if fail {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"token-refresh-failed"}`))
+		return
+	}
+	response := map[string]any{
+		"ok":                    true,
+		"headers":               map[string]string{"authorization": "Bearer " + realToken},
+		"strip_request_headers": []string{"authorization"},
+	}
+	if expiresAt != "" {
+		response["expires_at"] = expiresAt
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (b *fakeBroker) setFail(value bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fail = value
+}
+
+func (b *fakeBroker) setExpiresAt(value string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.expiresAt = value
+}
+
+func (b *fakeBroker) callCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.calls
+}
+
+type upstreamRecord struct {
+	authorization []string
+	header        http.Header
+	path          string
+}
+
+type fakeUpstream struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	records []upstreamRecord
+	handler http.HandlerFunc
+}
+
+func newFakeUpstream(t *testing.T) *fakeUpstream {
+	t.Helper()
+	upstream := &fakeUpstream{}
+	upstream.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstream.mu.Lock()
+		upstream.records = append(upstream.records, upstreamRecord{
+			authorization: r.Header.Values("Authorization"),
+			header:        r.Header.Clone(),
+			path:          r.URL.RequestURI(),
+		})
+		handler := upstream.handler
+		upstream.mu.Unlock()
+		if handler != nil {
+			handler(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer "+realToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"bad credential"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(upstream.server.Close)
+	return upstream
+}
+
+func (u *fakeUpstream) last(t *testing.T) upstreamRecord {
+	t.Helper()
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if len(u.records) == 0 {
+		t.Fatal("upstream received no requests")
+	}
+	return u.records[len(u.records)-1]
+}
+
+func newTestProxy(t *testing.T, broker *fakeBroker, upstream *fakeUpstream) *httptest.Server {
+	t.Helper()
+	parsed, err := url.Parse(upstream.server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := &Proxy{
+		Route: Route{
+			Listen:                "unused",
+			Capability:            "codex-main",
+			Upstream:              parsed.Host,
+			AllowInsecureUpstream: true,
+		},
+		Broker:    &BrokerClient{URL: broker.server.URL, Token: "egress-role-token", Client: broker.server.Client()},
+		Transport: http.DefaultTransport,
+	}
+	server := httptest.NewServer(proxy)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestInjectsRealTokenForPlaceholderAuth is the core Phase 1 proof: the
+// client sends the placeholder (or nothing), the upstream receives exactly
+// one Authorization header carrying the real broker-fetched token, and the
+// placeholder never reaches the upstream.
+func TestInjectsRealTokenForPlaceholderAuth(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	request, err := http.NewRequest(http.MethodPost, proxy.URL+"/backend-api/responses?stream=true", strings.NewReader(`{"prompt":"hi"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+Placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from upstream, got %d", response.StatusCode)
+	}
+
+	record := upstream.last(t)
+	if len(record.authorization) != 1 || record.authorization[0] != "Bearer "+realToken {
+		t.Fatalf("upstream authorization = %v, want exactly the injected token", record.authorization)
+	}
+	if record.path != "/backend-api/responses?stream=true" {
+		t.Fatalf("upstream path = %q", record.path)
+	}
+	for name, values := range record.header {
+		for _, value := range values {
+			if strings.Contains(value, Placeholder) {
+				t.Fatalf("placeholder reached upstream in header %s", name)
+			}
+		}
+	}
+}
+
+// TestPlaceholderStrippedFromAnyHeader pins the scrub rule: a placeholder in
+// a header the broker did not list in strip_request_headers is still removed.
+func TestPlaceholderStrippedFromAnyHeader(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	request, err := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("X-Api-Key", Placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+
+	record := upstream.last(t)
+	if record.header.Get("X-Api-Key") != "" {
+		t.Fatal("placeholder-bearing header forwarded to upstream")
+	}
+}
+
+// TestFailsClosedWhenBrokerDenies pins fail-closed behavior: a broker denial
+// yields 502 with a generic reason, and nothing reaches the upstream.
+func TestFailsClosedWhenBrokerDenies(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setFail(true)
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	response, err := http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", response.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["ok"] != false || strings.Contains(fmt.Sprint(body), realToken) {
+		t.Fatalf("unexpected error body: %v", body)
+	}
+	upstream.mu.Lock()
+	defer upstream.mu.Unlock()
+	if len(upstream.records) != 0 {
+		t.Fatal("request reached upstream despite broker denial")
+	}
+}
+
+// TestNoStaleMaterialAfterExpiry pins the other half of fail-closed: expired
+// cached material is never reused; when the refetch fails, the request fails.
+func TestNoStaleMaterialAfterExpiry(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setExpiresAt(time.Now().UTC().Add(-time.Minute).Format(time.RFC3339))
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	response, err := http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("first request should succeed (fresh fetch), got %d", response.StatusCode)
+	}
+
+	broker.setFail(true)
+	response, err = http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expired material must not be reused: got %d", response.StatusCode)
+	}
+}
+
+// TestCacheReusedUntilExpiry pins cache behavior: consecutive requests within
+// the validity window trigger exactly one broker fetch.
+func TestCacheReusedUntilExpiry(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setExpiresAt(time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	for range 3 {
+		response, err := http.Get(proxy.URL + "/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+	}
+	if calls := broker.callCount(); calls != 1 {
+		t.Fatalf("expected 1 broker fetch for 3 requests, got %d", calls)
+	}
+}
+
+// TestStreamingResponsePassthrough pins SSE behavior: the first event reaches
+// the client while the upstream is still holding the connection open.
+func TestStreamingResponsePassthrough(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	release := make(chan struct{})
+	upstream.handler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: first\n\n"))
+		w.(http.Flusher).Flush()
+		<-release
+		_, _ = w.Write([]byte("data: second\n\n"))
+	}
+	proxy := newTestProxy(t, broker, upstream)
+
+	response, err := http.Get(proxy.URL + "/stream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	reader := bufio.NewReader(response.Body)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "data: first\n" {
+		t.Fatalf("first streamed line = %q", line)
+	}
+	close(release)
+}
+
+// TestHopByHopHeadersNotForwarded pins RFC 9110 hygiene at the proxy hop.
+func TestHopByHopHeadersNotForwarded(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	request, err := http.NewRequest(http.MethodGet, proxy.URL+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Proxy-Authorization", "Bearer should-not-forward")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+
+	record := upstream.last(t)
+	if record.header.Get("Proxy-Authorization") != "" {
+		t.Fatal("hop-by-hop header forwarded to upstream")
+	}
+}
+
+// TestConfigRefusesPlaintextBrokerByDefault pins the transport rule from the
+// plan: the egressd-broker leg carries real credentials and must be TLS
+// unless local dev explicitly opts out.
+func TestConfigRefusesPlaintextBrokerByDefault(t *testing.T) {
+	config := &Config{
+		BrokerURL: "http://127.0.0.1:7347",
+		Routes:    []Route{{Listen: "127.0.0.1:0", Capability: "c", Upstream: "example.com"}},
+	}
+	if err := config.Validate(); err == nil {
+		t.Fatal("plaintext broker URL must be rejected without allow_insecure_broker")
+	}
+	config.AllowInsecureBroker = true
+	if err := config.Validate(); err != nil {
+		t.Fatalf("opt-in insecure broker should validate: %v", err)
+	}
+}

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -334,6 +334,31 @@ These providers are compatibility providers. They remove raw secret env vars
 from the agent container, but token/header capability calls still return
 credentials to the agent.
 
+## Injection Support (Mediated Egress)
+
+Providers opt into header injection (`protocol/injection.md`) with an
+`injection-hosts` config list naming the upstream hosts the credential may be
+injected for. A provider without `injection-hosts` does not support
+injection and `/v1/injection/*` denies with `injection-not-supported`.
+
+```yaml
+providers:
+  - name: codex-main
+    plugin: codex-oauth
+    config:
+      auth-file: /state/codex/auth.json
+      injection-hosts:
+        - chatgpt.com
+        - auth.openai.com
+```
+
+The `token` and `codex-oauth` plugins support injection. For `codex-oauth`,
+injected material is `authorization: Bearer <access token>` using the same
+refresh flow as file vending; audit entries use the `injection.*` operation
+prefix. Grants must carry `materialization: header-inject` (see
+`protocol/injection.md` for the identity role/pairing model and endpoint
+shapes).
+
 ## Headers
 
 Allowed caller request headers:

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -358,6 +358,8 @@ providers:
   - name: codex-main
     plugin: codex-oauth
     config:
+      injection-hosts:
+        - chatgpt.com
       auth-file: %q
       token-url: %q
       client-id: test-client

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -354,6 +354,54 @@ func TestEgressIdentityWithGrantsIsConfigError(t *testing.T) {
 	}
 }
 
+// TestDeniedInjectionAuditIncludesContext pins the audit guarantee on denial
+// paths: a denied injection request is audited with the capability, host,
+// method, path, and operation the caller named — denials are exactly where
+// audit context matters most.
+func TestDeniedInjectionAuditIncludesContext(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	payload := injectionRequest()
+	payload["host"] = "evil.example.com"
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", payload)
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("disallowed host must deny: status=%d body=%v", status, body)
+	}
+
+	audit, err := os.ReadFile(f.audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(string(audit)), "\n") {
+		var candidate map[string]any
+		if err := json.Unmarshal([]byte(line), &candidate); err != nil {
+			t.Fatal(err)
+		}
+		if candidate["reason"] == "host-not-allowed" {
+			entry = candidate
+			break
+		}
+	}
+	if entry == nil {
+		t.Fatalf("no host-not-allowed audit entry found: %s", audit)
+	}
+	expectations := map[string]any{
+		"provider":  "codex-main",
+		"operation": "injection.headers",
+		"host":      "evil.example.com",
+		"method":    "POST",
+		"path":      "/backend-api/responses",
+		"allowed":   false,
+	}
+	for key, want := range expectations {
+		if entry[key] != want {
+			t.Fatalf("audit entry %s = %v, want %v (entry: %v)", key, entry[key], want, entry)
+		}
+	}
+}
+
 // TestInjectionAuditOmitsSecretValues pins the audit rule: injection requests
 // are audited with metadata only; header values never appear in the audit
 // log on allow or deny paths.

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -1,12 +1,8 @@
 package broker_test
 
-// Phase 0 skeletons for the mediated credential egress injection contract
-// (protocol/injection.md, docs/mediated-egress-plan.md).
-//
-// Every test here is skipped pending its implementation phase. The bodies are
-// written against the intended black-box behavior so the contract is
-// reviewable as code and unskipping is the only change needed when the
-// implementation lands (plan Phase 1 for the broker side).
+// Conformance suite for the mediated credential egress injection contract
+// (protocol/injection.md, docs/mediated-egress-plan.md), live as of plan
+// Phase 1.
 
 import (
 	"bytes"
@@ -18,8 +14,6 @@ import (
 	"strings"
 	"testing"
 )
-
-const injectionPending = "pending Phase 1 (docs/mediated-egress-plan.md): /v1/injection endpoints and identity roles not implemented"
 
 // nvtPlaceholder is the documented zero-entropy placeholder constant from
 // protocol/injection.md.
@@ -167,7 +161,6 @@ func injectionRequest() map[string]any {
 // egress identity obtains injectable headers; the agent identity holding the
 // grant itself is refused. This is the load-bearing non-possession property.
 func TestInjectionRequiresEgressRole(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -189,7 +182,6 @@ func TestInjectionRequiresEgressRole(t *testing.T) {
 // TestInjectionDeniesUnpairedEgressIdentity pins pairing: an egress identity
 // paired to a different agent cannot fetch material for this agent's grants.
 func TestInjectionDeniesUnpairedEgressIdentity(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -203,7 +195,6 @@ func TestInjectionDeniesUnpairedEgressIdentity(t *testing.T) {
 // the other direction: egress identities are injection-only and must be
 // denied on every compatibility endpoint that returns secrets to the caller.
 func TestEgressRoleCannotCallSecretBearingEndpoints(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -228,7 +219,6 @@ func TestEgressRoleCannotCallSecretBearingEndpoints(t *testing.T) {
 // may discover hosts and the placeholder constant, and the response never
 // contains secret material.
 func TestAgentRoleReceivesRoutingConfigOnly(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -255,7 +245,6 @@ func TestAgentRoleReceivesRoutingConfigOnly(t *testing.T) {
 // identity without a header-inject grant for the capability is denied,
 // including for unknown capabilities.
 func TestRoutingDeniesUngrantedCapability(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -270,7 +259,6 @@ func TestRoutingDeniesUngrantedCapability(t *testing.T) {
 // TestRoutingDeniesWrongPairedEgress pins routing scoping for egress callers:
 // an egress identity is authorized against its paired agent's grants only.
 func TestRoutingDeniesWrongPairedEgress(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -284,7 +272,6 @@ func TestRoutingDeniesWrongPairedEgress(t *testing.T) {
 // a file-bundle grant is a direct-mode grant with no sidecar to route to, so
 // routing denies rather than acting as a cross-mode probe.
 func TestRoutingDeniesFileBundleGrant(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	identities := mediatedIdentities()
 	identities["frontend"] = roleIdentity{
@@ -306,7 +293,6 @@ func TestRoutingDeniesFileBundleGrant(t *testing.T) {
 // exclusion: a header-inject grant makes the compatibility file endpoint deny
 // for that provider and agent. No hybrid mode exists.
 func TestHeaderInjectGrantExcludesFileBundle(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 
@@ -320,7 +306,6 @@ func TestHeaderInjectGrantExcludesFileBundle(t *testing.T) {
 // file-bundle grant (the default) denies injection for the paired egress
 // identity.
 func TestFileBundleGrantExcludesInjection(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	identities := mediatedIdentities()
 	identities["frontend"] = roleIdentity{
@@ -342,7 +327,6 @@ func TestFileBundleGrantExcludesInjection(t *testing.T) {
 // an egress identity are a validation error, not an ignored field — the
 // degeneration into "two tokens with the same grants" must be unrepresentable.
 func TestEgressIdentityWithGrantsIsConfigError(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(map[string]roleIdentity{
 		"frontend": {
@@ -374,7 +358,6 @@ func TestEgressIdentityWithGrantsIsConfigError(t *testing.T) {
 // are audited with metadata only; header values never appear in the audit
 // log on allow or deny paths.
 func TestInjectionAuditOmitsSecretValues(t *testing.T) {
-	t.Skip(injectionPending)
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(mediatedIdentities())
 

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	nonPossessionPending = "pending Phase 3 (docs/mediated-egress-plan.md): mediated operator/compose wiring not implemented"
-	placeholderPending   = "pending Phase 1 (docs/mediated-egress-plan.md): egressd and placeholder convention not implemented"
+	placeholderPending   = "pending Phase 3 (docs/mediated-egress-plan.md): protocol-level inertness is covered by egressd/internal/egress tests as of Phase 1; this container-level test lands with mediated wiring"
 	egressDeniedPending  = "pending Phase 5 (docs/mediated-egress-plan.md): egress enforcement not implemented"
 )
 


### PR DESCRIPTION
## Summary

Phase 1 of `docs/mediated-egress-plan.md`, implementing the `protocol/injection.md` contract pinned in #53. Built per the agreed split: prove the generic injection path against fake upstreams and a static bearer shape first — no Codex API key required anywhere. The real-credential validation (broker-owned `auth.json` via `codex-oauth`) is wired and conformance-tested, ready for the Phase 2 `chatgpt_base_url` gate.

## Broker

- **Identity roles and pairing**: `role: agent|egress` on identities, one-to-one `paired-agent`, per-grant `materialization` (`file-bundle` default). Grants on an egress identity and dangling/wrong-role pairings are config validation errors — the "two tokens with the same grants" degeneration is unrepresentable.
- **`POST /v1/injection/headers`** (egress role only): authorized against the *paired agent's* `header-inject` grants, host checked against the provider's `injection-hosts` allowlist. Returns headers + `expires_at` + `strip_request_headers`.
- **`POST /v1/injection/routing`**: non-secret hosts + placeholder constant; agent callers need their own header-inject grant, egress callers are scoped to their paired agent.
- **Role/materialization enforcement**: egress identities are denied on all secret-bearing endpoints (`/v1/token`, `/v1/headers`, `/v1/files`, `/v1/http/request`); a `header-inject` grant disables the file/token/header compatibility paths for that provider (no hybrid mode).
- **Providers**: `token` and `codex-oauth` opt in via `injection-hosts` config. `codex-oauth` reuses the exact refresh flow from file vending (audit ops under `injection.*`), so the existing broker-owned `auth.json` becomes injectable with zero new credentials.
- **Optional TLS serving** (`NVT_BROKER_TLS_CERT`/`KEY`) — the egressd↔broker leg is the one path carrying real credentials through the agent netns.

## egressd (new Go module, stdlib only)

Per-route reverse proxy: fetches injectable headers under its own egress-role identity, caches until `expires_at` minus margin, injects, re-originates to the pinned upstream host. Fail closed: broker error or expired material → 502, never stale reuse, never a bundle. Placeholder-bearing request headers are stripped unconditionally. SSE streaming passes through with per-write flush. Plaintext broker URLs are refused unless `allow_insecure_broker` is set (local dev only).

## Tests

- The 11 injection conformance tests from Phase 0 are **unskipped and pass** against the real broker (identity split, cross-agent pairing refusal, role restrictions, routing authorization, materialization exclusion both ways, config validation, audit secrecy).
- 8 new egressd tests prove the Phase 1 contract end to end with fake broker + fake upstream: client sends placeholder → upstream receives exactly the injected real token, placeholder never reaches upstream; fail-closed on denial and on expired material; cache reuse; SSE first-event latency; hop-by-hop hygiene; broker TLS rule.
- Full broker suite green (existing tests unaffected; legacy agents.yaml shape parses unchanged). egressd vet+test added to CI.

## Review focus (trusted core — line-by-line per the plan)

1. `broker/core/agents.py` — role/pairing validation; is any invalid pairing representable?
2. `broker/core/server.py` — endpoint authorization order (role → pairing → grant → materialization → host).
3. `egressd/internal/egress/proxy.go` — header filtering (strip list, placeholder scrub, hop-by-hop), fail-closed paths, no header values in logs.

## Notes

- Local brokers need an image rebuild (`make broker-build`) to serve the new endpoints; existing agents.yaml files parse unchanged (role defaults to `agent`, materialization to `file-bundle`).
- Next: Phase 2 go/no-go — point a real Codex CLI at egressd via `chatgpt_base_url` with a `codex-main` header-inject grant and enumerate hosts/cert-pinning behavior under deny-all.