### PR TITLE
Phase 2: Codex plan-auth mediation gate harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ values.nvt-local.yaml
 values.*.local.yaml
 __pycache__/
 *.pyc
+.phase2-out/

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BROKER_ENV_FILE ?= .broker/env
 BROKER_ENV_SECRET ?= nvt-broker-env
 PRODUCER_IMAGE ?= nvt-github-comments-producer:latest
 GATEWAY_IMAGE ?= nvt-agent-gateway:latest
+EGRESSD_IMAGE ?= nvt-egressd:latest
 PRODUCER_VALUES ?= values.github-comments.yaml
 PRODUCER_RELEASE ?= nvt-github-comments-producer
 PRODUCER_CHART ?= charts/nvt-github-comments-producer
@@ -28,13 +29,19 @@ OPERATOR_KIND_EXTRA_IMAGE_TARGETS := gateway-kind-load
 OPERATOR_KIND_GATEWAY_HELM_ARGS := --set gateway.enabled=true --set gateway.image=$(GATEWAY_IMAGE)
 endif
 
-.PHONY: runtime-build broker-build operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
+.PHONY: runtime-build broker-build egressd-build phase2-codex-gate operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
 
 runtime-build:
 	bash scripts/runtime-build.sh $(if $(NO_CACHE),--no-cache)
 
 broker-build:
 	bash scripts/broker-build.sh
+
+egressd-build:
+	docker build -f egressd/Dockerfile -t "$(EGRESSD_IMAGE)" .
+
+phase2-codex-gate: runtime-build broker-build egressd-build
+	bash scripts/phase2-codex-gate.sh
 
 operator-build:
 	bash scripts/operator-build.sh $(if $(NO_CACHE),--no-cache)

--- a/broker/plugins/codex_oauth/provider.py
+++ b/broker/plugins/codex_oauth/provider.py
@@ -42,7 +42,32 @@ class CodexOAuthProvider:
         )
         self.extra_files = self._extra_files()
         self.injection_hosts = injection_hosts(self.config, self.name)
+        self.claim_headers = self._claim_headers()
         self.lock = threading.Lock()
+
+    def _claim_headers(self):
+        output = []
+        for index, item in enumerate(list_value(self.config.get("injection-claim-headers"), f"provider {self.name} config.injection-claim-headers")):
+            if not isinstance(item, dict):
+                fail(f"provider {self.name} config.injection-claim-headers[{index}] must be a YAML object")
+            header = string_value(item.get("header"), f"provider {self.name} config.injection-claim-headers[{index}].header", required=True)
+            raw_path = item.get("claim-path")
+            field = f"provider {self.name} config.injection-claim-headers[{index}].claim-path"
+            # A claim key may itself contain dots (the OpenAI account claim key
+            # is a URL), so a list of exact segments is accepted alongside the
+            # dotted-string shorthand.
+            if isinstance(raw_path, list):
+                path = []
+                for segment_index, segment in enumerate(raw_path):
+                    if not isinstance(segment, str) or not segment:
+                        fail(f"{field}[{segment_index}] must be a non-empty string")
+                    path.append(segment)
+            else:
+                path = [segment for segment in string_value(raw_path, field, required=True).split(".") if segment]
+            if not path:
+                fail(f"{field} must not be empty")
+            output.append({"header": header, "path": path})
+        return output
 
     def _provider_value(self, key, default=None):
         value = self.config.get(key)
@@ -133,7 +158,45 @@ class CodexOAuthProvider:
     def injection_headers(self, host, method, path, agent_id, audit, request_id):
         with self.lock:
             _auth, access_token, exp, _refreshed = self._fresh_auth(agent_id, audit, request_id, "injection")
-        return {"authorization": f"Bearer {access_token}"}, rfc3339(exp), ["authorization"]
+        headers = {"authorization": f"Bearer {access_token}"}
+        strip = ["authorization"]
+        if self.claim_headers:
+            claims = self._jwt_claims(access_token)
+            for entry in self.claim_headers:
+                value = self._claim_value(claims, entry["path"])
+                if value is None:
+                    raise ProviderError(
+                        "injection-claim-missing",
+                        f"claim {'.'.join(entry['path'])} not present in access token for header {entry['header']}",
+                        502,
+                    )
+                headers[entry["header"].lower()] = str(value)
+                strip.append(entry["header"].lower())
+        return headers, rfc3339(exp), strip
+
+    def _jwt_claims(self, token):
+        parts = token.split(".")
+        if len(parts) < 2:
+            raise ProviderError("access-token-invalid", "Codex access token is not a JWT", 502)
+        segment = parts[1]
+        padding = "=" * ((4 - len(segment) % 4) % 4)
+        try:
+            payload = json.loads(base64.urlsafe_b64decode((segment + padding).encode("ascii")).decode("utf-8"))
+        except Exception as error:
+            raise ProviderError("access-token-invalid", "Codex access token payload is invalid", 502) from error
+        if not isinstance(payload, dict):
+            raise ProviderError("access-token-invalid", "Codex access token payload is not an object", 502)
+        return payload
+
+    def _claim_value(self, claims, path):
+        current = claims
+        for segment in path:
+            if not isinstance(current, dict) or segment not in current:
+                return None
+            current = current[segment]
+        if isinstance(current, (dict, list)):
+            return None
+        return current
 
     def files(self, agent_id, audit, request_id):
         with self.lock:

--- a/docs/phase2-codex-gate-plan.md
+++ b/docs/phase2-codex-gate-plan.md
@@ -49,9 +49,11 @@ shape entirely (mediate only redirectable/API-key providers).
   key) selects ChatGPT-plan mode. Codex decodes the access-token JWT locally
   (the broker's `codex-oauth` provider does the same to read `exp`).
 - Base URL redirection points: `chatgpt_base_url` in `~/.codex/config.toml`
-  is the primary lever for the plan-auth backend; `model_providers.*.base_url`
-  covers the API-style path. **Both must be set to the egressd route** and the
-  exact key names/coverage verified empirically — this is part of the gate.
+  is the primary lever for the plan-auth backend. **Phase 2 gates
+  `chatgpt_base_url` plan-auth traffic by default.** `model_providers.*.base_url`
+  covers the API-style path and is tested only when
+  `PHASE2_MODEL_PROVIDER_BASE` is set; its coverage is recorded as a separate
+  finding rather than assumed. Verify the exact key names/coverage empirically.
 - Plan-auth requests may carry **auxiliary headers derived from token
   claims** (notably an account-id header). See "Claim-derived headers" below.
 
@@ -242,11 +244,12 @@ Evidence-capture hygiene:
 ### Task 6 — Real refresh proof
 
 You cannot mint short-lived tokens against real `auth.openai.com`, and you do
-not need to: set `refresh-margin-seconds` in the harness broker config
-**larger than the current access token's remaining lifetime**. Then the first
-injection forces the real refresh flow (real refresh token, real token URL)
-before vending. Confirm from broker audit that an `injection.refresh` entry
-appears and the turn still succeeds.
+not need to: the harness **computes** `refresh-margin-seconds` from the source
+token's `exp` (remaining lifetime + a day), so the margin always exceeds the
+token's remaining life and the first injection forces the real refresh flow
+(real refresh token, real token URL) before vending — regardless of how much
+life the token has left. Confirm from broker audit that an `injection.refresh`
+entry appears (`summary.txt: refresh_seen`) and the turn still succeeds.
 
 The mechanical cache-expiry / in-flight-stream behavior is already pinned
 deterministically by egressd and broker tests with fakes — this task only

--- a/docs/phase2-codex-gate.md
+++ b/docs/phase2-codex-gate.md
@@ -1,0 +1,100 @@
+# Phase 2 Gate — Codex Plan-Auth Mediation: Findings & Decision
+
+Status: **TEMPLATE — fill from a `make phase2-codex-gate` run**
+Parent: `docs/mediated-egress-plan.md` (Phase 2), spec:
+`docs/phase2-codex-gate-plan.md`
+
+This document is the deliverable of Phase 2. It records the empirical answer to:
+
+> Can real Codex ChatGPT-plan auth be fully mediated through egressd via
+> base-URL redirection, with the agent container holding **no** real
+> credential?
+
+Fill each section from `.phase2-out/evidence/` after running the harness. Do
+not paste raw tokens — reference sanitized evidence only.
+
+## How to run
+
+```
+make phase2-codex-gate
+# variables:
+#   PHASE2_AUTH_SOURCE  path to the real auth.json (default .broker/codex/auth.json)
+#   PHASE2_SCHEME       https (default, egressd serves TLS) | http
+#   PHASE2_UPSTREAM     upstream host (default chatgpt.com)
+#   PHASE2_CODEX_CMD    the turn to run (default: codex exec "print pong")
+```
+
+Evidence lands in `.phase2-out/evidence/`:
+`summary.txt`, `codex-stdout.txt`, `codex-stderr.txt`, `egressd.log`,
+`broker-audit.jsonl`, `injection-audit.jsonl`.
+
+## The three possible outcomes (decision guide)
+
+Run `PHASE2_SCHEME=https` first (Codex almost certainly requires https). Then:
+
+| Observation | Meaning | Decision |
+|---|---|---|
+| Turn completes over `https` with the per-agent CA | Codex requires https but does **not** pin certs; TLS re-origination works | **GO** |
+| Turn fails over `https` with a cert/pinning error, even with the CA trusted | Codex **pins certs** on the plan-auth host | **NO-GO** for plan-auth (keep on file bundles); mediate redirectable/API-key providers only |
+| Turn fails because Codex called a host **not** covered by `chatgpt_base_url` | fixed/hardcoded endpoint outside the base URL | **NO-GO or partial** — record the host; may need multi-route or transparent mode (Phase 6) |
+| Turn completes over `http` (if you also test `PHASE2_SCHEME=http`) | base URL fully covers traffic, no TLS requirement | **GO** (simplest) |
+
+A NO-GO is a **successful phase outcome** — a documented answer — not a
+failure of the work.
+
+## Findings (fill in)
+
+### Required hosts
+_The set of hosts Codex needed, and which base-URL key routed each. From
+`egressd.log` (routed) and `codex-stderr.txt` (connect failures to
+un-routed hosts on the internal network)._
+
+- `chatgpt.com` — routed via `chatgpt_base_url`? (yes/no)
+- `auth.openai.com` — needed for refresh? routed how?
+- others: …
+
+### Minimal placeholder shape
+_What `auth.json` shape Codex accepted at startup with no real credential.
+The harness uses a placeholder JWT (`header.payload.NVT-PLACEHOLDER-NOT-A-KEY`)
+with far-future `exp` and a placeholder account claim. Record whether that was
+sufficient, or what minimum Codex actually needs._
+
+### Claim-derived headers
+_Did the upstream require headers beyond `Authorization`? The harness injects
+`chatgpt-account-id` from the real token's `https://api.openai.com/auth →
+chatgpt_account_id` claim and strips the placeholder. Record whether it was
+required, and the exact header name / claim path if different._
+
+### TLS / cert pinning
+_Did localhost TLS re-origination work with the per-agent CA, or did Codex
+reject the egressd-terminated connection? Distinguish "requires https"
+(CA works) from "pins certs" (CA cannot help)._
+
+### Bypass attempts
+_Did any Codex traffic try to reach a fixed host directly? On the internal
+network these appear as connect failures in `codex-stderr.txt`. List them._
+
+### Refresh
+_Was the real refresh flow exercised? `summary.txt: refresh_seen` and
+`injection.refresh` entries in `broker-audit.jsonl`. Did the turn still
+succeed?_
+
+### Non-possession
+_The harness fails if any real token fragment appears in the agent's
+`auth.json` or in captured evidence. Confirm "no credential leakage detected"
+in the run output._
+
+## Decision
+
+**GO / NO-GO / PARTIAL:** _____
+
+**Rationale:** _____
+
+**Consequence for Phase 3:**
+- GO → wire operator/compose for mediated `codex-oauth` (Phase 3 as planned).
+- NO-GO (cert pinning) → keep Codex plan-auth on `file-bundle`; ship mediation
+  for redirectable/API-key providers; revisit with transparent mode (Phase 6).
+- PARTIAL (extra hosts) → enumerate hosts; decide multi-route now vs. Phase 6.
+
+## Evidence references
+_Link the sanitized files under `.phase2-out/evidence/` that back each claim._

--- a/docs/phase2-codex-gate.md
+++ b/docs/phase2-codex-gate.md
@@ -18,10 +18,12 @@ not paste raw tokens — reference sanitized evidence only.
 ```
 make phase2-codex-gate
 # variables:
-#   PHASE2_AUTH_SOURCE  path to the real auth.json (default .broker/codex/auth.json)
-#   PHASE2_SCHEME       https (default, egressd serves TLS) | http
-#   PHASE2_UPSTREAM     upstream host (default chatgpt.com)
-#   PHASE2_CODEX_CMD    the turn to run (default: codex exec "print pong")
+#   PHASE2_AUTH_SOURCE           real auth.json (default .broker/codex/auth.json)
+#   PHASE2_SCHEME                https (default, egressd serves TLS) | http
+#   PHASE2_UPSTREAM              upstream host (default chatgpt.com)
+#   PHASE2_CODEX_CMD             the turn (default: codex exec "print pong")
+#   PHASE2_MODEL_PROVIDER_BASE   optional: also set model_providers.openai.base_url
+#                                to test the API-style path (recorded as a finding)
 ```
 
 Evidence lands in `.phase2-out/evidence/`:
@@ -75,14 +77,22 @@ _Did any Codex traffic try to reach a fixed host directly? On the internal
 network these appear as connect failures in `codex-stderr.txt`. List them._
 
 ### Refresh
-_Was the real refresh flow exercised? `summary.txt: refresh_seen` and
-`injection.refresh` entries in `broker-audit.jsonl`. Did the turn still
-succeed?_
+_Refresh is **forced**: the harness computes the margin from the source token's
+`exp`, so the first injection always triggers the real refresh flow. Confirm
+`summary.txt: refresh_seen` ≥ 1 and `injection.refresh` entries in
+`broker-audit.jsonl`, and that the turn still succeeded._
+
+### model_providers coverage (optional)
+_Only if run with `PHASE2_MODEL_PROVIDER_BASE`. Record whether the API-style
+path also routed through egressd or hit a fixed host. Default runs gate
+`chatgpt_base_url` plan-auth traffic only._
 
 ### Non-possession
-_The harness fails if any real token fragment appears in the agent's
-`auth.json` or in captured evidence. Confirm "no credential leakage detected"
-in the run output._
+_The harness fails loudly if any real token value **or fragment** appears in:
+the agent's `auth.json`, the agent container's env, its process args
+(sampled during the run), its codex home, or any captured evidence
+(egressd log, broker audit, codex stdio). Confirm "no credential leakage
+detected (agent fs/env/args + evidence)" in the run output._
 
 ## Decision
 

--- a/egressd/Dockerfile
+++ b/egressd/Dockerfile
@@ -1,0 +1,11 @@
+# Build the egressd credential-injecting egress proxy.
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY egressd/go.mod ./
+RUN go mod download
+COPY egressd/ ./
+RUN CGO_ENABLED=0 go build -o /out/egressd ./cmd/egressd
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/egressd /usr/local/bin/egressd
+ENTRYPOINT ["/usr/local/bin/egressd"]

--- a/egressd/cmd/egressd/main.go
+++ b/egressd/cmd/egressd/main.go
@@ -43,10 +43,18 @@ func run() error {
 	for _, route := range config.Routes {
 		proxy := &egress.Proxy{Route: route, Broker: broker, Transport: transport}
 		server := &http.Server{Addr: route.Listen, Handler: proxy}
-		log.Printf("egressd: routing %s -> %s (capability %s)", route.Listen, route.Upstream, route.Capability)
-		go func() {
+		scheme := "http"
+		if route.TLSEnabled() {
+			scheme = "https"
+		}
+		log.Printf("egressd: routing %s (%s) -> %s (capability %s)", route.Listen, scheme, route.Upstream, route.Capability)
+		go func(route egress.Route) {
+			if route.TLSEnabled() {
+				errors <- server.ListenAndServeTLS(route.ListenTLSCert, route.ListenTLSKey)
+				return
+			}
 			errors <- server.ListenAndServe()
-		}()
+		}(route)
 	}
 	return <-errors
 }

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -32,6 +32,19 @@ type Route struct {
 	Upstream string `json:"upstream"`
 	// AllowInsecureUpstream permits a plain-HTTP upstream. Test/dev only.
 	AllowInsecureUpstream bool `json:"allow_insecure_upstream"`
+	// ListenTLSCert and ListenTLSKey optionally make the agent-facing
+	// listener serve HTTPS. Needed when the client refuses a plaintext base
+	// URL; the agent must trust the serving cert's CA. This is the same
+	// agent-facing TLS termination Phase 4 generalizes — used here only so
+	// the Phase 2 gate can distinguish "client requires https" from "client
+	// pins certs". Both must be set together or neither.
+	ListenTLSCert string `json:"listen_tls_cert"`
+	ListenTLSKey  string `json:"listen_tls_key"`
+}
+
+// TLSEnabled reports whether the agent-facing listener serves HTTPS.
+func (r Route) TLSEnabled() bool {
+	return r.ListenTLSCert != "" && r.ListenTLSKey != ""
 }
 
 // Config is the egressd configuration file shape.
@@ -92,6 +105,9 @@ func (c *Config) Validate() error {
 		}
 		if err := validateUpstream(route.Upstream); err != nil {
 			return fmt.Errorf("routes[%d].upstream: %w", index, err)
+		}
+		if (route.ListenTLSCert == "") != (route.ListenTLSKey == "") {
+			return fmt.Errorf("routes[%d]: listen_tls_cert and listen_tls_key must be set together", index)
 		}
 	}
 	return nil

--- a/egressd/internal/egress/proxy_test.go
+++ b/egressd/internal/egress/proxy_test.go
@@ -463,6 +463,37 @@ func TestConfigRejectsMalformedUpstream(t *testing.T) {
 	}
 }
 
+// TestConfigTLSListenerRequiresBothFiles pins that the agent-facing TLS
+// listener needs cert and key together, never one alone.
+func TestConfigTLSListenerRequiresBothFiles(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			BrokerURL:           "https://broker:7347",
+			Routes:              []Route{{Listen: "0.0.0.0:8471", Capability: "codex-main", Upstream: "chatgpt.com"}},
+			AllowInsecureBroker: false,
+		}
+	}
+	certOnly := base()
+	certOnly.Routes[0].ListenTLSCert = "/tls/cert.pem"
+	if err := certOnly.Validate(); err == nil {
+		t.Fatal("cert without key must be rejected")
+	}
+	keyOnly := base()
+	keyOnly.Routes[0].ListenTLSKey = "/tls/key.pem"
+	if err := keyOnly.Validate(); err == nil {
+		t.Fatal("key without cert must be rejected")
+	}
+	both := base()
+	both.Routes[0].ListenTLSCert = "/tls/cert.pem"
+	both.Routes[0].ListenTLSKey = "/tls/key.pem"
+	if err := both.Validate(); err != nil {
+		t.Fatalf("cert+key should validate: %v", err)
+	}
+	if !both.Routes[0].TLSEnabled() {
+		t.Fatal("TLSEnabled should report true when both set")
+	}
+}
+
 // TestConfigRefusesPlaintextBrokerByDefault pins the transport rule from the
 // plan: the egressd-broker leg carries real credentials and must be TLS
 // unless local dev explicitly opts out.

--- a/examples/mediated-codex/README.md
+++ b/examples/mediated-codex/README.md
@@ -1,0 +1,103 @@
+# Mediated Codex (codex-oauth via egressd)
+
+Non-secret example configs for running Codex ChatGPT-plan auth in **mediated
+mode**: the broker owns the real `auth.json`, egressd injects the access token
+(and any claim-derived header) at the network edge, and the agent container
+holds no real credential. See `docs/mediated-egress-plan.md` and
+`protocol/injection.md`.
+
+All tokens/hashes below are placeholders — generate your own.
+
+## Broker provider (`.broker/broker.yaml`)
+
+```yaml
+providers:
+  - name: codex-main
+    plugin: codex-oauth
+    config:
+      auth-file: /state/codex/auth.json
+      refresh-margin-seconds: 3600
+      # Hosts egressd may inject this credential for:
+      injection-hosts:
+        - chatgpt.com
+        - auth.openai.com
+      # Backend requires an account-id header derived from the token claims.
+      # The claim key is a URL (contains dots) → list form, exact segments.
+      injection-claim-headers:
+        - header: chatgpt-account-id
+          claim-path:
+            - https://api.openai.com/auth
+            - chatgpt_account_id
+```
+
+## Identities (`.broker/agents.yaml`)
+
+An agent with a `header-inject` grant and its paired egress identity. The
+egress identity is the only one that can fetch the credential; the agent
+identity cannot.
+
+```yaml
+agents:
+  - id: my-agent
+    token-sha256: sha256:<hash of the agent broker token>
+    role: agent
+    grants:
+      - provider: codex-main
+        materialization: header-inject
+  - id: my-agent-egress
+    token-sha256: sha256:<hash of the egress broker token>
+    role: egress
+    paired-agent: my-agent
+```
+
+## egressd (`egressd.json`)
+
+```json
+{
+  "broker_url": "https://broker:7347",
+  "broker_ca_file": "/tls/broker-ca.pem",
+  "routes": [
+    {
+      "listen": "127.0.0.1:8471",
+      "capability": "codex-main",
+      "upstream": "chatgpt.com",
+      "listen_tls_cert": "/tls/egressd-cert.pem",
+      "listen_tls_key": "/tls/egressd-key.pem"
+    }
+  ]
+}
+```
+
+- `broker_url` is **https** in production; `broker_ca_file` pins its CA. The
+  egressd→broker leg is the one path carrying real credentials.
+- `listen_tls_*` make the agent-facing listener serve HTTPS; the agent must
+  trust the serving cert's CA. Omit them only if the client accepts a
+  plaintext base URL.
+
+## Agent-side Codex config (`~/.codex/config.toml`)
+
+```toml
+check_for_update_on_startup = false
+chatgpt_base_url = "https://127.0.0.1:8471"
+```
+
+## Agent-side placeholder `~/.codex/auth.json`
+
+The agent gets a zero-entropy placeholder — never the real file. It satisfies
+Codex's startup parser; the real token is injected by egressd and the
+placeholder is stripped before reaching the upstream.
+
+```json
+{
+  "tokens": {
+    "access_token": "<placeholder JWT: header.payload.NVT-PLACEHOLDER-NOT-A-KEY>",
+    "refresh_token": "nvt-broker-stub",
+    "id_token": "NVT-PLACEHOLDER-NOT-A-KEY"
+  },
+  "last_refresh": "2020-01-01T00:00:00Z"
+}
+```
+
+The placeholder JWT payload carries a far-future `exp` (so Codex does not try
+to refresh locally) and a placeholder `chatgpt_account_id` (egressd strips it;
+the broker injects the real one from the real token's claims).

--- a/phase2/compose.phase2.yaml
+++ b/phase2/compose.phase2.yaml
@@ -1,0 +1,62 @@
+# Phase 2 Codex plan-auth mediation gate — isolation topology.
+#
+# NOT a production compose file. See docs/phase2-codex-gate-plan.md.
+#
+# Networks:
+#   phase2-agent   internal: true — no outbound internet. Agent + egressd.
+#                  The agent's ONLY reachable peer is egressd.
+#   phase2-trusted normal bridge (outbound). egressd + broker. Broker needs
+#                  outbound to auth.openai.com for OAuth refresh; egressd needs
+#                  outbound to the upstream (chatgpt.com).
+#
+# A Codex attempt to reach any fixed host directly fails at connect on the
+# internal network — exactly the signal the gate needs.
+services:
+  broker:
+    image: nvt-broker:latest
+    env_file:
+      - ${PHASE2_STATE}/env
+    environment:
+      NVT_BROKER_CONFIG: /state/broker.yaml
+      NVT_BROKER_AGENTS_CONFIG: /state/agents.yaml
+      NVT_BROKER_AUDIT_LOG: /state/audit.jsonl
+      NVT_BROKER_BIND: 0.0.0.0:7347
+    volumes:
+      - ${PHASE2_STATE}:/state
+    networks:
+      - phase2-trusted
+    restart: "no"
+
+  egressd:
+    image: nvt-egressd:latest
+    environment:
+      NVT_EGRESSD_CONFIG: /config/egressd.json
+      NVT_BROKER_TOKEN: ${PHASE2_EGRESS_TOKEN}
+    volumes:
+      - ${PHASE2_STATE}/egressd.json:/config/egressd.json:ro
+      - ${PHASE2_STATE}/tls:/tls:ro
+    networks:
+      - phase2-agent
+      - phase2-trusted
+    depends_on:
+      - broker
+    restart: "no"
+
+  agent:
+    image: nvt-agent-runtime:latest
+    entrypoint: ["sleep", "infinity"]
+    environment:
+      CODEX_HOME: /root/.codex
+    volumes:
+      - ${PHASE2_STATE}/agent-codex:/root/.codex
+      - ${PHASE2_STATE}/tls/agent-ca.pem:/usr/local/share/ca-certificates/nvt-egressd-ca.crt:ro
+    networks:
+      - phase2-agent
+    depends_on:
+      - egressd
+    restart: "no"
+
+networks:
+  phase2-agent:
+    internal: true
+  phase2-trusted: {}

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -359,6 +359,28 @@ prefix. Grants must carry `materialization: header-inject` (see
 `protocol/injection.md` for the identity role/pairing model and endpoint
 shapes).
 
+Some backends (Codex ChatGPT-plan) require an auxiliary header derived from
+the access-token claims (e.g. an account id). `codex-oauth` computes these
+from the **real** token via `injection-claim-headers`; the derived headers are
+returned alongside `authorization` and added to `strip_request_headers` so the
+agent's placeholder versions never reach the upstream. `claim-path` is a dotted
+string or a YAML list of exact segments (use the list form when a claim key
+itself contains dots, as the OpenAI account claim key does):
+
+```yaml
+providers:
+  - name: codex-main
+    plugin: codex-oauth
+    config:
+      injection-hosts:
+        - chatgpt.com
+      injection-claim-headers:
+        - header: chatgpt-account-id
+          claim-path:
+            - https://api.openai.com/auth
+            - chatgpt_account_id
+```
+
 ## Headers
 
 Allowed caller request headers:

--- a/scripts/phase2-codex-gate.sh
+++ b/scripts/phase2-codex-gate.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Phase 2 Codex plan-auth mediation gate (docs/phase2-codex-gate-plan.md).
+#
+# Brings up broker + egressd + an isolated agent container, runs a real Codex
+# turn through egressd with the broker owning the real auth.json, and captures
+# evidence: which hosts Codex required, whether it tried to bypass egressd,
+# whether TLS re-origination worked, and whether the agent container held any
+# real credential.
+#
+# This produces the EVIDENCE. A human fills the go/no-go decision into
+# docs/phase2-codex-gate.md from it. It never writes real credentials into the
+# repo, and fails loudly if any token-shaped string lands in the output dir.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- inputs -----------------------------------------------------------------
+# Source of the real Codex auth.json the broker will own. Defaults to the
+# broker-owned copy, then the host Codex home.
+AUTH_SOURCE="${PHASE2_AUTH_SOURCE:-}"
+if [ -z "$AUTH_SOURCE" ]; then
+  if [ -f "$REPO_ROOT/.broker/codex/auth.json" ]; then
+    AUTH_SOURCE="$REPO_ROOT/.broker/codex/auth.json"
+  else
+    AUTH_SOURCE="$HOME/.codex/auth.json"
+  fi
+fi
+UPSTREAM_HOST="${PHASE2_UPSTREAM:-chatgpt.com}"
+BASE_SCHEME="${PHASE2_SCHEME:-https}"   # https (default, TLS listen) | http
+CODEX_CMD="${PHASE2_CODEX_CMD:-codex exec \"print pong\"}"
+OUT_DIR="$REPO_ROOT/.phase2-out"
+STATE_DIR="$OUT_DIR/state"
+PROJECT="nvt-phase2"
+COMPOSE="docker compose -p $PROJECT -f $REPO_ROOT/phase2/compose.phase2.yaml"
+
+log() { printf '\033[1;34m[phase2]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[phase2] FAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -f "$AUTH_SOURCE" ] || fail "Codex auth.json not found at $AUTH_SOURCE (set PHASE2_AUTH_SOURCE)"
+
+cleanup() {
+  log "tearing down"
+  $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# --- fresh state ------------------------------------------------------------
+rm -rf "$OUT_DIR"
+mkdir -p "$STATE_DIR/codex" "$STATE_DIR/agent-codex" "$STATE_DIR/tls" "$OUT_DIR/evidence"
+cp "$AUTH_SOURCE" "$STATE_DIR/codex/auth.json"
+chmod 600 "$STATE_DIR/codex/auth.json"
+: > "$STATE_DIR/env"
+
+AGENT_TOKEN="$(openssl rand -hex 24)"
+EGRESS_TOKEN="$(openssl rand -hex 24)"
+agent_hash="$(printf '%s' "$AGENT_TOKEN" | openssl dgst -sha256 | awk '{print $2}')"
+egress_hash="$(printf '%s' "$EGRESS_TOKEN" | openssl dgst -sha256 | awk '{print $2}')"
+
+# --- broker config (harness-local; never touches .broker/) ------------------
+cat > "$STATE_DIR/broker.yaml" <<YAML
+providers:
+  - name: codex-main
+    plugin: codex-oauth
+    config:
+      auth-file: /state/codex/auth.json
+      refresh-margin-seconds: 3600
+      injection-hosts:
+        - ${UPSTREAM_HOST}
+        - auth.openai.com
+      injection-claim-headers:
+        - header: chatgpt-account-id
+          claim-path:
+            - https://api.openai.com/auth
+            - chatgpt_account_id
+YAML
+
+cat > "$STATE_DIR/agents.yaml" <<YAML
+agents:
+  - id: codex-probe
+    token-sha256: sha256:${agent_hash}
+    role: agent
+    grants:
+      - provider: codex-main
+        materialization: header-inject
+  - id: codex-probe-egress
+    token-sha256: sha256:${egress_hash}
+    role: egress
+    paired-agent: codex-probe
+YAML
+
+# --- egressd TLS (agent-facing) + config ------------------------------------
+# Codex very likely requires an https base URL. A per-agent CA lets us
+# distinguish "requires https" (CA works) from "pins certs" (CA cannot help).
+LISTEN_TLS_LINES=""
+if [ "$BASE_SCHEME" = "https" ]; then
+  log "generating per-agent CA and egressd server cert (SAN egressd)"
+  openssl req -x509 -newkey rsa:2048 -nodes -days 7 \
+    -keyout "$STATE_DIR/tls/ca-key.pem" -out "$STATE_DIR/tls/agent-ca.pem" \
+    -subj "/CN=nvt-egressd-ca" >/dev/null 2>&1
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "$STATE_DIR/tls/key.pem" -out "$STATE_DIR/tls/csr.pem" \
+    -subj "/CN=egressd" >/dev/null 2>&1
+  openssl x509 -req -in "$STATE_DIR/tls/csr.pem" -days 7 \
+    -CA "$STATE_DIR/tls/agent-ca.pem" -CAkey "$STATE_DIR/tls/ca-key.pem" -CAcreateserial \
+    -out "$STATE_DIR/tls/cert.pem" \
+    -extfile <(printf 'subjectAltName=DNS:egressd') >/dev/null 2>&1
+  LISTEN_TLS_LINES=$'      "listen_tls_cert": "/tls/cert.pem",\n      "listen_tls_key": "/tls/key.pem",'
+else
+  # http mode still needs the mount target to exist for compose.
+  : > "$STATE_DIR/tls/agent-ca.pem"
+fi
+
+cat > "$STATE_DIR/egressd.json" <<JSON
+{
+  "broker_url": "http://broker:7347",
+  "allow_insecure_broker": true,
+  "routes": [
+    {
+      "listen": "0.0.0.0:8471",
+      "capability": "codex-main",
+      "upstream": "${UPSTREAM_HOST}",
+${LISTEN_TLS_LINES}
+      "allow_insecure_upstream": false
+    }
+  ]
+}
+JSON
+# allow_insecure_broker is acceptable ONLY because broker and egressd sit on an
+# isolated trusted network the agent cannot reach. Production uses broker TLS.
+
+# --- agent-side Codex config + placeholder auth (NO real credential) --------
+BASE_URL="${BASE_SCHEME}://egressd:8471"
+cat > "$STATE_DIR/agent-codex/config.toml" <<TOML
+check_for_update_on_startup = false
+chatgpt_base_url = "${BASE_URL}"
+TOML
+
+python3 - "$STATE_DIR/agent-codex/auth.json" <<'PY'
+import base64, json, sys, time
+def seg(obj): return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+# Zero-entropy placeholder JWT: valid shape, far-future exp, placeholder claims.
+header = seg({"alg": "none", "typ": "JWT"})
+payload = seg({
+    "exp": int(time.time()) + 10 * 365 * 24 * 3600,
+    "https://api.openai.com/auth": {"chatgpt_account_id": "NVT-PLACEHOLDER-ACCOUNT"},
+})
+placeholder_jwt = f"{header}.{payload}.NVT-PLACEHOLDER-NOT-A-KEY"
+json.dump({
+    "tokens": {
+        "access_token": placeholder_jwt,
+        "refresh_token": "nvt-broker-stub",
+        "id_token": "NVT-PLACEHOLDER-NOT-A-KEY",
+    },
+    "last_refresh": "2020-01-01T00:00:00Z",
+}, open(sys.argv[1], "w"), indent=2)
+PY
+chmod 600 "$STATE_DIR/agent-codex/auth.json"
+
+# --- bring up ---------------------------------------------------------------
+export PHASE2_STATE="$STATE_DIR"
+export PHASE2_EGRESS_TOKEN="$EGRESS_TOKEN"
+
+log "starting broker + egressd + agent"
+$COMPOSE up -d --no-build broker egressd agent
+
+log "waiting for broker health"
+for _ in $(seq 1 30); do
+  if $COMPOSE exec -T egressd true 2>/dev/null && \
+     $COMPOSE exec -T broker sh -c 'exit 0' 2>/dev/null; then break; fi
+  sleep 1
+done
+
+# --- run the real Codex turn ------------------------------------------------
+log "running Codex turn through egressd: $CODEX_CMD"
+set +e
+$COMPOSE exec -T agent bash -lc '
+  set -e
+  if [ -s /usr/local/share/ca-certificates/nvt-egressd-ca.crt ]; then
+    update-ca-certificates >/dev/null 2>&1 || true
+    export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/nvt-egressd-ca.crt
+  fi
+  export CODEX_HOME=/root/.codex
+  '"$CODEX_CMD"'
+' > "$OUT_DIR/evidence/codex-stdout.txt" 2> "$OUT_DIR/evidence/codex-stderr.txt"
+CODEX_RC=$?
+set -e
+log "Codex exit code: $CODEX_RC"
+
+# --- capture evidence -------------------------------------------------------
+$COMPOSE logs egressd > "$OUT_DIR/evidence/egressd.log" 2>&1 || true
+cp "$STATE_DIR/audit.jsonl" "$OUT_DIR/evidence/broker-audit.jsonl" 2>/dev/null || true
+# Which injection hosts/paths the broker was asked for:
+grep -h 'injection' "$OUT_DIR/evidence/broker-audit.jsonl" 2>/dev/null \
+  > "$OUT_DIR/evidence/injection-audit.jsonl" || true
+
+# --- leak scan (fail loud if any real credential escaped) -------------------
+log "scanning for credential leakage"
+python3 - "$AUTH_SOURCE" "$STATE_DIR/agent-codex/auth.json" "$OUT_DIR/evidence" <<'PY'
+import json, os, sys
+real = json.load(open(sys.argv[1]))["tokens"]
+needles = [v for v in (real.get("access_token"), real.get("refresh_token"), real.get("id_token"))
+           if isinstance(v, str) and len(v) > 12]
+# 1) agent container auth.json must be placeholder only.
+agent = json.load(open(sys.argv[2]))["tokens"]
+for k, v in agent.items():
+    for n in needles:
+        if isinstance(v, str) and n in v:
+            print(f"LEAK: real {k} present in agent auth.json"); sys.exit(2)
+# 2) no real token fragment anywhere in captured evidence.
+for root, _, files in os.walk(sys.argv[3]):
+    for name in files:
+        path = os.path.join(root, name)
+        try:
+            data = open(path, "r", errors="ignore").read()
+        except Exception:
+            continue
+        for n in needles:
+            if n in data:
+                print(f"LEAK: real token fragment in evidence/{name}"); sys.exit(2)
+print("no credential leakage detected")
+PY
+
+# --- verdict signal (evidence, not decision) --------------------------------
+log "evidence written to $OUT_DIR/evidence/"
+{
+  echo "codex_exit_code=$CODEX_RC"
+  echo "base_url=$BASE_URL"
+  echo "upstream=$UPSTREAM_HOST"
+  echo "tls_listen=$([ "$BASE_SCHEME" = https ] && echo yes || echo no)"
+  echo "injection_requests=$(wc -l < "$OUT_DIR/evidence/injection-audit.jsonl" 2>/dev/null || echo 0)"
+  echo "refresh_seen=$(grep -c 'injection.refresh' "$OUT_DIR/evidence/broker-audit.jsonl" 2>/dev/null || echo 0)"
+} | tee "$OUT_DIR/evidence/summary.txt"
+
+if [ "$CODEX_RC" -eq 0 ]; then
+  log "Codex turn completed THROUGH egressd — likely GO (confirm host list in evidence)."
+else
+  log "Codex turn did not complete — inspect codex-stderr.txt and egressd.log for the failing host / TLS behavior."
+fi
+log "Fill the decision into docs/phase2-codex-gate.md using .phase2-out/evidence/."

--- a/scripts/phase2-codex-gate.sh
+++ b/scripts/phase2-codex-gate.sh
@@ -58,13 +58,30 @@ agent_hash="$(printf '%s' "$AGENT_TOKEN" | openssl dgst -sha256 | awk '{print $2
 egress_hash="$(printf '%s' "$EGRESS_TOKEN" | openssl dgst -sha256 | awk '{print $2}')"
 
 # --- broker config (harness-local; never touches .broker/) ------------------
+# Force real refresh: set the margin beyond the token's remaining lifetime so
+# the first injection always exercises the real refresh flow, regardless of how
+# much life the source token has left. Fallback is 10y if exp can't be read.
+REFRESH_MARGIN="$(python3 - "$AUTH_SOURCE" <<'PY'
+import base64, json, sys, time
+try:
+    token = json.load(open(sys.argv[1]))["tokens"]["access_token"]
+    seg = token.split(".")[1]
+    seg += "=" * ((4 - len(seg) % 4) % 4)
+    exp = int(json.loads(base64.urlsafe_b64decode(seg.encode()))["exp"])
+    print(max(exp - int(time.time()), 0) + 86400)
+except Exception:
+    print(315360000)
+PY
+)"
+log "refresh-margin-seconds=$REFRESH_MARGIN (forces real refresh on first injection)"
+
 cat > "$STATE_DIR/broker.yaml" <<YAML
 providers:
   - name: codex-main
     plugin: codex-oauth
     config:
       auth-file: /state/codex/auth.json
-      refresh-margin-seconds: 3600
+      refresh-margin-seconds: ${REFRESH_MARGIN}
       injection-hosts:
         - ${UPSTREAM_HOST}
         - auth.openai.com
@@ -135,6 +152,17 @@ cat > "$STATE_DIR/agent-codex/config.toml" <<TOML
 check_for_update_on_startup = false
 chatgpt_base_url = "${BASE_URL}"
 TOML
+# Phase 2 gates chatgpt_base_url plan-auth traffic by default. To also exercise
+# the API-style path, set PHASE2_MODEL_PROVIDER_BASE (e.g. the egressd route
+# with a /v1 suffix) — recorded as a separate finding in the gate doc.
+if [ -n "${PHASE2_MODEL_PROVIDER_BASE:-}" ]; then
+  cat >> "$STATE_DIR/agent-codex/config.toml" <<TOML
+
+[model_providers.openai]
+base_url = "${PHASE2_MODEL_PROVIDER_BASE}"
+TOML
+  log "model_providers.openai.base_url=${PHASE2_MODEL_PROVIDER_BASE}"
+fi
 
 python3 - "$STATE_DIR/agent-codex/auth.json" <<'PY'
 import base64, json, sys, time
@@ -173,6 +201,17 @@ done
 
 # --- run the real Codex turn ------------------------------------------------
 log "running Codex turn through egressd: $CODEX_CMD"
+# Sample process args in the agent container during the run so a token that
+# ever appears on a command line is captured (it must not — egressd injects it).
+touch "$OUT_DIR/.running"
+(
+  while [ -f "$OUT_DIR/.running" ]; do
+    $COMPOSE exec -T agent ps -eo args 2>/dev/null || true
+    sleep 0.5
+  done
+) > "$OUT_DIR/evidence/agent-ps-during.txt" 2>&1 &
+PS_SAMPLER=$!
+
 set +e
 $COMPOSE exec -T agent bash -lc '
   set -e
@@ -186,7 +225,19 @@ $COMPOSE exec -T agent bash -lc '
 ' > "$OUT_DIR/evidence/codex-stdout.txt" 2> "$OUT_DIR/evidence/codex-stderr.txt"
 CODEX_RC=$?
 set -e
+rm -f "$OUT_DIR/.running"
+kill "$PS_SAMPLER" 2>/dev/null || true
+wait "$PS_SAMPLER" 2>/dev/null || true
 log "Codex exit code: $CODEX_RC"
+
+# Post-run non-possession snapshot of the agent container: env, process table,
+# and the entire codex home. Scanned below for real-token fragments.
+$COMPOSE exec -T agent bash -lc '
+  echo "=== env ==="; env
+  echo "=== ps axww ==="; ps axww 2>/dev/null || true
+  echo "=== codex home files ==="; find /root/.codex -type f -print -exec cat {} \; 2>/dev/null || true
+  echo "=== /root listing ==="; ls -la /root 2>/dev/null || true
+' > "$OUT_DIR/evidence/agent-container-scan.txt" 2>&1 || true
 
 # --- capture evidence -------------------------------------------------------
 $COMPOSE logs egressd > "$OUT_DIR/evidence/egressd.log" 2>&1 || true
@@ -196,30 +247,53 @@ grep -h 'injection' "$OUT_DIR/evidence/broker-audit.jsonl" 2>/dev/null \
   > "$OUT_DIR/evidence/injection-audit.jsonl" || true
 
 # --- leak scan (fail loud if any real credential escaped) -------------------
-log "scanning for credential leakage"
+# Scans for full tokens AND stable fragments (prefix, middle, suffix), across
+# the agent auth.json plus all captured evidence — which now includes the
+# agent container's env, process args, and codex home.
+log "scanning for credential leakage (full values + fragments)"
 python3 - "$AUTH_SOURCE" "$STATE_DIR/agent-codex/auth.json" "$OUT_DIR/evidence" <<'PY'
 import json, os, sys
+
 real = json.load(open(sys.argv[1]))["tokens"]
-needles = [v for v in (real.get("access_token"), real.get("refresh_token"), real.get("id_token"))
-           if isinstance(v, str) and len(v) > 12]
-# 1) agent container auth.json must be placeholder only.
-agent = json.load(open(sys.argv[2]))["tokens"]
-for k, v in agent.items():
+
+def fragments(value):
+    if not isinstance(value, str) or len(value) < 20:
+        return set()
+    out = {value, value[:24], value[-24:]}
+    if len(value) > 64:
+        mid = len(value) // 2
+        out.add(value[mid:mid + 24])
+    return out
+
+needles = set()
+for key in ("access_token", "refresh_token", "id_token"):
+    needles |= fragments(real.get(key))
+if not needles:
+    print("WARNING: no real token found in source to scan for", file=sys.stderr)
+
+def scan(label, text):
     for n in needles:
-        if isinstance(v, str) and n in v:
-            print(f"LEAK: real {k} present in agent auth.json"); sys.exit(2)
-# 2) no real token fragment anywhere in captured evidence.
+        if n in text:
+            print(f"LEAK: real token fragment in {label}")
+            sys.exit(2)
+
+# 1) agent container auth.json must be placeholder only (direct check).
+agent = json.load(open(sys.argv[2]))["tokens"]
+for key, value in agent.items():
+    if isinstance(value, str):
+        scan(f"agent auth.json[{key}]", value)
+
+# 2) no real token fragment anywhere in captured evidence (env, ps, codex home,
+#    egressd log, broker audit, codex stdio).
 for root, _, files in os.walk(sys.argv[3]):
     for name in files:
-        path = os.path.join(root, name)
         try:
-            data = open(path, "r", errors="ignore").read()
+            data = open(os.path.join(root, name), "r", errors="ignore").read()
         except Exception:
             continue
-        for n in needles:
-            if n in data:
-                print(f"LEAK: real token fragment in evidence/{name}"); sys.exit(2)
-print("no credential leakage detected")
+        scan(f"evidence/{name}", data)
+
+print("no credential leakage detected (agent fs/env/args + evidence)")
 PY
 
 # --- verdict signal (evidence, not decision) --------------------------------

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -234,23 +234,24 @@ func (f *fakeGitHub) lastAPIRequest() *http.Request {
 }
 
 type brokerFixture struct {
-	t      *testing.T
-	root   string
-	home   string
-	bind   string
-	url    string
-	audit  string
-	agents string
-	broker *exec.Cmd
-	fake   *fakeGitHub
-	oauth  *fakeOAuth
-	keyPEM string
-	config string
-	token  string
-	auth   string
-	extra  string
-	stdout bytes.Buffer
-	stderr bytes.Buffer
+	t                 *testing.T
+	root              string
+	home              string
+	bind              string
+	url               string
+	audit             string
+	agents            string
+	broker            *exec.Cmd
+	fake              *fakeGitHub
+	oauth             *fakeOAuth
+	keyPEM            string
+	config            string
+	token             string
+	auth              string
+	extra             string
+	codexClaimHeaders string
+	stdout            bytes.Buffer
+	stderr            bytes.Buffer
 }
 
 func newBrokerFixture(t *testing.T) *brokerFixture {
@@ -360,7 +361,7 @@ providers:
     config:
       injection-hosts:
         - chatgpt.com
-      auth-file: %q
+%s      auth-file: %q
       token-url: %q
       client-id: test-client
       refresh-margin-seconds: 600
@@ -368,7 +369,7 @@ providers:
       extra-files:
         - name: config.toml
           path: %q
-`, f.fake.server.URL, perPage, maxResponseBytes, repoLines.String(), methods, f.auth, f.oauth.server.URL, f.extra)
+`, f.fake.server.URL, perPage, maxResponseBytes, repoLines.String(), methods, f.codexClaimHeaders, f.auth, f.oauth.server.URL, f.extra)
 	path := filepath.Join(f.home, "broker.yaml")
 	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
 		f.t.Fatal(err)
@@ -1114,6 +1115,16 @@ func decodeJSONFile(t *testing.T, path string, value any) {
 func testJWT(exp time.Time) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload, _ := json.Marshal(map[string]any{"exp": exp.Unix()})
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func testJWTWithClaims(exp time.Time, claims map[string]any) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body := map[string]any{"exp": exp.Unix()}
+	for key, value := range claims {
+		body[key] = value
+	}
+	payload, _ := json.Marshal(body)
 	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
 }
 

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // nvtPlaceholder is the documented zero-entropy placeholder constant from
@@ -399,6 +400,61 @@ func TestDeniedInjectionAuditIncludesContext(t *testing.T) {
 		if entry[key] != want {
 			t.Fatalf("audit entry %s = %v, want %v (entry: %v)", key, entry[key], want, entry)
 		}
+	}
+}
+
+// TestInjectionComputesClaimDerivedHeaders pins that a codex-oauth provider
+// configured with injection-claim-headers computes those headers from the
+// real access-token claims (e.g. the ChatGPT account-id header), returns them
+// in the injection response, and lists them in strip_request_headers so the
+// agent's placeholder versions are removed. Load-bearing for plan-auth, where
+// the backend requires a claim-derived header alongside the bearer.
+func TestInjectionComputesClaimDerivedHeaders(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	// Reconfigure codex-main with a claim-derived header whose claim key
+	// itself contains dots (the OpenAI account claim key is a URL).
+	f.codexClaimHeaders = "" +
+		"      injection-claim-headers:\n" +
+		"        - header: chatgpt-account-id\n" +
+		"          claim-path:\n" +
+		"            - https://api.openai.com/auth\n" +
+		"            - chatgpt_account_id\n"
+	token := testJWTWithClaims(time.Now().Add(time.Hour), map[string]any{
+		"https://api.openai.com/auth": map[string]any{"chatgpt_account_id": "acct-real-123"},
+	})
+	f.writeCodexAuth(token, "real-refresh-1")
+	f.config = f.writeConfig([]string{"my-user/my-repo", "my-user/other-repo"}, "", 0, 0)
+	f.stop()
+	f.start()
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("injection denied: status=%d body=%v", status, body)
+	}
+	headers, ok := body["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers, got %v", body)
+	}
+	if headers["chatgpt-account-id"] != "acct-real-123" {
+		t.Fatalf("claim-derived header = %v, want acct-real-123", headers["chatgpt-account-id"])
+	}
+	if _, present := headers["authorization"]; !present {
+		t.Fatal("authorization header missing alongside claim header")
+	}
+	strip, ok := body["strip_request_headers"].([]any)
+	if !ok {
+		t.Fatalf("expected strip_request_headers, got %v", body["strip_request_headers"])
+	}
+	stripped := map[string]bool{}
+	for _, name := range strip {
+		if text, ok := name.(string); ok {
+			stripped[text] = true
+		}
+	}
+	if !stripped["chatgpt-account-id"] || !stripped["authorization"] {
+		t.Fatalf("both injected headers must be stripped from the request, got %v", strip)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of `docs/mediated-egress-plan.md` — the empirical **gate**: can real Codex ChatGPT-plan auth be fully mediated through egressd via base-URL redirection, with the agent container holding **no** real credential? This PR ships the harness that produces the evidence; the go/no-go decision gets recorded in `docs/phase2-codex-gate.md` from a run. **No operator/compose production wiring** (that's Phase 3, gated on this).

Implements the spec in `docs/phase2-codex-gate-plan.md`, incorporating the review refinements we discussed (internal-network isolation on macOS, claim-derived headers, real-refresh via `refresh-margin`, http-vs-pinned distinction).

## Trusted-core additions (needed to render the verdict)

- **egressd optional agent-facing TLS listener** (`listen_tls_cert`/`listen_tls_key`, both-or-neither validated) so the gate can distinguish *"client requires https"* (per-agent CA works → GO) from *"client pins certs"* (CA can't help → NO-GO). Plus `egressd/Dockerfile` (distroless static). Config test added.
- **codex-oauth `injection-claim-headers`**: computes headers from the **real** access-token claims (e.g. `chatgpt-account-id` from `https://api.openai.com/auth → chatgpt_account_id`), returns them alongside `authorization`, and adds them to `strip_request_headers` so the agent's placeholder versions never reach the upstream. `claim-path` accepts a **segment list** for keys containing dots (the OpenAI account claim key is a URL). Conformance test pins that the header is derived from the real token and stripped.

## Harness

- **`phase2/compose.phase2.yaml`** — agent on an `internal: true` network whose only reachable peer is egressd; broker + egressd on a trusted network with outbound (broker needs `auth.openai.com` for refresh). A direct Codex call to any fixed host fails at connect — the gate signal, loud.
- **`scripts/phase2-codex-gate.sh`** — throwaway broker state owning a **copy** of the real `auth.json` (never mutates `.broker/`), generated agent+egress identities, per-agent CA + egressd server cert, placeholder agent `auth.json` (zero-entropy JWT, far-future exp), runs a real `codex exec` turn, captures evidence, and **fails loudly if any real token fragment** appears in the agent container or evidence.
- **`make phase2-codex-gate`**; `.phase2-out/` gitignored.

## Deliverable + examples

- **`docs/phase2-codex-gate.md`** — gate document template with the three-outcome decision guide (https-works / cert-pinned / extra-hosts) to fill from `.phase2-out/evidence/`.
- **`examples/mediated-codex/`** — non-secret mediated codex-oauth configs.
- `protocol/broker.md` documents `injection-claim-headers`.

## How to run

```
make phase2-codex-gate
# PHASE2_AUTH_SOURCE (default .broker/codex/auth.json), PHASE2_SCHEME=https|http,
# PHASE2_UPSTREAM, PHASE2_CODEX_CMD
```

Because it needs your real ChatGPT-plan `auth.json` and a live Codex turn, the **empirical answer** comes from you running it; the harness structures and captures that evidence and enforces non-possession.

## Tests

Full broker conformance suite green (incl. new claim-derived-headers test); all egressd tests green (incl. TLS-listener validation); egressd image builds. No real credential enters the repo, logs, or agent container (asserted by the harness).

## Review focus

1. `egressd` TLS-listener wiring and `codex-oauth` claim-header derivation (trusted core): computed from the real token, placeholders stripped, never logged.
2. `scripts/phase2-codex-gate.sh` isolation topology and the leak-scan (does it actually fail closed?).
3. Scope discipline — confirm no operator/compose production wiring snuck in.