### PR TITLE
Phase 5 fixes: static_token injection signature, egressd cache TTL clamp

### DIFF
--- a/broker/plugins/static_token/provider.py
+++ b/broker/plugins/static_token/provider.py
@@ -68,5 +68,5 @@ class StaticTokenProvider:
     def identity_for_repo(self, repo, effective_repositories):
         raise ProviderError("identity-not-supported", f"provider {self.name} does not support commit identity; use identity.mode=explicit")
 
-    def injection_headers(self, host, method, path, agent_id, audit, request_id):
+    def injection_headers(self, host, method, path, agent_id, audit, request_id, grant=None):
         return {"authorization": f"Bearer {self.token}"}, None, ["authorization"]

--- a/docs/phase5-enforcement-plan.md
+++ b/docs/phase5-enforcement-plan.md
@@ -59,7 +59,7 @@ enforcement and nothing else.
 - **The egress-denied smoke skeleton is staged and skipped**:
   `TestMediatedEgressDenied` (`tests/runtime/mediated_smoke_test.go:428`).
 
-## Bugs found while planning (fix first, tiny PR or first commits of 6b)
+## Bugs found while planning (fixed — shipped as the Phase 5 fix PR)
 
 1. **`static_token.injection_headers` signature mismatch.** `server.py:212`
    calls providers with 7 args (now including `grant`), but

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -16,8 +16,13 @@ import (
 // considered stale.
 const expiryMargin = 30 * time.Second
 
-// defaultTTL bounds cache reuse when the broker reports no expiry.
-const defaultTTL = 60 * time.Second
+// maxCacheTTL bounds cache reuse regardless of credential expiry. This is
+// the load-bearing half of the revocation bound: broker-side grant checks
+// run per *fetch*, so a revoked grant keeps working until the cache expires.
+// Credential validity (e.g. a ~1h GitHub installation token) must not set
+// that window; refetching is cheap because the broker caches minted tokens
+// with its own buffer.
+const maxCacheTTL = 60 * time.Second
 
 // hopByHopHeaders are never forwarded in either direction (RFC 9110 §7.6.1).
 var hopByHopHeaders = map[string]bool{
@@ -95,10 +100,13 @@ func (p *Proxy) material(ctx context.Context, method, path string) (*Material, e
 
 func (p *Proxy) entryValidLocked(entry *cacheEntry) bool {
 	now := p.now()
+	if !now.Before(entry.fetchedAt.Add(maxCacheTTL)) {
+		return false
+	}
 	if !entry.material.ExpiresAt.IsZero() {
 		return now.Before(entry.material.ExpiresAt.Add(-expiryMargin))
 	}
-	return now.Before(entry.fetchedAt.Add(defaultTTL))
+	return true
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/egressd/internal/egress/proxy_test.go
+++ b/egressd/internal/egress/proxy_test.go
@@ -474,6 +474,66 @@ func TestCacheReusedUntilExpiry(t *testing.T) {
 	}
 }
 
+// TestCacheTTLClampBoundsRevocation pins the revocation bound: cached
+// material is never served past maxCacheTTL, even when the credential
+// itself is valid for much longer (the ~1h GitHub installation token is the
+// regression case). After the clamp expires, the next request re-asks the
+// broker — so a revoked grant fails closed within one clamp window, not one
+// credential lifetime.
+func TestCacheTTLClampBoundsRevocation(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setExpiresAt(time.Now().UTC().Add(time.Hour).Format(time.RFC3339))
+	upstream := newFakeUpstream(t)
+	proxy, handle := newTestProxyWithHandle(t, broker, upstream)
+
+	var offset atomic.Int64
+	handle.Now = func() time.Time { return time.Now().Add(time.Duration(offset.Load())) }
+
+	response, err := http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if calls := broker.callCount(); calls != 1 {
+		t.Fatalf("expected 1 initial fetch, got %d", calls)
+	}
+
+	// Within the clamp: served from cache.
+	offset.Store(int64(maxCacheTTL / 2))
+	response, err = http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if calls := broker.callCount(); calls != 1 {
+		t.Fatalf("expected cache reuse inside the clamp, got %d fetches", calls)
+	}
+
+	// Past the clamp, credential still valid for ~1h: must refetch anyway.
+	offset.Store(int64(maxCacheTTL + time.Second))
+	response, err = http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if calls := broker.callCount(); calls != 2 {
+		t.Fatalf("expected refetch after the clamp despite long-lived credential, got %d fetches", calls)
+	}
+
+	// Revocation: the broker now denies; the next post-clamp request fails
+	// closed instead of riding the hour-long credential.
+	broker.setFail(true)
+	offset.Store(int64(2*maxCacheTTL + 2*time.Second))
+	response, err = http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("revoked grant must fail closed after the clamp, got %d", response.StatusCode)
+	}
+}
+
 // TestStreamingResponsePassthrough pins SSE behavior: the first event reaches
 // the client while the upstream is still holding the connection open.
 func TestStreamingResponsePassthrough(t *testing.T) {

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -371,6 +371,8 @@ providers:
     plugin: token
     config:
       token-env: TEST_PAT_TOKEN
+      injection-hosts:
+        - api.example.test
     allow:
       repositories:
         - my-user/my-repo

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -471,6 +471,69 @@ func TestInjectionComputesClaimDerivedHeaders(t *testing.T) {
 	}
 }
 
+// TestInjectionServesEveryProviderTypeWithInjectionHosts exercises one
+// injection fetch against every provider *type* that declares
+// injection-hosts. Providers are called with a shared positional signature
+// (host, method, path, agent_id, audit, request_id, grant); a provider
+// missing a parameter fails only at call time, invisible to type-specific
+// tests — static_token shipped broken exactly this way when the grant
+// parameter was added.
+func TestInjectionServesEveryProviderTypeWithInjectionHosts(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(map[string]roleIdentity{
+		"frontend": {
+			Token: "frontend-token",
+			Role:  "agent",
+			Grants: []roleGrant{
+				{Provider: "codex-main", Materialization: "header-inject"},
+				{Provider: "git-app", Materialization: "header-inject", Repositories: []string{"my-user/my-repo"}},
+				{Provider: "pat-provider", Materialization: "header-inject", Repositories: []string{"my-user/my-repo"}},
+			},
+		},
+		"frontend-egress": {
+			Token:       "frontend-egress-token",
+			Role:        "egress",
+			PairedAgent: "frontend",
+		},
+	})
+
+	cases := []struct {
+		capability string
+		host       string
+		method     string
+		path       string
+		wantPrefix string
+	}{
+		// codex-oauth
+		{"codex-main", "chatgpt.com", "POST", "/backend-api/responses", "Bearer "},
+		// github-app
+		{"git-app", "github.com", "GET", "/my-user/my-repo.git/info/refs", "Basic "},
+		// token (static bearer)
+		{"pat-provider", "api.example.test", "GET", "/v1/anything", "Bearer pat-secret"},
+	}
+	for _, tt := range cases {
+		payload := map[string]any{
+			"capability": tt.capability,
+			"host":       tt.host,
+			"method":     tt.method,
+			"path":       tt.path,
+		}
+		status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", payload)
+		if status != http.StatusOK || body["ok"] != true {
+			t.Fatalf("injection for provider type %s denied: status=%d body=%v", tt.capability, status, body)
+		}
+		headers, _ := body["headers"].(map[string]any)
+		value, _ := headers["authorization"].(string)
+		if !strings.HasPrefix(value, tt.wantPrefix) {
+			t.Fatalf("provider %s authorization = %q, want prefix %q", tt.capability, value, tt.wantPrefix)
+		}
+		strip, _ := body["strip_request_headers"].([]any)
+		if len(strip) == 0 {
+			t.Fatalf("provider %s returned no strip_request_headers: %v", tt.capability, body)
+		}
+	}
+}
+
 // TestInjectionAuditOmitsSecretValues pins the audit rule: injection requests
 // are audited with metadata only; header values never appear in the audit
 // log on allow or deny paths.


### PR DESCRIPTION
The two pre-Phase-5 bugs from `docs/phase5-enforcement-plan.md` ("Bugs found while planning"), shipped first per the plan's build order (item 0).

## What changed

- **`static_token.injection_headers` signature** — the Phase 4 server dispatch passes `grant` as a 7th argument; `codex_oauth` and `github_app` were updated but `static_token` was missed, making any injection fetch against a `token` provider a live `TypeError` (surfacing as a 500). Fixed, and pinned by a new conformance test (`TestInjectionServesEveryProviderTypeWithInjectionHosts`) that exercises one injection fetch against **every provider type declaring `injection-hosts`** (codex-oauth, github-app, token), so a future signature change cannot ship half-applied again.
- **egressd cache TTL clamp** — cached injectable material was valid until `expires_at − 30s`, so a revoked git grant kept working from cache for up to ~1h (the installation-token lifetime). New `maxCacheTTL` (60s) bounds cache reuse independent of credential expiry, separating credential validity from authorization-cache lifetime — the load-bearing piece of the Phase 5 revocation bound. Pinned by `TestCacheTTLClampBoundsRevocation`: hour-valid credential is refetched after the clamp, and a revoked grant fails closed on the first post-clamp request. Refetching is cheap: the broker caches minted tokens per (provider, repo, permissions) with its own buffer.

## Tests

- `tests/broker`: full suite green, including the new per-provider-type injection test (`pat-provider` gained `injection-hosts` in the fixture).
- `egressd`: full suite green, including the new clamp test; existing cache-reuse tests (`TestCacheReusedUntilExpiry`, `TestCacheKeyedByMethodAndPath`) unchanged and passing.