### PR TITLE
Phase 2b: add CONNECT-only egressd forward proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ values.*.local.yaml
 __pycache__/
 *.pyc
 .phase2-out/
+.phase2b-out/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ OPERATOR_KIND_EXTRA_IMAGE_TARGETS := gateway-kind-load
 OPERATOR_KIND_GATEWAY_HELM_ARGS := --set gateway.enabled=true --set gateway.image=$(GATEWAY_IMAGE)
 endif
 
-.PHONY: runtime-build broker-build egressd-build phase2-codex-gate operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
+.PHONY: runtime-build broker-build egressd-build phase2-codex-gate phase2b-codex-forward-proxy operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
 
 runtime-build:
 	bash scripts/runtime-build.sh $(if $(NO_CACHE),--no-cache)
@@ -42,6 +42,9 @@ egressd-build:
 
 phase2-codex-gate: runtime-build broker-build egressd-build
 	bash scripts/phase2-codex-gate.sh
+
+phase2b-codex-forward-proxy: runtime-build egressd-build
+	bash scripts/phase2b-codex-forward-proxy.sh
 
 operator-build:
 	bash scripts/operator-build.sh $(if $(NO_CACHE),--no-cache)

--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -192,6 +192,8 @@ trusted-core work for a later phase, so this PR adds only the plumbing step.
 - Sanitized logs contain only CONNECT decision metadata:
   `event=connect`, `target_host`, `target_port`, `decision`, and optional
   `error_class`.
+- These CONNECT decisions are sanitized egressd stdout logs in this phase, not
+  broker `audit.jsonl` per-request audit entries.
 - The Phase 2b harness runs real Codex through
   `HTTPS_PROXY=http://egressd:<port>` with the existing Codex auth bundle.
   This proves forward-proxy plumbing only. It is not credential-less Codex.

--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -1,7 +1,7 @@
 # Plan: Mediated Credential Egress
 
-Status: living document — Phases 0–1 completed (#53, #54); Phase 2 in progress
-Version: v3.3 (as-executed Phase 1, transparent mediation mode, claim scope)
+Status: living document — Phases 0–2 completed (#53, #54, Phase 2 gate); Phase 2b in progress
+Version: v3.4 (Phase 2b CONNECT-only forward-proxy plumbing)
 
 ## Goal
 
@@ -163,7 +163,7 @@ As executed — adjusted from the original "Codex API-key mode" wording: no Open
 
 Broker side shipped with it: identity roles + one-to-one pairing (grants on an egress identity are unrepresentable), `/v1/injection/headers` and `/v1/injection/routing` with authorization order role → pairing → grant → materialization → host, egress identities denied on all secret-bearing endpoints, header-inject grants excluding bundle/token/header paths, denial audit with full caller context, and optional broker TLS serving (`NVT_BROKER_TLS_CERT/KEY`). All 12 injection conformance tests live in CI.
 
-### Phase 2 — ChatGPT-plan flow as the go/no-go gate (in progress)
+### Phase 2 — ChatGPT-plan flow as the go/no-go gate (completed — NO-GO for redirect-only)
 
 **Implementation spec: `docs/phase2-codex-gate-plan.md`** — an empirical gate run in an internal-only compose topology (agent on an `internal: true` network, egressd the only path out, broker owning the real `auth.json` in a throwaway state dir). Deliverable is `docs/phase2-codex-gate.md` recording required hosts, the minimal placeholder `auth.json`/JWT shape, any claim-derived headers (e.g. account-id) the provider must compute from the real token, cert-pinning observations, and the go/no-go decision. Real refresh is forced by setting `refresh-margin-seconds` beyond the token's remaining lifetime — no short-lived fixture needed against the real token URL.
 
@@ -175,6 +175,30 @@ Switch the working harness to the plan-auth path (`codex-oauth` grant in `header
 Test refresh deterministically with broker-issued artificially short-lived tokens; verify the true SSE guarantee — new requests use the refreshed token, in-flight streams complete on the old one.
 
 **Go/no-go**: if plan-auth can't be redirected, plan-auth Codex stays on bundles and we reassess — bearer-shape mediation (Phase 1's result) ships independently either way for any redirectable provider. A NO-GO is a successful phase outcome (a documented answer), not a failure of the work.
+
+### Phase 2b — CONNECT-only egressd forward proxy (low-risk plumbing)
+
+Pulled forward after the Phase 2 NO-GO: current Codex plan-auth uses
+hardcoded WebSocket endpoints, but a probe showed it honors proxy environment
+variables and the container trust store. Full TLS termination/MITM remains
+trusted-core work for a later phase, so this PR adds only the plumbing step.
+
+- egressd gains a CONNECT-only forward-proxy listener with a configurable
+  host allowlist and default-deny behavior.
+- The proxy blind-tunnels allowed `host:port` targets; it does not implement
+  plain HTTP proxying, TLS termination, WebSocket injection, or credential
+  injection.
+- The broker contract remains unchanged.
+- Sanitized logs contain only CONNECT decision metadata:
+  `event=connect`, `target_host`, `target_port`, `decision`, and optional
+  `error_class`.
+- The Phase 2b harness runs real Codex through
+  `HTTPS_PROXY=http://egressd:<port>` with the existing Codex auth bundle.
+  This proves forward-proxy plumbing only. It is not credential-less Codex.
+
+Credential-less Codex still waits for CA/TLS termination plus WebSocket
+handshake injection. The next PR after this should focus on Codex fallback
+hardening and short-TTL vended bundles.
 
 ### Phase 3 — Operator + compose wiring (non-possession ships)
 
@@ -219,11 +243,12 @@ One phase per PR. This is load-bearing: line-by-line review of the trusted core 
 | 1 | Phase 0: protocol doc + conformance/smoke test skeletons | human review of the contract — slowest, most careful |
 | 2 | Phase 1: egressd + identity split + Codex API-key mode | trusted-core review; timeboxed spike result |
 | 3 | Phase 2: ChatGPT-plan flow + refresh/SSE tests | **go/no-go decision recorded in the PR** |
+| 3b | Phase 2b: CONNECT-only egressd forward proxy, no TLS termination or injection | egressd CONNECT tests + Codex proxy harness |
 | 4 | Phase 3: operator + compose wiring; non-possession tests → CI | conformance green in CI |
 | 5 | Phase 4: git-HTTPS mediation (CA, TLS termination) | trusted-core review — highest-risk surface, deliberately alone |
 | 6a | Phase 5: enforcement (own-Pod evaluation, iptables + FORWARD deny) | egress-denied test → CI |
 | 6b | Phase 5: audit, quotas, revocation, Anthropic proof; flip operator default | both smoke tests green |
-| 7 | Phase 6: forward-proxy mode (CONNECT + CA) for arbitrary-tool coverage | trusted-core review (reuses Phase 4 CA) |
+| 7 | Phase 6: TLS-terminating forward-proxy mode (CONNECT + CA) for arbitrary-tool credential mediation | trusted-core review (reuses Phase 4 CA) |
 | 8 | Phase 6: true transparent REDIRECT + optional body substitution | after Phase 5 enforcement; egress-denied still green |
 
 ## Division of labor

--- a/docs/phase2-codex-gate.md
+++ b/docs/phase2-codex-gate.md
@@ -171,6 +171,11 @@ of:
 - bring Phase 6-style forward-proxy/transparent mediation earlier for Codex
   plan-auth, because that can catch hardcoded endpoints.
 
+Phase 2b implements the low-risk first part of that last option:
+CONNECT-only forward-proxy plumbing in `egressd`, without TLS termination,
+broker API changes, or credential injection. See
+`docs/phase2b-codex-forward-proxy.md`.
+
 This is a successful Phase 2 result: the gate answered the question before
 operator/compose production wiring was built around a false assumption.
 

--- a/docs/phase2b-codex-forward-proxy.md
+++ b/docs/phase2b-codex-forward-proxy.md
@@ -1,0 +1,99 @@
+# Phase 2b — Codex CONNECT-Only Forward Proxy
+
+Status: implemented as low-risk plumbing after the Phase 2 redirect-only
+NO-GO.
+
+This phase adds a forward-proxy mode to `egressd` that supports only HTTP
+`CONNECT` blind tunnels. It is intentionally not credential-less Codex
+mediation yet.
+
+## Boundary
+
+What this phase does:
+
+- accepts HTTP `CONNECT host:port` requests;
+- allows only configured hosts, default deny;
+- defaults allowed ports to `443`;
+- tunnels bytes blindly after `200 Connection Established`;
+- logs only sanitized CONNECT decisions:
+  `event=connect`, `target_host`, `target_port`, `decision`, and optional
+  `error_class`.
+
+What this phase does not do:
+
+- no plain HTTP proxying for `GET`/`POST` proxy requests;
+- no TLS termination or per-agent CA;
+- no WebSocket handshake inspection or injection;
+- no credential injection;
+- no broker API changes;
+- no `agentd` changes.
+
+Codex still uses its existing `auth.json` in the Phase 2b harness. The harness
+proves that current Codex honors proxy environment variables for the hardcoded
+WebSocket endpoints; it does not prove credential non-possession.
+
+## Harness
+
+Run:
+
+```sh
+make phase2b-codex-forward-proxy
+```
+
+Useful override:
+
+```sh
+PHASE2B_AUTH_SOURCE=/path/to/auth.json make phase2b-codex-forward-proxy
+```
+
+The harness starts an isolated agent container and `egressd` on an internal
+agent network. `egressd` also has an outbound network and listens as a
+CONNECT-only proxy at `http://egressd:8471`.
+
+The Codex run sets:
+
+```text
+HTTPS_PROXY=http://egressd:8471
+HTTP_PROXY=http://egressd:8471
+ALL_PROXY=http://egressd:8471
+NO_PROXY=localhost,127.0.0.1,::1,broker,egressd
+```
+
+It runs:
+
+```sh
+codex exec --skip-git-repo-check "print pong"
+```
+
+Evidence lands in `.phase2b-out/evidence/`:
+
+- `codex-stdout.txt`
+- `codex-stderr.txt`
+- `egressd.log`
+- `summary.txt`
+
+Acceptance:
+
+- Codex prints `pong`.
+- `egressd.log` contains allowed CONNECT decisions for allowlisted hosts.
+- `egressd.log` contains no credential/header-shaped text.
+
+Denied-host behavior is covered by focused `egressd` Go tests, not by the real
+Codex harness.
+
+## Initial Allowlist
+
+The harness allowlist is:
+
+- `chatgpt.com`
+- `ab.chatgpt.com`
+- `github.com`
+- `api.openai.com`
+
+Only port `443` is allowed by default.
+
+## Next PR
+
+The next PR should harden Codex fallback behavior and short-TTL vended bundles.
+Credential-less Codex waits for later CA/TLS termination plus WebSocket
+handshake injection.

--- a/docs/phase2b-codex-forward-proxy.md
+++ b/docs/phase2b-codex-forward-proxy.md
@@ -19,6 +19,10 @@ What this phase does:
   `event=connect`, `target_host`, `target_port`, `decision`, and optional
   `error_class`.
 
+Those CONNECT decisions are sanitized `egressd` stdout logs only in this PR.
+They are not broker `audit.jsonl` entries; per-request broker audit remains a
+later egress enforcement/audit phase.
+
 What this phase does not do:
 
 - no plain HTTP proxying for `GET`/`POST` proxy requests;
@@ -89,6 +93,7 @@ The harness allowlist is:
 - `ab.chatgpt.com`
 - `github.com`
 - `api.openai.com`
+- `auth.openai.com`
 
 Only port `443` is allowed by default.
 

--- a/docs/phase2b-codex-forward-proxy.md
+++ b/docs/phase2b-codex-forward-proxy.md
@@ -14,6 +14,8 @@ What this phase does:
 - accepts HTTP `CONNECT host:port` requests;
 - allows only configured hosts, default deny;
 - defaults allowed ports to `443`;
+- caps concurrent tunnels by default at `64`;
+- closes idle tunnels after `60s` by default;
 - tunnels bytes blindly after `200 Connection Established`;
 - logs only sanitized CONNECT decisions:
   `event=connect`, `target_host`, `target_port`, `decision`, and optional
@@ -22,6 +24,11 @@ What this phase does:
 Those CONNECT decisions are sanitized `egressd` stdout logs only in this PR.
 They are not broker `audit.jsonl` entries; per-request broker audit remains a
 later egress enforcement/audit phase.
+
+Broker URL, CA, and token settings are inert for forward-proxy-only
+configuration. `egressd` validates and uses broker settings only when injection
+routes are configured; broker audit and broker-side validation for proxy flows
+remain part of later injection-route phases.
 
 What this phase does not do:
 
@@ -66,19 +73,25 @@ NO_PROXY=localhost,127.0.0.1,::1,broker,egressd
 It runs:
 
 ```sh
-codex exec --skip-git-repo-check "print pong"
+codex exec --skip-git-repo-check --output-last-message /tmp/phase2b-last-message.txt \
+  "Reply with exactly this nonce and no other text: phase2b-..."
 ```
+
+If the installed Codex does not support `--output-last-message`, the harness
+falls back to plain `codex exec` with the same nonce prompt and checks the last
+non-empty captured output line.
 
 Evidence lands in `.phase2b-out/evidence/`:
 
 - `codex-stdout.txt`
 - `codex-stderr.txt`
+- `codex-last-message.txt`
 - `egressd.log`
 - `summary.txt`
 
 Acceptance:
 
-- Codex prints `pong`.
+- Codex's final answer exactly matches the generated `phase2b-...` nonce.
 - `egressd.log` contains allowed CONNECT decisions for allowlisted hosts.
 - `egressd.log` contains no credential/header-shaped text.
 

--- a/egressd/cmd/egressd/main.go
+++ b/egressd/cmd/egressd/main.go
@@ -9,9 +9,12 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/mirkoSekulic/nvt-agent/egressd/internal/egress"
 )
+
+const forwardProxyReadHeaderTimeout = 5 * time.Second
 
 func main() {
 	if err := run(); err != nil {
@@ -68,7 +71,11 @@ func run() error {
 			Config: *config.ForwardProxy,
 			Logger: log.New(os.Stdout, "", 0),
 		}
-		server := &http.Server{Addr: config.ForwardProxy.Listen, Handler: proxy}
+		server := &http.Server{
+			Addr:              config.ForwardProxy.Listen,
+			Handler:           proxy,
+			ReadHeaderTimeout: forwardProxyReadHeaderTimeout,
+		}
 		go func() {
 			errors <- server.ListenAndServe()
 		}()

--- a/egressd/cmd/egressd/main.go
+++ b/egressd/cmd/egressd/main.go
@@ -29,17 +29,24 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	token := os.Getenv("NVT_BROKER_TOKEN")
-	if token == "" {
-		return fmt.Errorf("NVT_BROKER_TOKEN is required (egress-role identity)")
+	var broker *egress.BrokerClient
+	if len(config.Routes) > 0 {
+		token := os.Getenv("NVT_BROKER_TOKEN")
+		if token == "" {
+			return fmt.Errorf("NVT_BROKER_TOKEN is required when injection routes are configured")
+		}
+		brokerHTTP, err := brokerHTTPClient(config)
+		if err != nil {
+			return err
+		}
+		broker = &egress.BrokerClient{URL: config.BrokerURL, Token: token, Client: brokerHTTP}
 	}
-	brokerHTTP, err := brokerHTTPClient(config)
-	if err != nil {
-		return err
-	}
-	broker := &egress.BrokerClient{URL: config.BrokerURL, Token: token, Client: brokerHTTP}
 	transport := &http.Transport{ForceAttemptHTTP2: true}
-	errors := make(chan error, len(config.Routes))
+	listenerCount := len(config.Routes)
+	if config.ForwardProxy != nil {
+		listenerCount++
+	}
+	errors := make(chan error, listenerCount)
 	for _, route := range config.Routes {
 		proxy := &egress.Proxy{Route: route, Broker: broker, Transport: transport}
 		server := &http.Server{Addr: route.Listen, Handler: proxy}
@@ -48,13 +55,23 @@ func run() error {
 			scheme = "https"
 		}
 		log.Printf("egressd: routing %s (%s) -> %s (capability %s)", route.Listen, scheme, route.Upstream, route.Capability)
-		go func(route egress.Route) {
+		go func(route egress.Route, server *http.Server) {
 			if route.TLSEnabled() {
 				errors <- server.ListenAndServeTLS(route.ListenTLSCert, route.ListenTLSKey)
 				return
 			}
 			errors <- server.ListenAndServe()
-		}(route)
+		}(route, server)
+	}
+	if config.ForwardProxy != nil {
+		proxy := &egress.ForwardProxy{
+			Config: *config.ForwardProxy,
+			Logger: log.New(os.Stdout, "", 0),
+		}
+		server := &http.Server{Addr: config.ForwardProxy.Listen, Handler: proxy}
+		go func() {
+			errors <- server.ListenAndServe()
+		}()
 	}
 	return <-errors
 }

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -126,6 +126,26 @@ func (c *Config) Validate() error {
 		if err := c.ForwardProxy.Validate(); err != nil {
 			return fmt.Errorf("forward_proxy: %w", err)
 		}
+		if err := c.validateForwardProxyRouteOverlap(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateForwardProxyRouteOverlap() error {
+	routeHosts := map[string]bool{}
+	for _, route := range c.Routes {
+		host, ok := normalizedRouteUpstreamHost(route.Upstream)
+		if ok {
+			routeHosts[host] = true
+		}
+	}
+	for _, host := range c.ForwardProxy.AllowHosts {
+		normalized := strings.ToLower(host)
+		if routeHosts[normalized] {
+			return fmt.Errorf("forward_proxy.allow_hosts[%q] overlaps mediated route upstream", host)
+		}
 	}
 	return nil
 }
@@ -158,6 +178,22 @@ func (c *ForwardProxyConfig) effectiveAllowPorts() []int {
 		return []int{443}
 	}
 	return c.AllowPorts
+}
+
+func normalizedRouteUpstreamHost(upstream string) (string, bool) {
+	host := upstream
+	if strings.Contains(upstream, ":") {
+		split, _, err := net.SplitHostPort(upstream)
+		if err != nil {
+			return "", false
+		}
+		host = split
+	}
+	normalized, err := normalizeProxyHost(host)
+	if err != nil {
+		return "", false
+	}
+	return normalized, true
 }
 
 // validateUpstream enforces that the pinned re-origination target is a bare

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -58,8 +58,18 @@ type Config struct {
 	// the agent netns is a conformance failure.
 	AllowInsecureBroker bool `json:"allow_insecure_broker"`
 	// BrokerCAFile optionally pins a CA bundle for the broker TLS endpoint.
-	BrokerCAFile string  `json:"broker_ca_file"`
-	Routes       []Route `json:"routes"`
+	BrokerCAFile string              `json:"broker_ca_file"`
+	Routes       []Route             `json:"routes"`
+	ForwardProxy *ForwardProxyConfig `json:"forward_proxy"`
+}
+
+// ForwardProxyConfig enables CONNECT-only blind-tunnel proxying. It does not
+// terminate TLS or inject credentials; it only allows configured host:port
+// targets through.
+type ForwardProxyConfig struct {
+	Listen     string   `json:"listen"`
+	AllowHosts []string `json:"allow_hosts"`
+	AllowPorts []int    `json:"allow_ports"`
 }
 
 // LoadConfig reads and validates the configuration file.
@@ -80,21 +90,23 @@ func LoadConfig(path string) (*Config, error) {
 
 // Validate enforces the transport and route rules.
 func (c *Config) Validate() error {
-	parsed, err := url.Parse(c.BrokerURL)
-	if err != nil || parsed.Host == "" {
-		return fmt.Errorf("broker_url must be a valid URL")
+	if len(c.Routes) == 0 && c.ForwardProxy == nil {
+		return fmt.Errorf("at least one route or forward_proxy is required")
 	}
-	switch parsed.Scheme {
-	case "https":
-	case "http":
-		if !c.AllowInsecureBroker {
-			return fmt.Errorf("broker_url must be https unless allow_insecure_broker is set (local dev only)")
+	if len(c.Routes) > 0 {
+		parsed, err := url.Parse(c.BrokerURL)
+		if err != nil || parsed.Host == "" {
+			return fmt.Errorf("broker_url must be a valid URL")
 		}
-	default:
-		return fmt.Errorf("broker_url must be an http(s) URL")
-	}
-	if len(c.Routes) == 0 {
-		return fmt.Errorf("at least one route is required")
+		switch parsed.Scheme {
+		case "https":
+		case "http":
+			if !c.AllowInsecureBroker {
+				return fmt.Errorf("broker_url must be https unless allow_insecure_broker is set (local dev only)")
+			}
+		default:
+			return fmt.Errorf("broker_url must be an http(s) URL")
+		}
 	}
 	for index, route := range c.Routes {
 		if route.Listen == "" {
@@ -110,7 +122,42 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("routes[%d]: listen_tls_cert and listen_tls_key must be set together", index)
 		}
 	}
+	if c.ForwardProxy != nil {
+		if err := c.ForwardProxy.Validate(); err != nil {
+			return fmt.Errorf("forward_proxy: %w", err)
+		}
+	}
 	return nil
+}
+
+// Validate enforces the forward proxy's fail-closed shape. An empty allowlist
+// is valid and means deny all.
+func (c *ForwardProxyConfig) Validate() error {
+	if c.Listen == "" {
+		return fmt.Errorf("listen is required")
+	}
+	for _, host := range c.AllowHosts {
+		normalized, err := normalizeProxyHost(host)
+		if err != nil {
+			return fmt.Errorf("allow_hosts[%q]: %w", host, err)
+		}
+		if normalized != strings.ToLower(host) {
+			return fmt.Errorf("allow_hosts[%q]: must be normalized lowercase host without brackets", host)
+		}
+	}
+	for _, port := range c.effectiveAllowPorts() {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("allow_ports contains invalid port %d", port)
+		}
+	}
+	return nil
+}
+
+func (c *ForwardProxyConfig) effectiveAllowPorts() []int {
+	if len(c.AllowPorts) == 0 {
+		return []int{443}
+	}
+	return c.AllowPorts
 }
 
 // validateUpstream enforces that the pinned re-origination target is a bare

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Placeholder is the documented zero-entropy constant from
@@ -67,9 +68,11 @@ type Config struct {
 // terminate TLS or inject credentials; it only allows configured host:port
 // targets through.
 type ForwardProxyConfig struct {
-	Listen     string   `json:"listen"`
-	AllowHosts []string `json:"allow_hosts"`
-	AllowPorts []int    `json:"allow_ports"`
+	Listen                   string   `json:"listen"`
+	AllowHosts               []string `json:"allow_hosts"`
+	AllowPorts               []int    `json:"allow_ports"`
+	MaxConcurrentTunnels     int      `json:"max_concurrent_tunnels"`
+	TunnelIdleTimeoutSeconds int      `json:"tunnel_idle_timeout_seconds"`
 }
 
 // LoadConfig reads and validates the configuration file.
@@ -157,18 +160,20 @@ func (c *ForwardProxyConfig) Validate() error {
 		return fmt.Errorf("listen is required")
 	}
 	for _, host := range c.AllowHosts {
-		normalized, err := normalizeProxyHost(host)
-		if err != nil {
+		if _, err := normalizeProxyHost(host); err != nil {
 			return fmt.Errorf("allow_hosts[%q]: %w", host, err)
-		}
-		if normalized != strings.ToLower(host) {
-			return fmt.Errorf("allow_hosts[%q]: must be normalized lowercase host without brackets", host)
 		}
 	}
 	for _, port := range c.effectiveAllowPorts() {
 		if port < 1 || port > 65535 {
 			return fmt.Errorf("allow_ports contains invalid port %d", port)
 		}
+	}
+	if c.MaxConcurrentTunnels < 0 {
+		return fmt.Errorf("max_concurrent_tunnels must be non-negative")
+	}
+	if c.TunnelIdleTimeoutSeconds < 0 {
+		return fmt.Errorf("tunnel_idle_timeout_seconds must be non-negative")
 	}
 	return nil
 }
@@ -178,6 +183,20 @@ func (c *ForwardProxyConfig) effectiveAllowPorts() []int {
 		return []int{443}
 	}
 	return c.AllowPorts
+}
+
+func (c *ForwardProxyConfig) effectiveMaxConcurrentTunnels() int {
+	if c.MaxConcurrentTunnels == 0 {
+		return defaultForwardProxyMaxConcurrentTunnels
+	}
+	return c.MaxConcurrentTunnels
+}
+
+func (c *ForwardProxyConfig) effectiveTunnelIdleTimeout() time.Duration {
+	if c.TunnelIdleTimeoutSeconds == 0 {
+		return defaultForwardProxyTunnelIdleTimeout
+	}
+	return time.Duration(c.TunnelIdleTimeoutSeconds) * time.Second
 }
 
 func normalizedRouteUpstreamHost(upstream string) (string, bool) {

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -107,6 +107,7 @@ func (p *ForwardProxy) init() {
 		for _, host := range p.Config.AllowHosts {
 			normalized, err := normalizeProxyHost(host)
 			if err != nil {
+				p.writeInvalidAllowHost(host)
 				continue
 			}
 			p.allowHosts[normalized] = true
@@ -117,6 +118,14 @@ func (p *ForwardProxy) init() {
 		}
 		p.tunnelSlots = make(chan struct{}, p.Config.effectiveMaxConcurrentTunnels())
 	})
+}
+
+func (p *ForwardProxy) writeInvalidAllowHost(host string) {
+	logger := p.Logger
+	if logger == nil {
+		logger = log.Default()
+	}
+	logger.Printf("event=forward_proxy_init allow_host=%q decision=deny error_class=invalid_allow_host", host)
 }
 
 func (p *ForwardProxy) dialer() *net.Dialer {

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -13,7 +13,11 @@ import (
 	"time"
 )
 
-const dialTimeout = 10 * time.Second
+const (
+	dialTimeout                             = 10 * time.Second
+	defaultForwardProxyMaxConcurrentTunnels = 64
+	defaultForwardProxyTunnelIdleTimeout    = 60 * time.Second
+)
 
 // ForwardProxy is a CONNECT-only blind tunnel. It does not inspect or modify
 // TLS, WebSocket frames, headers, cookies, bodies, or credentials.
@@ -22,9 +26,10 @@ type ForwardProxy struct {
 	Dialer *net.Dialer
 	Logger *log.Logger
 
-	once       sync.Once
-	allowHosts map[string]bool
-	allowPorts map[int]bool
+	once        sync.Once
+	allowHosts  map[string]bool
+	allowPorts  map[int]bool
+	tunnelSlots chan struct{}
 }
 
 func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -44,6 +49,14 @@ func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "CONNECT target not allowed", http.StatusForbidden)
 		return
 	}
+	releaseTunnel, ok := p.acquireTunnel()
+	if !ok {
+		p.writeDecision(target.host, target.port, "deny", "tunnel_limit_exceeded")
+		http.Error(w, "CONNECT tunnel limit exceeded", http.StatusServiceUnavailable)
+		return
+	}
+	defer releaseTunnel()
+
 	upstream, err := p.dialer().DialContext(r.Context(), "tcp", net.JoinHostPort(target.host, strconv.Itoa(target.port)))
 	if err != nil {
 		p.writeDecision(target.host, target.port, "deny", "upstream_unreachable")
@@ -70,21 +83,40 @@ func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
 		return
 	}
-	tunnel(client, buffered, upstream)
+	tunnel(client, buffered, upstream, p.Config.effectiveTunnelIdleTimeout())
 }
 
 func (p *ForwardProxy) allowed(target connectTarget) bool {
+	p.init()
+	return p.allowHosts[target.host] && p.allowPorts[target.port]
+}
+
+func (p *ForwardProxy) acquireTunnel() (func(), bool) {
+	p.init()
+	select {
+	case p.tunnelSlots <- struct{}{}:
+		return func() { <-p.tunnelSlots }, true
+	default:
+		return nil, false
+	}
+}
+
+func (p *ForwardProxy) init() {
 	p.once.Do(func() {
 		p.allowHosts = map[string]bool{}
 		for _, host := range p.Config.AllowHosts {
-			p.allowHosts[strings.ToLower(host)] = true
+			normalized, err := normalizeProxyHost(host)
+			if err != nil {
+				continue
+			}
+			p.allowHosts[normalized] = true
 		}
 		p.allowPorts = map[int]bool{}
 		for _, port := range p.Config.effectiveAllowPorts() {
 			p.allowPorts[port] = true
 		}
+		p.tunnelSlots = make(chan struct{}, p.Config.effectiveMaxConcurrentTunnels())
 	})
-	return p.allowHosts[target.host] && p.allowPorts[target.port]
 }
 
 func (p *ForwardProxy) dialer() *net.Dialer {
@@ -144,15 +176,6 @@ func connectTargetFromRequest(r *http.Request) (connectTarget, error) {
 			return connectTarget{}, fmt.Errorf("host header does not match CONNECT target")
 		}
 	}
-	if rawHost := r.Header.Get("Host"); rawHost != "" && rawHost != r.Host {
-		hostHeader, err := parseConnectTarget(rawHost)
-		if err != nil {
-			return connectTarget{}, err
-		}
-		if hostHeader != target {
-			return connectTarget{}, fmt.Errorf("host header does not match CONNECT target")
-		}
-	}
 	return target, nil
 }
 
@@ -179,20 +202,53 @@ func normalizeProxyHost(host string) (string, error) {
 	return lower, nil
 }
 
-func tunnel(client net.Conn, buffered *bufio.ReadWriter, upstream net.Conn) {
+func tunnel(client net.Conn, buffered *bufio.ReadWriter, upstream net.Conn, idleTimeout time.Duration) {
+	setTunnelDeadline(idleTimeout, client, upstream)
 	done := make(chan struct{}, 2)
 	go func() {
-		_, _ = io.Copy(upstream, buffered)
+		_, _ = io.Copy(upstream, tunnelActivityReader{
+			reader:      buffered,
+			idleTimeout: idleTimeout,
+			conns:       []net.Conn{client, upstream},
+		})
 		_ = closeWrite(upstream)
 		done <- struct{}{}
 	}()
 	go func() {
-		_, _ = io.Copy(client, upstream)
+		_, _ = io.Copy(client, tunnelActivityReader{
+			reader:      upstream,
+			idleTimeout: idleTimeout,
+			conns:       []net.Conn{client, upstream},
+		})
 		_ = closeWrite(client)
 		done <- struct{}{}
 	}()
 	<-done
 	<-done
+}
+
+type tunnelActivityReader struct {
+	reader      io.Reader
+	idleTimeout time.Duration
+	conns       []net.Conn
+}
+
+func (r tunnelActivityReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		setTunnelDeadline(r.idleTimeout, r.conns...)
+	}
+	return n, err
+}
+
+func setTunnelDeadline(idleTimeout time.Duration, conns ...net.Conn) {
+	if idleTimeout <= 0 {
+		return
+	}
+	deadline := time.Now().Add(idleTimeout)
+	for _, conn := range conns {
+		_ = conn.SetDeadline(deadline)
+	}
 }
 
 func closeWrite(conn net.Conn) error {

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -1,0 +1,184 @@
+package egress
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const dialTimeout = 10 * time.Second
+
+// ForwardProxy is a CONNECT-only blind tunnel. It does not inspect or modify
+// TLS, WebSocket frames, headers, cookies, bodies, or credentials.
+type ForwardProxy struct {
+	Config ForwardProxyConfig
+	Dialer *net.Dialer
+	Logger *log.Logger
+
+	once       sync.Once
+	allowHosts map[string]bool
+	allowPorts map[int]bool
+}
+
+func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodConnect {
+		p.writeDecision("", 0, "deny", "plain_http_not_supported")
+		http.Error(w, "plain HTTP proxying is not supported", http.StatusMethodNotAllowed)
+		return
+	}
+	target, err := parseConnectTarget(r.Host)
+	if err != nil {
+		target = connectTarget{}
+		p.writeDecision("", 0, "deny", "malformed_target")
+		http.Error(w, "malformed CONNECT target", http.StatusBadRequest)
+		return
+	}
+	if !p.allowed(target) {
+		p.writeDecision(target.host, target.port, "deny", "target_not_allowed")
+		http.Error(w, "CONNECT target not allowed", http.StatusForbidden)
+		return
+	}
+	upstream, err := p.dialer().DialContext(r.Context(), "tcp", net.JoinHostPort(target.host, strconv.Itoa(target.port)))
+	if err != nil {
+		p.writeDecision(target.host, target.port, "deny", "upstream_unreachable")
+		http.Error(w, "CONNECT upstream unreachable", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = upstream.Close() }()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		p.writeDecision(target.host, target.port, "deny", "hijack_unavailable")
+		http.Error(w, "CONNECT unavailable", http.StatusInternalServerError)
+		return
+	}
+	client, buffered, err := hijacker.Hijack()
+	if err != nil {
+		p.writeDecision(target.host, target.port, "deny", "hijack_failed")
+		http.Error(w, "CONNECT unavailable", http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = client.Close() }()
+
+	p.writeDecision(target.host, target.port, "allow", "")
+	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+	tunnel(client, buffered, upstream)
+}
+
+func (p *ForwardProxy) allowed(target connectTarget) bool {
+	p.once.Do(func() {
+		p.allowHosts = map[string]bool{}
+		for _, host := range p.Config.AllowHosts {
+			p.allowHosts[strings.ToLower(host)] = true
+		}
+		p.allowPorts = map[int]bool{}
+		for _, port := range p.Config.effectiveAllowPorts() {
+			p.allowPorts[port] = true
+		}
+	})
+	return p.allowHosts[target.host] && p.allowPorts[target.port]
+}
+
+func (p *ForwardProxy) dialer() *net.Dialer {
+	if p.Dialer != nil {
+		return p.Dialer
+	}
+	return &net.Dialer{Timeout: dialTimeout}
+}
+
+func (p *ForwardProxy) writeDecision(host string, port int, decision, errorClass string) {
+	logger := p.Logger
+	if logger == nil {
+		logger = log.Default()
+	}
+	if errorClass != "" {
+		logger.Printf("event=connect target_host=%s target_port=%d decision=%s error_class=%s", host, port, decision, errorClass)
+		return
+	}
+	logger.Printf("event=connect target_host=%s target_port=%d decision=%s", host, port, decision)
+}
+
+type connectTarget struct {
+	host string
+	port int
+}
+
+func parseConnectTarget(value string) (connectTarget, error) {
+	if strings.Contains(value, "://") || strings.ContainsAny(value, "/\\@?# \t\r\n") || strings.Contains(value, "%") {
+		return connectTarget{}, fmt.Errorf("target must be host:port")
+	}
+	host, portText, err := net.SplitHostPort(value)
+	if err != nil {
+		return connectTarget{}, fmt.Errorf("target must be host:port")
+	}
+	host, err = normalizeProxyHost(host)
+	if err != nil {
+		return connectTarget{}, err
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > 65535 {
+		return connectTarget{}, fmt.Errorf("invalid port")
+	}
+	return connectTarget{host: host, port: port}, nil
+}
+
+func normalizeProxyHost(host string) (string, error) {
+	if host == "" {
+		return "", fmt.Errorf("empty host")
+	}
+	if strings.HasPrefix(host, "[") || strings.HasSuffix(host, "]") {
+		return "", fmt.Errorf("bracketed host is not allowed in allowlist")
+	}
+	if strings.ContainsAny(host, "/\\@?#: \t\r\n") || strings.Contains(host, "%") {
+		return "", fmt.Errorf("invalid host")
+	}
+	if strings.HasSuffix(host, ".") {
+		return "", fmt.Errorf("trailing dot host is not allowed")
+	}
+	lower := strings.ToLower(host)
+	for _, r := range lower {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			continue
+		}
+		return "", fmt.Errorf("host must be ascii DNS name or IPv4 literal")
+	}
+	return lower, nil
+}
+
+func tunnel(client net.Conn, buffered *bufio.ReadWriter, upstream net.Conn) {
+	done := make(chan struct{}, 2)
+	go func() {
+		if buffered.Reader.Buffered() > 0 {
+			_, _ = io.Copy(upstream, buffered)
+		} else {
+			_, _ = io.Copy(upstream, client)
+		}
+		_ = closeWrite(upstream)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(client, upstream)
+		_ = closeWrite(client)
+		done <- struct{}{}
+	}()
+	<-done
+}
+
+func closeWrite(conn net.Conn) error {
+	type closeWriter interface {
+		CloseWrite() error
+	}
+	if writer, ok := conn.(closeWriter); ok {
+		return writer.CloseWrite()
+	}
+	return conn.Close()
+}

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -33,9 +33,8 @@ func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "plain HTTP proxying is not supported", http.StatusMethodNotAllowed)
 		return
 	}
-	target, err := parseConnectTarget(r.Host)
+	target, err := connectTargetFromRequest(r)
 	if err != nil {
-		target = connectTarget{}
 		p.writeDecision("", 0, "deny", "malformed_target")
 		http.Error(w, "malformed CONNECT target", http.StatusBadRequest)
 		return
@@ -131,6 +130,32 @@ func parseConnectTarget(value string) (connectTarget, error) {
 	return connectTarget{host: host, port: port}, nil
 }
 
+func connectTargetFromRequest(r *http.Request) (connectTarget, error) {
+	target, err := parseConnectTarget(r.URL.Host)
+	if err != nil {
+		return connectTarget{}, err
+	}
+	if r.Host != "" {
+		hostHeader, err := parseConnectTarget(r.Host)
+		if err != nil {
+			return connectTarget{}, err
+		}
+		if hostHeader != target {
+			return connectTarget{}, fmt.Errorf("host header does not match CONNECT target")
+		}
+	}
+	if rawHost := r.Header.Get("Host"); rawHost != "" && rawHost != r.Host {
+		hostHeader, err := parseConnectTarget(rawHost)
+		if err != nil {
+			return connectTarget{}, err
+		}
+		if hostHeader != target {
+			return connectTarget{}, fmt.Errorf("host header does not match CONNECT target")
+		}
+	}
+	return target, nil
+}
+
 func normalizeProxyHost(host string) (string, error) {
 	if host == "" {
 		return "", fmt.Errorf("empty host")
@@ -157,11 +182,7 @@ func normalizeProxyHost(host string) (string, error) {
 func tunnel(client net.Conn, buffered *bufio.ReadWriter, upstream net.Conn) {
 	done := make(chan struct{}, 2)
 	go func() {
-		if buffered.Reader.Buffered() > 0 {
-			_, _ = io.Copy(upstream, buffered)
-		} else {
-			_, _ = io.Copy(upstream, client)
-		}
+		_, _ = io.Copy(upstream, buffered)
 		_ = closeWrite(upstream)
 		done <- struct{}{}
 	}()
@@ -170,6 +191,7 @@ func tunnel(client net.Conn, buffered *bufio.ReadWriter, upstream net.Conn) {
 		_ = closeWrite(client)
 		done <- struct{}{}
 	}()
+	<-done
 	<-done
 }
 

--- a/egressd/internal/egress/forward_proxy_test.go
+++ b/egressd/internal/egress/forward_proxy_test.go
@@ -375,6 +375,32 @@ func TestForwardProxyLogsAreSanitized(t *testing.T) {
 	}
 }
 
+func TestForwardProxyInitLogsInvalidAllowHostAndFailsClosed(t *testing.T) {
+	var logs bytes.Buffer
+	proxy := &ForwardProxy{
+		Config: ForwardProxyConfig{
+			AllowHosts: []string{"chatgpt.com", "bad\nhost"},
+		},
+		Logger: log.New(&logs, "", 0),
+	}
+
+	proxy.init()
+
+	if !proxy.allowHosts["chatgpt.com"] {
+		t.Fatalf("valid allow host was not initialized: %#v", proxy.allowHosts)
+	}
+	if proxy.allowHosts["bad\nhost"] {
+		t.Fatalf("invalid allow host was initialized: %#v", proxy.allowHosts)
+	}
+	got := logs.String()
+	if !strings.Contains(got, `event=forward_proxy_init allow_host="bad\nhost" decision=deny error_class=invalid_allow_host`) {
+		t.Fatalf("missing invalid allow host diagnostic: %q", got)
+	}
+	if strings.Contains(got, "\nbad") {
+		t.Fatalf("invalid allow host log was not escaped: %q", got)
+	}
+}
+
 func TestForwardProxyRejectsPlainHTTPProxying(t *testing.T) {
 	var logs bytes.Buffer
 	proxy := newForwardProxyServer(t, ForwardProxyConfig{

--- a/egressd/internal/egress/forward_proxy_test.go
+++ b/egressd/internal/egress/forward_proxy_test.go
@@ -90,7 +90,6 @@ func sendRawProxyRequest(t *testing.T, proxy, request string) (net.Conn, string)
 			break
 		}
 	}
-	_ = reader
 	return conn, status
 }
 
@@ -126,6 +125,39 @@ func TestForwardProxyAllowedConnectEstablishesBlindTunnel(t *testing.T) {
 	}
 }
 
+func TestForwardProxyUsesConnectAuthorityInsteadOfHostHeader(t *testing.T) {
+	upstreamAddress, upstreamPort := newEchoTCPServer(t)
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"127.0.0.1"},
+		AllowPorts: []int{upstreamPort},
+	}, &logs)
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
+		"CONNECT example.com:%d HTTP/1.1\r\nHost: %s\r\n\r\n", upstreamPort, upstreamAddress,
+	))
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "403") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if got := logs.String(); !strings.Contains(got, "event=connect target_host=example.com") ||
+		!strings.Contains(got, "decision=deny error_class=target_not_allowed") {
+		t.Fatalf("CONNECT authority was not used for allow decision: %q", got)
+	}
+}
+
+func TestConnectTargetFromRequestRejectsHostHeaderMismatch(t *testing.T) {
+	request, err := http.NewRequest(http.MethodConnect, "http://chatgpt.com:443", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.URL.Scheme = ""
+	request.Host = "chatgpt.com:443"
+	request.Header.Set("Host", "api.openai.com:443")
+	if _, err := connectTargetFromRequest(request); err == nil {
+		t.Fatal("Host header mismatch must be rejected")
+	}
+}
+
 func TestForwardProxyDeniedConnectFailsClosed(t *testing.T) {
 	var logs bytes.Buffer
 	proxy := newForwardProxyServer(t, ForwardProxyConfig{
@@ -139,6 +171,67 @@ func TestForwardProxyDeniedConnectFailsClosed(t *testing.T) {
 	}
 	if got := logs.String(); !strings.Contains(got, "event=connect target_host=example.com target_port=443 decision=deny error_class=target_not_allowed") {
 		t.Fatalf("missing sanitized deny log: %q", got)
+	}
+}
+
+func TestForwardProxyTunnelWaitsForHalfClosedClientResponse(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		body, err := io.ReadAll(conn)
+		if err != nil || string(body) != "request-body" {
+			return
+		}
+		_, _ = io.WriteString(conn, "upstream-response")
+	}()
+	_, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamPort, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"127.0.0.1"},
+		AllowPorts: []int{upstreamPort},
+	}, &logs)
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", listener.Addr().String(), listener.Addr().String(),
+	))
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "200") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if _, err := io.WriteString(conn, "request-body"); err != nil {
+		t.Fatal(err)
+	}
+	type closeWriter interface {
+		CloseWrite() error
+	}
+	writer, ok := conn.(closeWriter)
+	if !ok {
+		t.Fatalf("client connection does not support CloseWrite")
+	}
+	if err := writer.CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	response, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(response) != "upstream-response" {
+		t.Fatalf("tunnel response after half-close = %q", response)
 	}
 }
 
@@ -232,5 +325,28 @@ func TestForwardProxyDefaultAllowPortIs443(t *testing.T) {
 	}
 	if ports := config.effectiveAllowPorts(); len(ports) != 1 || ports[0] != 443 {
 		t.Fatalf("default ports = %v", ports)
+	}
+}
+
+func TestConfigRejectsForwardProxyAllowHostOverlappingMediatedRoute(t *testing.T) {
+	config := &Config{
+		BrokerURL: "https://broker:7347",
+		Routes: []Route{{
+			Listen:     "127.0.0.1:8470",
+			Capability: "codex-main",
+			Upstream:   "ChatGPT.com:443",
+		}},
+		ForwardProxy: &ForwardProxyConfig{
+			Listen:     "127.0.0.1:8471",
+			AllowHosts: []string{"chatgpt.com"},
+		},
+	}
+	if err := config.Validate(); err == nil {
+		t.Fatal("forward proxy allowlist overlap with mediated route upstream must be rejected")
+	}
+
+	config.ForwardProxy.AllowHosts = []string{"api.openai.com"}
+	if err := config.Validate(); err != nil {
+		t.Fatalf("non-overlapping forward proxy host should validate: %v", err)
 	}
 }

--- a/egressd/internal/egress/forward_proxy_test.go
+++ b/egressd/internal/egress/forward_proxy_test.go
@@ -1,0 +1,236 @@
+package egress
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func newForwardProxyServer(t *testing.T, config ForwardProxyConfig, logs *bytes.Buffer) *httptest.Server {
+	t.Helper()
+	proxy := &ForwardProxy{
+		Config: config,
+		Logger: log.New(logs, "", 0),
+	}
+	server := httptest.NewServer(proxy)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newEchoTCPServer(t *testing.T) (address string, port int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		line, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			return
+		}
+		_, _ = io.WriteString(conn, "echo:"+line)
+	}()
+	_, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err = strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener.Addr().String(), port
+}
+
+func proxyAddress(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	address := strings.TrimPrefix(server.URL, "http://")
+	if strings.Contains(address, "://") {
+		t.Fatalf("unexpected httptest URL %q", server.URL)
+	}
+	return address
+}
+
+func sendRawProxyRequest(t *testing.T, proxy, request string) (net.Conn, string) {
+	t.Helper()
+	conn, err := net.Dial("tcp", proxy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(conn, request); err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	reader := bufio.NewReader(conn)
+	status, err := reader.ReadString('\n')
+	if err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			_ = conn.Close()
+			t.Fatal(err)
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+	_ = reader
+	return conn, status
+}
+
+func TestForwardProxyAllowedConnectEstablishesBlindTunnel(t *testing.T) {
+	upstreamAddress, upstreamPort := newEchoTCPServer(t)
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"127.0.0.1"},
+		AllowPorts: []int{upstreamPort},
+	}, &logs)
+	target := upstreamAddress
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target,
+	))
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "200") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if _, err := io.WriteString(conn, "ping\n"); err != nil {
+		t.Fatal(err)
+	}
+	response, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response != "echo:ping\n" {
+		t.Fatalf("tunnel response = %q", response)
+	}
+	if got := logs.String(); !strings.Contains(got, "event=connect target_host=127.0.0.1") ||
+		!strings.Contains(got, fmt.Sprintf("target_port=%d", upstreamPort)) ||
+		!strings.Contains(got, "decision=allow") {
+		t.Fatalf("missing sanitized allow log: %q", got)
+	}
+}
+
+func TestForwardProxyDeniedConnectFailsClosed(t *testing.T) {
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"chatgpt.com"},
+	}, &logs)
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy),
+		"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "403") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if got := logs.String(); !strings.Contains(got, "event=connect target_host=example.com target_port=443 decision=deny error_class=target_not_allowed") {
+		t.Fatalf("missing sanitized deny log: %q", got)
+	}
+}
+
+func TestForwardProxyMalformedConnectTargetsRejected(t *testing.T) {
+	malformed := []string{
+		"chatgpt.com",
+		"https://chatgpt.com:443",
+		"user@chatgpt.com:443",
+		"chatgpt.com:bad",
+		"chatgpt.com:0",
+		"chatgpt.com:443/path",
+		"chatgpt.com.:443",
+		"[::1]:443",
+	}
+	for _, target := range malformed {
+		t.Run(target, func(t *testing.T) {
+			if _, err := parseConnectTarget(target); err == nil {
+				t.Fatalf("target %q should be rejected", target)
+			}
+		})
+	}
+}
+
+func TestForwardProxyRuntimeMalformedConnectRejected(t *testing.T) {
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"chatgpt.com"},
+	}, &logs)
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy),
+		"CONNECT chatgpt.com HTTP/1.1\r\nHost: chatgpt.com\r\n\r\n")
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "400") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if got := logs.String(); !strings.Contains(got, "decision=deny error_class=malformed_target") {
+		t.Fatalf("missing malformed log: %q", got)
+	}
+}
+
+func TestForwardProxyLogsAreSanitized(t *testing.T) {
+	const canary = "CANARY-SECRET-AUTHORIZATION-COOKIE-TOKEN"
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"chatgpt.com"},
+	}, &logs)
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy), ""+
+		"CONNECT example.com:443 HTTP/1.1\r\n"+
+		"Host: example.com:443\r\n"+
+		"Proxy-Authorization: Bearer "+canary+"\r\n"+
+		"Cookie: session="+canary+"\r\n"+
+		"\r\n")
+	defer func() { _ = conn.Close() }()
+	if !strings.Contains(status, "403") {
+		t.Fatalf("CONNECT status = %q", status)
+	}
+	if got := logs.String(); strings.Contains(got, canary) ||
+		strings.Contains(strings.ToLower(got), "authorization") ||
+		strings.Contains(strings.ToLower(got), "cookie") {
+		t.Fatalf("logs contain sensitive input: %q", got)
+	}
+}
+
+func TestForwardProxyRejectsPlainHTTPProxying(t *testing.T) {
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts: []string{"chatgpt.com"},
+	}, &logs)
+	request, err := http.NewRequest(http.MethodGet, proxy.URL+"/https://chatgpt.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Proxy-Authorization", "Bearer should-not-log")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("plain HTTP proxying status = %d", response.StatusCode)
+	}
+	if got := logs.String(); !strings.Contains(got, "event=connect target_host= target_port=0 decision=deny error_class=plain_http_not_supported") ||
+		strings.Contains(got, "should-not-log") {
+		t.Fatalf("unexpected log for plain HTTP rejection: %q", got)
+	}
+}
+
+func TestForwardProxyDefaultAllowPortIs443(t *testing.T) {
+	config := &ForwardProxyConfig{Listen: "127.0.0.1:0", AllowHosts: []string{"chatgpt.com"}}
+	if err := config.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if ports := config.effectiveAllowPorts(); len(ports) != 1 || ports[0] != 443 {
+		t.Fatalf("default ports = %v", ports)
+	}
+}

--- a/egressd/internal/egress/forward_proxy_test.go
+++ b/egressd/internal/egress/forward_proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newForwardProxyServer(t *testing.T, config ForwardProxyConfig, logs *bytes.Buffer) *httptest.Server {
@@ -151,8 +152,7 @@ func TestConnectTargetFromRequestRejectsHostHeaderMismatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.URL.Scheme = ""
-	request.Host = "chatgpt.com:443"
-	request.Header.Set("Host", "api.openai.com:443")
+	request.Host = "api.openai.com:443"
 	if _, err := connectTargetFromRequest(request); err == nil {
 		t.Fatal("Host header mismatch must be rejected")
 	}
@@ -232,6 +232,87 @@ func TestForwardProxyTunnelWaitsForHalfClosedClientResponse(t *testing.T) {
 	}
 	if string(response) != "upstream-response" {
 		t.Fatalf("tunnel response after half-close = %q", response)
+	}
+}
+
+func TestForwardProxyTunnelIdleTimeoutCleansUpStalledPeers(t *testing.T) {
+	clientPeer, client := net.Pipe()
+	upstream, upstreamPeer := net.Pipe()
+	defer func() { _ = clientPeer.Close() }()
+	defer func() { _ = upstreamPeer.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		tunnel(client, bufio.NewReadWriter(bufio.NewReader(client), bufio.NewWriter(client)), upstream, 50*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stalled tunnel did not clean up after idle timeout")
+	}
+}
+
+func TestForwardProxyConcurrentTunnelLimitFailsClosed(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	upstreamAccepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		upstreamAccepted <- conn
+	}()
+	_, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamPort, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logs bytes.Buffer
+	proxy := newForwardProxyServer(t, ForwardProxyConfig{
+		AllowHosts:           []string{"127.0.0.1"},
+		AllowPorts:           []int{upstreamPort},
+		MaxConcurrentTunnels: 1,
+	}, &logs)
+	first, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", listener.Addr().String(), listener.Addr().String(),
+	))
+	defer func() { _ = first.Close() }()
+	if !strings.Contains(status, "200") {
+		t.Fatalf("first CONNECT status = %q", status)
+	}
+	var upstreamConn net.Conn
+	select {
+	case upstreamConn = <-upstreamAccepted:
+	case <-time.After(time.Second):
+		t.Fatal("upstream did not accept first tunnel")
+	}
+	defer func() { _ = upstreamConn.Close() }()
+
+	const canary = "CANARY-SECOND-TUNNEL-SECRET"
+	second, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\nProxy-Authorization: Bearer %s\r\n\r\n",
+		listener.Addr().String(), listener.Addr().String(), canary,
+	))
+	defer func() { _ = second.Close() }()
+	if !strings.Contains(status, "503") {
+		t.Fatalf("second CONNECT status = %q", status)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "decision=deny error_class=tunnel_limit_exceeded") {
+		t.Fatalf("missing tunnel limit denial log: %q", got)
+	}
+	if strings.Contains(got, canary) || strings.Contains(strings.ToLower(got), "authorization") {
+		t.Fatalf("tunnel limit log contains sensitive input: %q", got)
 	}
 }
 
@@ -319,12 +400,18 @@ func TestForwardProxyRejectsPlainHTTPProxying(t *testing.T) {
 }
 
 func TestForwardProxyDefaultAllowPortIs443(t *testing.T) {
-	config := &ForwardProxyConfig{Listen: "127.0.0.1:0", AllowHosts: []string{"chatgpt.com"}}
+	config := &ForwardProxyConfig{Listen: "127.0.0.1:0", AllowHosts: []string{"ChatGPT.com"}}
 	if err := config.Validate(); err != nil {
 		t.Fatal(err)
 	}
 	if ports := config.effectiveAllowPorts(); len(ports) != 1 || ports[0] != 443 {
 		t.Fatalf("default ports = %v", ports)
+	}
+	if got := config.effectiveMaxConcurrentTunnels(); got != defaultForwardProxyMaxConcurrentTunnels {
+		t.Fatalf("default max concurrent tunnels = %d", got)
+	}
+	if got := config.effectiveTunnelIdleTimeout(); got != defaultForwardProxyTunnelIdleTimeout {
+		t.Fatalf("default tunnel idle timeout = %s", got)
 	}
 }
 

--- a/phase2/compose.phase2b.yaml
+++ b/phase2/compose.phase2b.yaml
@@ -1,0 +1,34 @@
+# Phase 2b Codex forward-proxy plumbing harness.
+#
+# NOT a production compose file. This proves CONNECT-only proxy routing for
+# current Codex plan auth using existing Codex auth inside the agent container.
+# It is not credential-less mediation.
+services:
+  egressd:
+    image: nvt-egressd:latest
+    environment:
+      NVT_EGRESSD_CONFIG: /config/egressd.json
+    volumes:
+      - ${PHASE2B_STATE}/egressd.json:/config/egressd.json:ro
+    networks:
+      - phase2b-agent
+      - phase2b-egress
+    restart: "no"
+
+  agent:
+    image: nvt-agent-runtime:latest
+    entrypoint: ["sleep", "infinity"]
+    environment:
+      CODEX_HOME: /root/.codex
+    volumes:
+      - ${PHASE2B_STATE}/agent-codex:/root/.codex
+    networks:
+      - phase2b-agent
+    depends_on:
+      - egressd
+    restart: "no"
+
+networks:
+  phase2b-agent:
+    internal: true
+  phase2b-egress: {}

--- a/scripts/phase2b-codex-forward-proxy.sh
+++ b/scripts/phase2b-codex-forward-proxy.sh
@@ -17,25 +17,77 @@ if [ -z "$AUTH_SOURCE" ]; then
     AUTH_SOURCE="$HOME/.codex/auth.json"
   fi
 fi
-CODEX_CMD="${PHASE2B_CODEX_CMD:-codex exec --skip-git-repo-check \"print pong\"}"
+
 OUT_DIR="$REPO_ROOT/.phase2b-out"
 STATE_DIR="$OUT_DIR/state"
+EVIDENCE_DIR="$OUT_DIR/evidence"
 PROJECT="nvt-phase2b"
 COMPOSE="docker compose -p $PROJECT -f $REPO_ROOT/phase2/compose.phase2b.yaml"
+PROXY_URL="http://egressd:8471"
+ALLOW_HOSTS=(chatgpt.com ab.chatgpt.com github.com api.openai.com auth.openai.com)
+ALLOW_HOSTS_CSV="$(IFS=,; echo "${ALLOW_HOSTS[*]}")"
+NONCE="phase2b-$(date +%s)-$$"
+CODEX_RC="not_run"
+FAILURE_REASON=""
+EGRESSD_LOG="$EVIDENCE_DIR/egressd.log"
+CODEX_STDOUT="$EVIDENCE_DIR/codex-stdout.txt"
+CODEX_STDERR="$EVIDENCE_DIR/codex-stderr.txt"
+CODEX_LAST="$EVIDENCE_DIR/codex-last-message.txt"
+SUMMARY="$EVIDENCE_DIR/summary.txt"
 
 log() { printf '\033[1;34m[phase2b]\033[0m %s\n' "$*"; }
-fail() { printf '\033[1;31m[phase2b] FAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+fail() {
+  FAILURE_REASON="$*"
+  printf '\033[1;31m[phase2b] FAIL:\033[0m %s\n' "$*" >&2
+  exit 1
+}
 
-[ -f "$AUTH_SOURCE" ] || fail "Codex auth.json not found at $AUTH_SOURCE (set PHASE2B_AUTH_SOURCE)"
+count_allowed_connects() {
+  if [ -f "$EGRESSD_LOG" ]; then
+    grep -c 'event=connect .* decision=allow' "$EGRESSD_LOG" || true
+  else
+    echo 0
+  fi
+}
+
+capture_egressd_logs() {
+  mkdir -p "$EVIDENCE_DIR"
+  $COMPOSE logs --no-log-prefix egressd > "$EGRESSD_LOG" 2>&1 || true
+}
+
+write_summary() {
+  mkdir -p "$EVIDENCE_DIR"
+  {
+    echo "codex_exit_code=$CODEX_RC"
+    echo "proxy_url=$PROXY_URL"
+    echo "allow_hosts=$ALLOW_HOSTS_CSV"
+    echo "credentialless_codex=no"
+    echo "allowed_connects=$(count_allowed_connects)"
+    if [ -n "$FAILURE_REASON" ]; then
+      echo "failure_reason=$FAILURE_REASON"
+    fi
+  } > "$SUMMARY"
+}
 
 cleanup() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ -z "$FAILURE_REASON" ]; then
+    FAILURE_REASON="unexpected exit $rc"
+  fi
+  capture_egressd_logs
+  write_summary
   log "tearing down"
   $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+  rm -f "$STATE_DIR/agent-codex/auth.json"
+  exit "$rc"
 }
 trap cleanup EXIT
 
 rm -rf "$OUT_DIR"
-mkdir -p "$STATE_DIR/agent-codex" "$OUT_DIR/evidence"
+mkdir -p "$STATE_DIR/agent-codex" "$EVIDENCE_DIR"
+
+[ -f "$AUTH_SOURCE" ] || fail "Codex auth.json not found at $AUTH_SOURCE (set PHASE2B_AUTH_SOURCE)"
+
 cp "$AUTH_SOURCE" "$STATE_DIR/agent-codex/auth.json"
 chmod 600 "$STATE_DIR/agent-codex/auth.json"
 
@@ -43,70 +95,85 @@ cat > "$STATE_DIR/agent-codex/config.toml" <<'TOML'
 check_for_update_on_startup = false
 TOML
 
-cat > "$STATE_DIR/egressd.json" <<'JSON'
+{
+  cat <<'JSON'
 {
   "forward_proxy": {
     "listen": "0.0.0.0:8471",
     "allow_hosts": [
-      "chatgpt.com",
-      "ab.chatgpt.com",
-      "github.com",
-      "api.openai.com"
+JSON
+  for index in "${!ALLOW_HOSTS[@]}"; do
+    comma=","
+    if [ "$index" -eq "$((${#ALLOW_HOSTS[@]} - 1))" ]; then
+      comma=""
+    fi
+    printf '      "%s"%s\n' "${ALLOW_HOSTS[$index]}" "$comma"
+  done
+  cat <<'JSON'
     ]
   }
 }
 JSON
+} > "$STATE_DIR/egressd.json"
 
 export PHASE2B_STATE="$STATE_DIR"
 
 log "starting egressd forward proxy + isolated agent"
 $COMPOSE up -d --no-build egressd agent
 
-for _ in $(seq 1 30); do
-  egressd_container="$($COMPOSE ps -q egressd 2>/dev/null || true)"
-  if [ -n "$egressd_container" ] &&
-     [ "$(docker inspect -f '{{.State.Running}}' "$egressd_container" 2>/dev/null || true)" = "true" ]; then
+for attempt in $(seq 1 30); do
+  if $COMPOSE exec -T agent bash -lc '</dev/tcp/egressd/8471' >/dev/null 2>&1; then
     break
+  fi
+  if [ "$attempt" -eq 30 ]; then
+    capture_egressd_logs
+    fail "egressd forward proxy did not become reachable at egressd:8471; see $EGRESSD_LOG"
   fi
   sleep 1
 done
 
-log "running Codex through HTTP(S)_PROXY=http://egressd:8471"
+log "running Codex through HTTP(S)_PROXY=$PROXY_URL"
 set +e
-$COMPOSE exec -T agent bash -lc '
+$COMPOSE exec -T \
+  -e PHASE2B_NONCE="$NONCE" \
+  -e PHASE2B_CODEX_CMD="${PHASE2B_CODEX_CMD:-}" \
+  agent bash -lc '
   set -e
   export CODEX_HOME=/root/.codex
   export HTTPS_PROXY=http://egressd:8471
   export HTTP_PROXY=http://egressd:8471
   export ALL_PROXY=http://egressd:8471
   export NO_PROXY=localhost,127.0.0.1,::1,broker,egressd
-  '"$CODEX_CMD"' < /dev/null
-' > "$OUT_DIR/evidence/codex-stdout.txt" 2> "$OUT_DIR/evidence/codex-stderr.txt"
+  if [ -n "$PHASE2B_CODEX_CMD" ]; then
+    eval "$PHASE2B_CODEX_CMD" < /dev/null
+    exit
+  fi
+  prompt="Reply with exactly this nonce and no other text: ${PHASE2B_NONCE}"
+  if codex exec --help 2>&1 | grep -q -- "--output-last-message"; then
+    codex exec --skip-git-repo-check --output-last-message /tmp/phase2b-last-message.txt "$prompt" < /dev/null
+    cat /tmp/phase2b-last-message.txt
+  else
+    codex exec --skip-git-repo-check "$prompt" < /dev/null
+  fi
+' > "$CODEX_STDOUT" 2> "$CODEX_STDERR"
 CODEX_RC=$?
 set -e
 
-$COMPOSE logs --no-log-prefix egressd > "$OUT_DIR/evidence/egressd.log" 2>&1 || true
+capture_egressd_logs
+cp "$CODEX_STDOUT" "$CODEX_LAST"
 
-if grep -Ei 'authorization|cookie|set-cookie|bearer|token|refresh|access_token|id_token' "$OUT_DIR/evidence/egressd.log" >/dev/null; then
-  fail "egressd log contains credential/header-shaped text; inspect $OUT_DIR/evidence/egressd.log"
+if grep -Ei '(authorization:|proxy-authorization:|cookie:|set-cookie:|bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|access_token[=:]|id_token[=:]|refresh_token[=:])' "$EGRESSD_LOG" >/dev/null; then
+  fail "egressd log contains credential/header-shaped text; inspect $EGRESSD_LOG"
 fi
-if ! grep -q 'event=connect .* decision=allow' "$OUT_DIR/evidence/egressd.log"; then
+if ! grep -q 'event=connect .* decision=allow' "$EGRESSD_LOG"; then
   fail "no allowed CONNECT decision found in egressd log"
 fi
-if ! grep -q 'pong' "$OUT_DIR/evidence/codex-stdout.txt"; then
-  fail "Codex did not print pong; see $OUT_DIR/evidence"
-fi
-
-{
-  echo "codex_exit_code=$CODEX_RC"
-  echo "proxy_url=http://egressd:8471"
-  echo "allow_hosts=chatgpt.com,ab.chatgpt.com,github.com,api.openai.com"
-  echo "credentialless_codex=no"
-  echo "allowed_connects=$(grep -c 'event=connect .* decision=allow' "$OUT_DIR/evidence/egressd.log" 2>/dev/null || echo 0)"
-} | tee "$OUT_DIR/evidence/summary.txt"
-
 if [ "$CODEX_RC" -ne 0 ]; then
-  fail "Codex exited with $CODEX_RC; see $OUT_DIR/evidence"
+  fail "Codex exited with $CODEX_RC; see $EVIDENCE_DIR"
+fi
+if [ "$(awk 'NF { line=$0 } END { print line }' "$CODEX_LAST")" != "$NONCE" ]; then
+  fail "Codex final answer did not match nonce $NONCE; see $EVIDENCE_DIR"
 fi
 
-log "Phase 2b forward-proxy plumbing passed; evidence written to $OUT_DIR/evidence/"
+write_summary
+log "Phase 2b forward-proxy plumbing passed; evidence written to $EVIDENCE_DIR/"

--- a/scripts/phase2b-codex-forward-proxy.sh
+++ b/scripts/phase2b-codex-forward-proxy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Phase 2b Codex CONNECT-only forward proxy harness.
+#
+# This runs real Codex through egressd as a forward proxy using the existing
+# Codex auth.json mounted into the agent container. It proves proxy plumbing
+# only. Codex still possesses and uses its normal auth in this harness.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+AUTH_SOURCE="${PHASE2B_AUTH_SOURCE:-}"
+if [ -z "$AUTH_SOURCE" ]; then
+  if [ -f "$REPO_ROOT/.broker/codex/auth.json" ]; then
+    AUTH_SOURCE="$REPO_ROOT/.broker/codex/auth.json"
+  else
+    AUTH_SOURCE="$HOME/.codex/auth.json"
+  fi
+fi
+CODEX_CMD="${PHASE2B_CODEX_CMD:-codex exec --skip-git-repo-check \"print pong\"}"
+OUT_DIR="$REPO_ROOT/.phase2b-out"
+STATE_DIR="$OUT_DIR/state"
+PROJECT="nvt-phase2b"
+COMPOSE="docker compose -p $PROJECT -f $REPO_ROOT/phase2/compose.phase2b.yaml"
+
+log() { printf '\033[1;34m[phase2b]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[phase2b] FAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -f "$AUTH_SOURCE" ] || fail "Codex auth.json not found at $AUTH_SOURCE (set PHASE2B_AUTH_SOURCE)"
+
+cleanup() {
+  log "tearing down"
+  $COMPOSE down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+rm -rf "$OUT_DIR"
+mkdir -p "$STATE_DIR/agent-codex" "$OUT_DIR/evidence"
+cp "$AUTH_SOURCE" "$STATE_DIR/agent-codex/auth.json"
+chmod 600 "$STATE_DIR/agent-codex/auth.json"
+
+cat > "$STATE_DIR/agent-codex/config.toml" <<'TOML'
+check_for_update_on_startup = false
+TOML
+
+cat > "$STATE_DIR/egressd.json" <<'JSON'
+{
+  "forward_proxy": {
+    "listen": "0.0.0.0:8471",
+    "allow_hosts": [
+      "chatgpt.com",
+      "ab.chatgpt.com",
+      "github.com",
+      "api.openai.com"
+    ]
+  }
+}
+JSON
+
+export PHASE2B_STATE="$STATE_DIR"
+
+log "starting egressd forward proxy + isolated agent"
+$COMPOSE up -d --no-build egressd agent
+
+for _ in $(seq 1 30); do
+  egressd_container="$($COMPOSE ps -q egressd 2>/dev/null || true)"
+  if [ -n "$egressd_container" ] &&
+     [ "$(docker inspect -f '{{.State.Running}}' "$egressd_container" 2>/dev/null || true)" = "true" ]; then
+    break
+  fi
+  sleep 1
+done
+
+log "running Codex through HTTP(S)_PROXY=http://egressd:8471"
+set +e
+$COMPOSE exec -T agent bash -lc '
+  set -e
+  export CODEX_HOME=/root/.codex
+  export HTTPS_PROXY=http://egressd:8471
+  export HTTP_PROXY=http://egressd:8471
+  export ALL_PROXY=http://egressd:8471
+  export NO_PROXY=localhost,127.0.0.1,::1,broker,egressd
+  '"$CODEX_CMD"' < /dev/null
+' > "$OUT_DIR/evidence/codex-stdout.txt" 2> "$OUT_DIR/evidence/codex-stderr.txt"
+CODEX_RC=$?
+set -e
+
+$COMPOSE logs --no-log-prefix egressd > "$OUT_DIR/evidence/egressd.log" 2>&1 || true
+
+if grep -Ei 'authorization|cookie|set-cookie|bearer|token|refresh|access_token|id_token' "$OUT_DIR/evidence/egressd.log" >/dev/null; then
+  fail "egressd log contains credential/header-shaped text; inspect $OUT_DIR/evidence/egressd.log"
+fi
+if ! grep -q 'event=connect .* decision=allow' "$OUT_DIR/evidence/egressd.log"; then
+  fail "no allowed CONNECT decision found in egressd log"
+fi
+if ! grep -q 'pong' "$OUT_DIR/evidence/codex-stdout.txt"; then
+  fail "Codex did not print pong; see $OUT_DIR/evidence"
+fi
+
+{
+  echo "codex_exit_code=$CODEX_RC"
+  echo "proxy_url=http://egressd:8471"
+  echo "allow_hosts=chatgpt.com,ab.chatgpt.com,github.com,api.openai.com"
+  echo "credentialless_codex=no"
+  echo "allowed_connects=$(grep -c 'event=connect .* decision=allow' "$OUT_DIR/evidence/egressd.log" 2>/dev/null || echo 0)"
+} | tee "$OUT_DIR/evidence/summary.txt"
+
+if [ "$CODEX_RC" -ne 0 ]; then
+  fail "Codex exited with $CODEX_RC; see $OUT_DIR/evidence"
+fi
+
+log "Phase 2b forward-proxy plumbing passed; evidence written to $OUT_DIR/evidence/"


### PR DESCRIPTION
## Summary
- add CONNECT-only forward-proxy mode to egressd with default-deny host allowlist
- add sanitized CONNECT logging and focused forward-proxy tests
- add Phase 2b compose harness/docs for running Codex through egressd using existing auth

## Tests
- not run by this wrapper after agent handoff; review should verify egressd Go tests and the Phase 2b harness

## Notes
- this is blind-tunnel plumbing only: no TLS termination, no credential injection, and no credential-less Codex claim