### PR TITLE
Phase 5 prerequisite: broker TLS in the chart

### DIFF
--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -1,5 +1,36 @@
 # nvt Helm Chart
 
+## Broker TLS
+
+The broker serves TLS by default. The egressd→broker leg carries real
+credentials through the agent Pod's network namespace, so mediated runs in a
+cluster must not depend on `spec.egressAllowInsecureBroker`:
+
+```yaml
+broker:
+  tls:
+    enabled: true
+    secretName: nvt-broker-tls
+    existingSecret: ""
+```
+
+When `existingSecret` is empty, the chart generates a self-signed CA and a
+serving cert for `nvt-broker.<namespace>.svc` into `secretName` at install
+time and preserves it across upgrades (`helm lookup`), so the trust anchor
+does not rotate on every `helm upgrade`. Note that `helm template | kubectl
+apply` bypasses `lookup` and regenerates the cert on every render — use
+`helm upgrade --install` (or `existingSecret`) for stable trust.
+
+Set `existingSecret` to bring your own cert (for example from cert-manager);
+it must be a `kubernetes.io/tls` Secret that also carries `ca.crt`. The chart
+points the operator at the Secret (`NVT_BROKER_CA_SECRET`) and switches the
+operator-rendered broker URL to `https://nvt-broker:7347`; the operator then
+projects only the `ca.crt` item into agent Pods (agent and egressd
+containers) — the serving key never leaves the broker.
+
+With `tls.enabled=false` the broker stays plaintext and mediated AgentRuns
+must set `spec.egressAllowInsecureBroker: true` explicitly (local/dev only).
+
 ## Broker State Persistence
 
 By default the broker keeps `/state` on an `emptyDir`, preserving existing

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -17,9 +17,15 @@ broker:
 When `existingSecret` is empty, the chart generates a self-signed CA and a
 serving cert for `nvt-broker.<namespace>.svc` into `secretName` at install
 time and preserves it across upgrades (`helm lookup`), so the trust anchor
-does not rotate on every `helm upgrade`. Note that `helm template | kubectl
-apply` bypasses `lookup` and regenerates the cert on every render — use
-`helm upgrade --install` (or `existingSecret`) for stable trust.
+does not rotate on every `helm upgrade`. The broker Deployment carries a
+`checksum/broker-tls` pod annotation derived from the same material, so the
+broker restarts exactly when the Secret changes. `helm template | kubectl
+apply` bypasses `lookup` and regenerates the cert on every render; the
+checksum tracks the regenerated material, so the broker restarts onto the
+newly applied cert — but every apply rotates the trust anchor and breaks
+in-flight mediated runs, so prefer `helm upgrade --install` (or
+`existingSecret`) for stable trust. Rotating an `existingSecret` out of band
+requires a manual `kubectl rollout restart deployment/nvt-broker`.
 
 Set `existingSecret` to bring your own cert (for example from cert-manager);
 it must be a `kubernetes.io/tls` Secret that also carries `ca.crt`. The chart

--- a/charts/nvt/templates/_helpers.tpl
+++ b/charts/nvt/templates/_helpers.tpl
@@ -78,20 +78,54 @@ app.kubernetes.io/component: gateway
 {{- end -}}
 
 {{- /*
+  The chart-managed broker TLS Secret data (base64 values, JSON-encoded):
+  an already-issued Secret is preserved via lookup so the trust anchor is
+  stable across upgrades; otherwise a fresh CA + serving cert is generated
+  ONCE per render and memoized on .Values, so every template that includes
+  this helper (the Secret and the Deployment checksum) sees the same
+  material — including under `helm template | kubectl apply`, where lookup
+  is unavailable and each render regenerates.
+*/ -}}
+{{- define "nvt.brokerTLSSecretData" -}}
+{{- $ns := include "nvt.namespace" . -}}
+{{- $name := include "nvt.brokerTLSSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" $ns $name -}}
+{{- if $existing -}}
+{{- dict "tls.crt" (index $existing.data "tls.crt") "tls.key" (index $existing.data "tls.key") "ca.crt" (index $existing.data "ca.crt") | toJson -}}
+{{- else -}}
+{{- $cache := .Values._generatedBrokerTLS -}}
+{{- if not $cache -}}
+{{- $altNames := list "nvt-broker" (printf "nvt-broker.%s" $ns) (printf "nvt-broker.%s.svc" $ns) (printf "nvt-broker.%s.svc.cluster.local" $ns) -}}
+{{- $ca := genCA "nvt-broker-ca" 3650 -}}
+{{- $cert := genSignedCert "nvt-broker" nil $altNames 3650 $ca -}}
+{{- $cache = dict "tls.crt" ($cert.Cert | b64enc) "tls.key" ($cert.Key | b64enc) "ca.crt" ($ca.Cert | b64enc) -}}
+{{- $_ := set .Values "_generatedBrokerTLS" $cache -}}
+{{- end -}}
+{{- $cache | toJson -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
   Restart trigger for the broker Deployment: the broker loads its TLS
-  cert/key once at startup, so the pod template must change when the Secret
-  material changes. `lookup` returns the live Secret on real installs, making
-  the checksum stable across upgrades that keep the same material and
-  changing it when the material rotates. When lookup is unavailable (fresh
-  install, `helm template`), fall back to hashing the configured name — any
-  value works pre-install, and name changes still force a restart.
+  cert/key once at startup, so the pod template must change exactly when the
+  Secret material changes. For the chart-managed Secret the checksum hashes
+  the same memoized material the Secret template renders, so it is stable
+  across material-preserving upgrades and changes whenever the rendered
+  material does (including `helm template | kubectl apply` regeneration).
+  For existingSecret the material is not rendered by the chart: hash the
+  live Secret when lookup can see it, else the name. Out-of-band rotation of
+  an existingSecret between upgrades still needs a manual
+  `kubectl rollout restart deployment/nvt-broker`.
 */ -}}
 {{- define "nvt.brokerTLSChecksum" -}}
-{{- $name := include "nvt.brokerTLSSecretName" . -}}
-{{- $existing := lookup "v1" "Secret" (include "nvt.namespace" .) $name -}}
+{{- if .Values.broker.tls.existingSecret -}}
+{{- $existing := lookup "v1" "Secret" (include "nvt.namespace" .) .Values.broker.tls.existingSecret -}}
 {{- if $existing -}}
 {{- $existing.data | toJson | sha256sum -}}
 {{- else -}}
-{{- $name | sha256sum -}}
+{{- .Values.broker.tls.existingSecret | sha256sum -}}
+{{- end -}}
+{{- else -}}
+{{- include "nvt.brokerTLSSecretData" . | sha256sum -}}
 {{- end -}}
 {{- end -}}

--- a/charts/nvt/templates/_helpers.tpl
+++ b/charts/nvt/templates/_helpers.tpl
@@ -66,3 +66,32 @@ app.kubernetes.io/component: gateway
 app.kubernetes.io/name: nvt-agent-gateway
 app.kubernetes.io/component: gateway
 {{- end -}}
+
+{{- /*
+  Single source of truth for the broker TLS Secret name: a non-empty
+  existingSecret wins, otherwise the chart-managed secretName. Every template
+  that references the broker TLS Secret must use this helper so the broker
+  can never serve one Secret while the operator projects another.
+*/ -}}
+{{- define "nvt.brokerTLSSecretName" -}}
+{{- default .Values.broker.tls.secretName .Values.broker.tls.existingSecret -}}
+{{- end -}}
+
+{{- /*
+  Restart trigger for the broker Deployment: the broker loads its TLS
+  cert/key once at startup, so the pod template must change when the Secret
+  material changes. `lookup` returns the live Secret on real installs, making
+  the checksum stable across upgrades that keep the same material and
+  changing it when the material rotates. When lookup is unavailable (fresh
+  install, `helm template`), fall back to hashing the configured name — any
+  value works pre-install, and name changes still force a restart.
+*/ -}}
+{{- define "nvt.brokerTLSChecksum" -}}
+{{- $name := include "nvt.brokerTLSSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" (include "nvt.namespace" .) $name -}}
+{{- if $existing -}}
+{{- $existing.data | toJson | sha256sum -}}
+{{- else -}}
+{{- $name | sha256sum -}}
+{{- end -}}
+{{- end -}}

--- a/charts/nvt/templates/broker-deployment.yaml
+++ b/charts/nvt/templates/broker-deployment.yaml
@@ -19,6 +19,12 @@ spec:
       {{- include "nvt.brokerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if .Values.broker.tls.enabled }}
+      annotations:
+        # The broker loads its TLS cert/key once at startup; this checksum
+        # restarts it when the TLS Secret material (or name) changes.
+        checksum/broker-tls: {{ include "nvt.brokerTLSChecksum" . | quote }}
+      {{- end }}
       labels:
         {{- include "nvt.brokerSelectorLabels" . | nindent 8 }}
     spec:
@@ -90,7 +96,7 @@ spec:
         {{- if .Values.broker.tls.enabled }}
         - name: broker-tls
           secret:
-            secretName: {{ default .Values.broker.tls.secretName .Values.broker.tls.existingSecret | quote }}
+            secretName: {{ include "nvt.brokerTLSSecretName" . | quote }}
         {{- end }}
         - name: broker-config
           projected:

--- a/charts/nvt/templates/broker-deployment.yaml
+++ b/charts/nvt/templates/broker-deployment.yaml
@@ -64,6 +64,12 @@ spec:
               value: /config/agents.yaml
             - name: NVT_BROKER_AUDIT_LOG
               value: /state/audit.jsonl
+            {{- if .Values.broker.tls.enabled }}
+            - name: NVT_BROKER_TLS_CERT
+              value: /tls/tls.crt
+            - name: NVT_BROKER_TLS_KEY
+              value: /tls/tls.key
+            {{- end }}
           {{- if .Values.broker.envSecretName }}
           envFrom:
             - secretRef:
@@ -75,7 +81,17 @@ spec:
               readOnly: true
             - name: broker-state
               mountPath: /state
+            {{- if .Values.broker.tls.enabled }}
+            - name: broker-tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
       volumes:
+        {{- if .Values.broker.tls.enabled }}
+        - name: broker-tls
+          secret:
+            secretName: {{ default .Values.broker.tls.secretName .Values.broker.tls.existingSecret | quote }}
+        {{- end }}
         - name: broker-config
           projected:
             sources:

--- a/charts/nvt/templates/broker-tls-secret.yaml
+++ b/charts/nvt/templates/broker-tls-secret.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.broker.enabled .Values.broker.tls.enabled (not .Values.broker.tls.existingSecret) }}
+{{- $ns := include "nvt.namespace" . }}
+{{- $secretName := .Values.broker.tls.secretName }}
+{{- /*
+  Preserve an already-issued cert across upgrades so egressd/agent trust
+  anchors do not rotate on every `helm upgrade`. `lookup` returns nil during
+  `helm template` (no API server), so rendering always generates a fresh cert
+  — fine, since template output is never applied.
+*/}}
+{{- $existing := lookup "v1" "Secret" $ns $secretName }}
+{{- if $existing }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "nvt.brokerLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ index $existing.data "tls.crt" }}
+  tls.key: {{ index $existing.data "tls.key" }}
+  ca.crt: {{ index $existing.data "ca.crt" }}
+{{- else }}
+{{- $altNames := list "nvt-broker" (printf "nvt-broker.%s" $ns) (printf "nvt-broker.%s.svc" $ns) (printf "nvt-broker.%s.svc.cluster.local" $ns) }}
+{{- $ca := genCA "nvt-broker-ca" 3650 }}
+{{- $cert := genSignedCert "nvt-broker" nil $altNames 3650 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "nvt.brokerLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/nvt/templates/broker-tls-secret.yaml
+++ b/charts/nvt/templates/broker-tls-secret.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.broker.enabled .Values.broker.tls.enabled (not .Values.broker.tls.existingSecret) }}
 {{- $ns := include "nvt.namespace" . }}
-{{- $secretName := .Values.broker.tls.secretName }}
+{{- $secretName := include "nvt.brokerTLSSecretName" . }}
 {{- /*
   Preserve an already-issued cert across upgrades so egressd/agent trust
   anchors do not rotate on every `helm upgrade`. `lookup` returns nil during

--- a/charts/nvt/templates/broker-tls-secret.yaml
+++ b/charts/nvt/templates/broker-tls-secret.yaml
@@ -1,41 +1,23 @@
 {{- if and .Values.broker.enabled .Values.broker.tls.enabled (not .Values.broker.tls.existingSecret) }}
-{{- $ns := include "nvt.namespace" . }}
-{{- $secretName := include "nvt.brokerTLSSecretName" . }}
 {{- /*
-  Preserve an already-issued cert across upgrades so egressd/agent trust
-  anchors do not rotate on every `helm upgrade`. `lookup` returns nil during
-  `helm template` (no API server), so rendering always generates a fresh cert
-  — fine, since template output is never applied.
+  Data comes from nvt.brokerTLSSecretData: an already-issued Secret is
+  preserved across upgrades (lookup) so egressd/agent trust anchors do not
+  rotate on every `helm upgrade`; otherwise a fresh CA + serving cert is
+  generated once per render and shared with the broker Deployment's
+  checksum annotation, so a `helm template | kubectl apply` rotation also
+  restarts the broker onto the newly applied material.
 */}}
-{{- $existing := lookup "v1" "Secret" $ns $secretName }}
-{{- if $existing }}
+{{- $data := include "nvt.brokerTLSSecretData" . | fromJson }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName | quote }}
-  namespace: {{ $ns | quote }}
+  name: {{ include "nvt.brokerTLSSecretName" . | quote }}
+  namespace: {{ include "nvt.namespace" . | quote }}
   labels:
     {{- include "nvt.brokerLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ index $existing.data "tls.crt" }}
-  tls.key: {{ index $existing.data "tls.key" }}
-  ca.crt: {{ index $existing.data "ca.crt" }}
-{{- else }}
-{{- $altNames := list "nvt-broker" (printf "nvt-broker.%s" $ns) (printf "nvt-broker.%s.svc" $ns) (printf "nvt-broker.%s.svc.cluster.local" $ns) }}
-{{- $ca := genCA "nvt-broker-ca" 3650 }}
-{{- $cert := genSignedCert "nvt-broker" nil $altNames 3650 $ca }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $secretName | quote }}
-  namespace: {{ $ns | quote }}
-  labels:
-    {{- include "nvt.brokerLabels" . | nindent 4 }}
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ $cert.Cert | b64enc }}
-  tls.key: {{ $cert.Key | b64enc }}
-  ca.crt: {{ $ca.Cert | b64enc }}
-{{- end }}
+  tls.crt: {{ index $data "tls.crt" }}
+  tls.key: {{ index $data "tls.key" }}
+  ca.crt: {{ index $data "ca.crt" }}
 {{- end }}

--- a/charts/nvt/templates/operator-deployment.yaml
+++ b/charts/nvt/templates/operator-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: NVT_BROKER_URL
               value: "https://nvt-broker:7347"
             - name: NVT_BROKER_CA_SECRET
-              value: {{ default .Values.broker.tls.secretName .Values.broker.tls.existingSecret | quote }}
+              value: {{ include "nvt.brokerTLSSecretName" . | quote }}
             {{- end }}
           ports:
             - name: metrics

--- a/charts/nvt/templates/operator-deployment.yaml
+++ b/charts/nvt/templates/operator-deployment.yaml
@@ -31,6 +31,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: NVT_EGRESSD_IMAGE
               value: {{ .Values.egress.egressdImage | quote }}
+            {{- if and .Values.broker.enabled .Values.broker.tls.enabled }}
+            - name: NVT_BROKER_URL
+              value: "https://nvt-broker:7347"
+            - name: NVT_BROKER_CA_SECRET
+              value: {{ default .Values.broker.tls.secretName .Values.broker.tls.existingSecret | quote }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/nvt/values.yaml
+++ b/charts/nvt/values.yaml
@@ -12,6 +12,16 @@ broker:
   enabled: true
   image: nvt-broker:latest
   envSecretName: ""
+  tls:
+    # Serve the broker over TLS. The egressd->broker leg carries real
+    # credentials through the agent's network namespace, so mediated
+    # production runs require it (mediated-egress-plan.md §2). When enabled
+    # and no existingSecret is given, the chart generates a self-signed CA +
+    # serving cert into secretName (preserved across upgrades). The CA cert
+    # is public material distributed to egressd and the agent by the operator.
+    enabled: true
+    secretName: nvt-broker-tls
+    existingSecret: ""
   persistence:
     enabled: false
     size: 1Gi

--- a/docs/phase5-enforcement-plan.md
+++ b/docs/phase5-enforcement-plan.md
@@ -1,6 +1,6 @@
 # Phase 5 Plan: Egress Enforcement + Audit + Quotas + Revocation
 
-Status: plan — implementation not started
+Status: prerequisite PR (broker TLS in the chart) in progress; 6a/6b not started
 Parent: [mediated-egress-plan.md](mediated-egress-plan.md) §6, §7, Phase 5 (PRs 6a/6b in the sequence table)
 
 ## Goal

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -44,6 +44,11 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	if err := controller.ValidateBrokerTLSConfig(); err != nil {
+		ctrl.Log.Error(err, "invalid broker TLS configuration")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Cache:                  managerCacheOptions(),

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -49,7 +49,17 @@ const (
 	workspaceMountPath    = "/workspace"
 	initialPromptPlugin   = "initial-prompt"
 
-	brokerURL                  = "http://nvt-broker:7347"
+	defaultBrokerURL = "http://nvt-broker:7347"
+	// brokerCAVolumeName carries the broker's CA certificate (public) into
+	// the egressd and agent containers so both can verify the TLS broker leg.
+	// Only the ca.crt item is projected from the TLS Secret — the serving key
+	// never enters the agent Pod.
+	brokerCAVolumeName         = "broker-ca"
+	brokerCAKey                = "ca.crt"
+	egressdBrokerCAMount       = "/etc/nvt-egressd/broker-ca"
+	egressdBrokerCAFile        = egressdBrokerCAMount + "/" + brokerCAKey
+	agentBrokerCAMount         = "/etc/nvt-broker-ca"
+	agentBrokerCAFile          = agentBrokerCAMount + "/" + brokerCAKey
 	brokerAgentsConfigMapName  = "nvt-broker-agents"
 	brokerAgentsConfigKey      = "agents.yaml"
 	brokerTokenKey             = "NVT_BROKER_TOKEN"
@@ -701,6 +711,7 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 	type egressdConfig struct {
 		BrokerURL           string         `json:"broker_url"`
 		AllowInsecureBroker bool           `json:"allow_insecure_broker"`
+		BrokerCAFile        string         `json:"broker_ca_file,omitempty"`
 		Routes              []egressdRoute `json:"routes"`
 		CA                  *egressdCA     `json:"ca,omitempty"`
 	}
@@ -731,9 +742,15 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 		routeIndex++
 	}
 	config := egressdConfig{
-		BrokerURL:           brokerURL,
+		BrokerURL:           BrokerURL(),
 		AllowInsecureBroker: agentRun.Spec.EgressAllowInsecureBroker,
 		Routes:              routes,
+	}
+	if brokerCADistributed() {
+		// TLS broker leg: pin the CA so egressd verifies the broker instead
+		// of relying on the insecure flag.
+		config.BrokerCAFile = egressdBrokerCAFile
+		config.AllowInsecureBroker = false
 	}
 	if needCA {
 		config.CA = &egressdCA{PublishDir: egressCAMountPath}
@@ -776,6 +793,26 @@ func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*c
 		},
 	}
 	hasGitGrant := agentRunHasGitGrant(agentRun)
+	if brokerCADistributed() {
+		// The agent talks to the broker in both egress modes (brokerctl), so
+		// the CA rides along whenever the broker leg is TLS.
+		volumes = append(volumes, corev1.Volume{
+			Name: brokerCAVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: BrokerCASecretName(),
+					Items: []corev1.KeyToPath{
+						{Key: brokerCAKey, Path: brokerCAKey},
+					},
+				},
+			},
+		})
+		agentVolumeMounts = append(agentVolumeMounts, corev1.VolumeMount{
+			Name:      brokerCAVolumeName,
+			MountPath: agentBrokerCAMount,
+			ReadOnly:  true,
+		})
+	}
 	if AgentRunEgressMode(agentRun) == nvtv1alpha1.AgentRunEgressMediated {
 		volumes = append(volumes, corev1.Volume{
 			Name: "egressd-config",
@@ -879,7 +916,7 @@ func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*c
 				{Name: "DOCKER_HOST", Value: "tcp://127.0.0.1:2375"},
 				{Name: "NVT_WORKSPACE", Value: workspaceMountPath},
 				{Name: "NVT_AGENT_CONFIG_FILE", Value: agentConfigMountPath},
-				{Name: "NVT_BROKER_URL", Value: brokerURL},
+				{Name: "NVT_BROKER_URL", Value: BrokerURL()},
 				{
 					Name: brokerTokenKey,
 					ValueFrom: &corev1.EnvVarSource{
@@ -908,9 +945,19 @@ func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*c
 			containers[0].Env = append(containers[0].Env, corev1.EnvVar{Name: "NVT_EGRESS_CA_FILE", Value: egressCAFilePath})
 		}
 	}
+	if brokerCADistributed() {
+		containers[0].Env = append(containers[0].Env, corev1.EnvVar{Name: "NVT_BROKER_CA_FILE", Value: agentBrokerCAFile})
+	}
 	if AgentRunEgressMode(agentRun) == nvtv1alpha1.AgentRunEgressMediated {
 		egressdVolumeMounts := []corev1.VolumeMount{
 			{Name: "egressd-config", MountPath: egressdConfigPath, SubPath: egressdConfigKey, ReadOnly: true},
+		}
+		if brokerCADistributed() {
+			egressdVolumeMounts = append(egressdVolumeMounts, corev1.VolumeMount{
+				Name:      brokerCAVolumeName,
+				MountPath: egressdBrokerCAMount,
+				ReadOnly:  true,
+			})
 		}
 		if hasGitGrant {
 			egressdVolumeMounts = append(egressdVolumeMounts, corev1.VolumeMount{
@@ -924,7 +971,7 @@ func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*c
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env: []corev1.EnvVar{
 				{Name: "NVT_EGRESSD_CONFIG", Value: egressdConfigPath},
-				{Name: "NVT_BROKER_URL", Value: brokerURL},
+				{Name: "NVT_BROKER_URL", Value: BrokerURL()},
 				{
 					Name: "NVT_BROKER_TOKEN",
 					ValueFrom: &corev1.EnvVarSource{
@@ -1020,6 +1067,36 @@ func EgressdImage() string {
 	return defaultEgressdImage
 }
 
+// BrokerURL is the broker base URL the operator wires into agent and egressd
+// containers. The chart sets NVT_BROKER_URL=https://nvt-broker:7347 when
+// broker TLS is enabled; the default stays plaintext so local/dev setups and
+// existing deployments are unchanged.
+func BrokerURL() string {
+	if url := strings.TrimSpace(os.Getenv("NVT_BROKER_URL")); url != "" {
+		return url
+	}
+	return defaultBrokerURL
+}
+
+// brokerIsTLS reports whether the broker leg is https, which requires the CA
+// certificate to be distributed to egressd and the agent.
+func brokerIsTLS() bool {
+	return strings.HasPrefix(BrokerURL(), "https://")
+}
+
+// BrokerCASecretName is the Secret holding the broker's CA certificate
+// (public material, key ca.crt). Empty means none configured.
+func BrokerCASecretName() string {
+	return strings.TrimSpace(os.Getenv("NVT_BROKER_CA_SECRET"))
+}
+
+// brokerCADistributed reports whether the operator both talks TLS to the
+// broker and knows which Secret carries the CA — the precondition for
+// mounting it and rendering broker_ca_file.
+func brokerCADistributed() bool {
+	return brokerIsTLS() && BrokerCASecretName() != ""
+}
+
 // AgentRunBrokerID returns the broker identity for an AgentRun.
 func AgentRunBrokerID(namespace, name string) string {
 	return namespace + "/" + name
@@ -1060,7 +1137,7 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 		if agentRun.Spec.RuntimeAuth != nil {
 			return fmt.Errorf("egress mediated is incompatible with spec.runtimeAuth")
 		}
-		if strings.HasPrefix(brokerURL, "http://") && !agentRun.Spec.EgressAllowInsecureBroker {
+		if strings.HasPrefix(BrokerURL(), "http://") && !agentRun.Spec.EgressAllowInsecureBroker {
 			return fmt.Errorf("egress mediated with plaintext broker requires spec.egressAllowInsecureBroker=true for local/dev use")
 		}
 	}

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -128,11 +128,23 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if IsTerminalAgentRunPhase(agentRun.Status.Phase) {
 		return r.reconcileTerminalPodCleanup(ctx, &agentRun)
 	}
-	if err := ValidateAgentRunEgressMode(&agentRun); err != nil {
-		if setErr := r.setAgentRunFailed(ctx, &agentRun, err.Error()); setErr != nil {
-			return ctrl.Result{}, setErr
+	existingPod, err := r.getOwnedAgentPod(ctx, &agentRun)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if existingPod == nil {
+		// Egress/TLS validation applies at creation time only: operator
+		// broker env changes must not retroactively fail runs whose Pod
+		// already exists with the old wiring.
+		if err := ValidateAgentRunEgressMode(&agentRun); err != nil {
+			if setErr := r.setAgentRunFailed(ctx, &agentRun, err.Error()); setErr != nil {
+				return ctrl.Result{}, setErr
+			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, nil
+		if err := r.validateBrokerCASecret(ctx, &agentRun); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	deadlineResult, deadlineExceeded, err := r.reconcileActiveDeadline(ctx, &agentRun)
 	if deadlineExceeded || err != nil {
@@ -151,16 +163,19 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err := r.reconcileCallbackTokenSecret(ctx, &agentRun); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.reconcileEgressdConfigMap(ctx, &agentRun); err != nil {
+	if err := r.reconcileEgressdConfigMap(ctx, &agentRun, existingPod != nil); err != nil {
 		return ctrl.Result{}, err
 	}
 	if err := r.reconcileBrokerAgentsPolicy(ctx, &agentRun); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	pod, err := r.reconcileAgentPod(ctx, &agentRun)
-	if err != nil {
-		return ctrl.Result{}, err
+	pod := existingPod
+	if pod == nil {
+		pod, err = r.createAgentPod(ctx, &agentRun)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	statusChanged := InitializeAgentRunStatus(&agentRun)
@@ -362,20 +377,29 @@ func (r *AgentRunReconciler) reconcileAgentConfigMap(ctx context.Context, agentR
 	return nil
 }
 
-func (r *AgentRunReconciler) reconcileEgressdConfigMap(ctx context.Context, agentRun *nvtv1alpha1.AgentRun) error {
+func (r *AgentRunReconciler) reconcileEgressdConfigMap(ctx context.Context, agentRun *nvtv1alpha1.AgentRun, podExists bool) error {
 	if AgentRunEgressMode(agentRun) != nvtv1alpha1.AgentRunEgressMediated {
 		return nil
 	}
-	desired, err := DesiredEgressdConfigMap(agentRun, r.Scheme)
-	if err != nil {
-		return err
-	}
 	configMap := &corev1.ConfigMap{}
-	err = r.Get(ctx, client.ObjectKeyFromObject(desired), configMap)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("get AgentRun egressd config ConfigMap: %w", err)
+	err := r.Get(ctx, client.ObjectKey{Namespace: agentRun.Namespace, Name: EgressdConfigMapName(agentRun.Name)}, configMap)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("get AgentRun egressd config ConfigMap: %w", err)
+	}
+	if err == nil && podExists {
+		// Never rewrite egressd config under an existing Pod: the Pod's
+		// mounts were rendered against this config, and operator broker env
+		// changes must not retarget a running run.
+		if !metav1.IsControlledBy(configMap, agentRun) {
+			return fmt.Errorf("AgentRun egressd config ConfigMap %s/%s exists but is not controlled by AgentRun %s", configMap.Namespace, configMap.Name, agentRun.Name)
 		}
+		return nil
+	}
+	desired, err2 := DesiredEgressdConfigMap(agentRun, r.Scheme)
+	if err2 != nil {
+		return err2
+	}
+	if err != nil {
 		if createErr := r.Create(ctx, desired); createErr != nil {
 			return fmt.Errorf("create AgentRun egressd config ConfigMap: %w", createErr)
 		}
@@ -590,30 +614,57 @@ func (r *AgentRunReconciler) setAgentRunFailed(ctx context.Context, agentRun *nv
 	})
 }
 
-func (r *AgentRunReconciler) reconcileAgentPod(ctx context.Context, agentRun *nvtv1alpha1.AgentRun) (*corev1.Pod, error) {
+// createAgentPod renders and creates the AgentRun Pod; the caller has already
+// established that no Pod exists.
+func (r *AgentRunReconciler) createAgentPod(ctx context.Context, agentRun *nvtv1alpha1.AgentRun) (*corev1.Pod, error) {
+	// Pods are create-once for this slice because most spec fields are immutable.
+	// A future replacement policy can decide how to handle spec changes.
 	desired, err := DesiredAgentPod(agentRun, r.Scheme)
 	if err != nil {
 		return nil, err
 	}
+	if createErr := r.Create(ctx, desired); createErr != nil {
+		return nil, fmt.Errorf("create AgentRun Pod: %w", createErr)
+	}
+	return desired, nil
+}
 
-	// Pods are create-once for this slice because most spec fields are immutable.
-	// A future replacement policy can decide how to handle spec changes.
+// getOwnedAgentPod returns the AgentRun's Pod, nil when it does not exist yet.
+func (r *AgentRunReconciler) getOwnedAgentPod(ctx context.Context, agentRun *nvtv1alpha1.AgentRun) (*corev1.Pod, error) {
 	pod := &corev1.Pod{}
-	key := client.ObjectKeyFromObject(desired)
+	key := client.ObjectKey{Namespace: agentRun.Namespace, Name: AgentPodName(agentRun.Name)}
 	if err := r.Get(ctx, key, pod); err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("get AgentRun Pod: %w", err)
+		if errors.IsNotFound(err) {
+			return nil, nil
 		}
-		if createErr := r.Create(ctx, desired); createErr != nil {
-			return nil, fmt.Errorf("create AgentRun Pod: %w", createErr)
-		}
-		return desired, nil
+		return nil, fmt.Errorf("get AgentRun Pod: %w", err)
 	}
 	if !metav1.IsControlledBy(pod, agentRun) {
 		return nil, fmt.Errorf("AgentRun Pod %s/%s exists but is not controlled by AgentRun %s", pod.Namespace, pod.Name, agentRun.Name)
 	}
-
 	return pod, nil
+}
+
+// validateBrokerCASecret ensures the configured broker CA Secret exists in
+// the AgentRun namespace and carries ca.crt before any Pod mounts it: the
+// Pod projects ca.crt non-optionally, so a bring-your-own TLS Secret without
+// that key would wedge every agent Pod in FailedMount.
+func (r *AgentRunReconciler) validateBrokerCASecret(ctx context.Context, agentRun *nvtv1alpha1.AgentRun) error {
+	if !brokerCADistributed() {
+		return nil
+	}
+	name := BrokerCASecretName()
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: agentRun.Namespace, Name: name}, secret); err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("broker CA Secret %s/%s not found: broker TLS requires a Secret carrying the CA certificate under key %s", agentRun.Namespace, name, brokerCAKey)
+		}
+		return fmt.Errorf("get broker CA Secret %s/%s: %w", agentRun.Namespace, name, err)
+	}
+	if len(secret.Data[brokerCAKey]) == 0 {
+		return fmt.Errorf("broker CA Secret %s/%s is missing key %s: bring-your-own broker TLS Secrets must include the CA certificate", agentRun.Namespace, name, brokerCAKey)
+	}
+	return nil
 }
 
 // DesiredTokenSecret returns an owned token Secret, preserving an existing token when present.
@@ -715,6 +766,9 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 		Routes              []egressdRoute `json:"routes"`
 		CA                  *egressdCA     `json:"ca,omitempty"`
 	}
+	if err := ValidateBrokerTLSConfig(); err != nil {
+		return "", err
+	}
 	grants := AgentRunBrokerGrants(agentRun.Spec.Broker)
 	routes := make([]egressdRoute, 0, len(grants))
 	routeIndex := 0
@@ -764,6 +818,9 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 
 // DesiredAgentPod returns the create-once Pod spec for an AgentRun.
 func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*corev1.Pod, error) {
+	if err := ValidateBrokerTLSConfig(); err != nil {
+		return nil, err
+	}
 	runtimeAuthMountPath, err := RuntimeAuthMountPath(agentRun)
 	if err != nil {
 		return nil, err
@@ -970,8 +1027,9 @@ func DesiredAgentPod(agentRun *nvtv1alpha1.AgentRun, scheme *runtime.Scheme) (*c
 			Image:           EgressdImage(),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env: []corev1.EnvVar{
+				// egressd reads the broker URL from its JSON config
+				// (broker_url), not from the environment.
 				{Name: "NVT_EGRESSD_CONFIG", Value: egressdConfigPath},
-				{Name: "NVT_BROKER_URL", Value: BrokerURL()},
 				{
 					Name: "NVT_BROKER_TOKEN",
 					ValueFrom: &corev1.EnvVarSource{
@@ -1097,6 +1155,20 @@ func brokerCADistributed() bool {
 	return brokerIsTLS() && BrokerCASecretName() != ""
 }
 
+// ValidateBrokerTLSConfig rejects the half-configured TLS state: an https
+// broker URL with no CA Secret would render Pods whose brokerctl/egressd
+// calls all fail TLS verification at runtime. Checked at operator startup
+// and again on every render/validation path as defense in depth.
+func ValidateBrokerTLSConfig() error {
+	if brokerIsTLS() && BrokerCASecretName() == "" {
+		return fmt.Errorf(
+			"NVT_BROKER_URL %s is https but NVT_BROKER_CA_SECRET is not set; agent Pods need the broker CA Secret (key %s) to verify the broker",
+			BrokerURL(), brokerCAKey,
+		)
+	}
+	return nil
+}
+
 // AgentRunBrokerID returns the broker identity for an AgentRun.
 func AgentRunBrokerID(namespace, name string) string {
 	return namespace + "/" + name
@@ -1128,6 +1200,9 @@ func AgentRunGrantMaterialization(grant nvtv1alpha1.AgentRunBrokerGrant) nvtv1al
 }
 
 func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
+	if err := ValidateBrokerTLSConfig(); err != nil {
+		return err
+	}
 	mode := AgentRunEgressMode(agentRun)
 	if mode != nvtv1alpha1.AgentRunEgressDirect && mode != nvtv1alpha1.AgentRunEgressMediated {
 		return fmt.Errorf("spec.egress must be direct or mediated, got %q", mode)

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -779,8 +780,9 @@ func TestTLSBrokerMediatedPodMountsBrokerCA(t *testing.T) {
 
 	egressd := requireContainer(t, *pod, "egressd")
 	assertVolumeMount(t, egressd, brokerCAVolumeName, egressdBrokerCAMount, "", true)
-	if envValue(egressd, "NVT_BROKER_URL") != "https://nvt-broker:7347" {
-		t.Fatalf("expected https broker URL on egressd, got %#v", egressd.Env)
+	// egressd takes the broker URL from its JSON config, not the environment.
+	if findEnvVar(egressd, "NVT_BROKER_URL") != nil {
+		t.Fatalf("egressd must not carry NVT_BROKER_URL env: %#v", egressd.Env)
 	}
 }
 
@@ -845,6 +847,136 @@ func TestTLSBrokerValidationAcceptsMediatedWithoutInsecureFlag(t *testing.T) {
 	agentRun.Spec.EgressAllowInsecureBroker = false
 	if err := ValidateAgentRunEgressMode(agentRun); err != nil {
 		t.Fatalf("mediated over TLS broker must not require egressAllowInsecureBroker, got %v", err)
+	}
+}
+
+func TestBrokerTLSConfigRejectsHTTPSWithoutCASecret(t *testing.T) {
+	t.Setenv("NVT_BROKER_URL", "https://nvt-broker:7347")
+	t.Setenv("NVT_BROKER_CA_SECRET", "")
+	if err := ValidateBrokerTLSConfig(); err == nil || !strings.Contains(err.Error(), "NVT_BROKER_CA_SECRET") {
+		t.Fatalf("expected https-without-CA-secret rejection, got %v", err)
+	}
+	if err := ValidateAgentRunEgressMode(testAgentRun()); err == nil || !strings.Contains(err.Error(), "NVT_BROKER_CA_SECRET") {
+		t.Fatalf("expected validation rejection, got %v", err)
+	}
+	if _, err := RenderEgressdConfigJSON(multiGrantMediatedAgentRun()); err == nil || !strings.Contains(err.Error(), "NVT_BROKER_CA_SECRET") {
+		t.Fatalf("expected egressd render rejection, got %v", err)
+	}
+	if _, err := DesiredAgentPod(testAgentRun(), testScheme(t)); err == nil || !strings.Contains(err.Error(), "NVT_BROKER_CA_SECRET") {
+		t.Fatalf("expected pod render rejection, got %v", err)
+	}
+}
+
+func testBrokerCASecret(namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "nvt-broker-tls", Namespace: namespace},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       data,
+	}
+}
+
+func TestReconcileRejectsMissingBrokerCASecret(t *testing.T) {
+	setTLSBrokerEnv(t)
+	ctx := context.Background()
+	scheme := testScheme(t)
+	agentRun := multiGrantMediatedAgentRun()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentRun{}).
+		WithObjects(agentRun, testBrokerAgentsConfigMap(agentRun.Namespace)).
+		Build()
+	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme}
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)})
+	if err == nil || !strings.Contains(err.Error(), "broker CA Secret") || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected missing broker CA Secret error, got %v", err)
+	}
+	assertAgentPodMissing(ctx, t, k8sClient, agentRun)
+}
+
+func TestReconcileRejectsBrokerCASecretWithoutCACrt(t *testing.T) {
+	setTLSBrokerEnv(t)
+	ctx := context.Background()
+	scheme := testScheme(t)
+	agentRun := multiGrantMediatedAgentRun()
+	caSecret := testBrokerCASecret(agentRun.Namespace, map[string][]byte{
+		"tls.crt": []byte("fixture-cert"),
+		"tls.key": []byte("fixture-key"),
+	})
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentRun{}).
+		WithObjects(agentRun, caSecret, testBrokerAgentsConfigMap(agentRun.Namespace)).
+		Build()
+	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme}
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)})
+	if err == nil || !strings.Contains(err.Error(), "missing key ca.crt") {
+		t.Fatalf("expected ca.crt-missing error naming the key, got %v", err)
+	}
+	assertAgentPodMissing(ctx, t, k8sClient, agentRun)
+}
+
+func TestReconcileTLSBrokerCreatesPodWhenCASecretValid(t *testing.T) {
+	setTLSBrokerEnv(t)
+	ctx := context.Background()
+	scheme := testScheme(t)
+	agentRun := multiGrantMediatedAgentRun()
+	caSecret := testBrokerCASecret(agentRun.Namespace, map[string][]byte{brokerCAKey: []byte("fixture-ca")})
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentRun{}).
+		WithObjects(agentRun, caSecret, testBrokerAgentsConfigMap(agentRun.Namespace)).
+		Build()
+	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var pod corev1.Pod
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentRun.Namespace, Name: AgentPodName(agentRun.Name)}, &pod); err != nil {
+		t.Fatalf("expected agent Pod, got %v", err)
+	}
+	requireVolume(t, pod, brokerCAVolumeName)
+}
+
+func TestReconcileDoesNotRetroactivelyRewriteRunningRuns(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	agentRun := multiGrantMediatedAgentRun()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentRun{}).
+		WithObjects(agentRun, testBrokerAgentsConfigMap(agentRun.Namespace)).
+		Build()
+	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme}
+	// First reconcile on the plaintext broker: creates Pod and egressd config.
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var before corev1.ConfigMap
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentRun.Namespace, Name: EgressdConfigMapName(agentRun.Name)}, &before); err != nil {
+		t.Fatalf("expected egressd ConfigMap, got %v", err)
+	}
+
+	// Operator broker env flips to TLS (even half-configured, with no CA
+	// Secret): the running run must be left alone — no failure, no config
+	// rewrite, no pod churn.
+	setTLSBrokerEnv(t)
+	t.Setenv("NVT_BROKER_CA_SECRET", "")
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)}); err != nil {
+		t.Fatalf("reconcile after broker env change: %v", err)
+	}
+	var updated nvtv1alpha1.AgentRun
+	if err := k8sClient.Get(ctx, clientKey(agentRun), &updated); err != nil {
+		t.Fatalf("get AgentRun: %v", err)
+	}
+	if updated.Status.Phase == nvtv1alpha1.AgentRunPhaseFailed {
+		t.Fatalf("broker env change retroactively failed a running run")
+	}
+	var after corev1.ConfigMap
+	if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentRun.Namespace, Name: EgressdConfigMapName(agentRun.Name)}, &after); err != nil {
+		t.Fatalf("get egressd ConfigMap: %v", err)
+	}
+	if !reflect.DeepEqual(before.Data, after.Data) {
+		t.Fatalf("egressd config rewritten under an existing Pod:\nbefore: %v\nafter: %v", before.Data, after.Data)
 	}
 }
 

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -168,8 +168,8 @@ func TestReconcileCreatesAgentPod(t *testing.T) {
 	if envValue(agentContainer, "NVT_AGENT_CONFIG_FILE") != agentConfigMountPath {
 		t.Fatalf("expected NVT_AGENT_CONFIG_FILE %q, got %#v", agentConfigMountPath, agentContainer.Env)
 	}
-	if envValue(agentContainer, "NVT_BROKER_URL") != brokerURL {
-		t.Fatalf("expected NVT_BROKER_URL %q, got %#v", brokerURL, agentContainer.Env)
+	if envValue(agentContainer, "NVT_BROKER_URL") != defaultBrokerURL {
+		t.Fatalf("expected NVT_BROKER_URL %q, got %#v", defaultBrokerURL, agentContainer.Env)
 	}
 	assertSecretKeyEnv(t, agentContainer, brokerTokenKey, BrokerTokenSecretName(agentRun.Name), brokerTokenKey)
 	assertSecretKeyEnv(t, agentContainer, callbackTokenKey, CallbackTokenSecretName(agentRun.Name), callbackTokenKey)
@@ -744,6 +744,107 @@ func TestDesiredAgentPodWithoutGitGrantHasNoCAVolume(t *testing.T) {
 	agent := requireContainer(t, *pod, "agent")
 	if findEnvVar(agent, "NVT_EGRESS_CA_FILE") != nil {
 		t.Fatalf("non-git agent must not carry NVT_EGRESS_CA_FILE: %#v", agent.Env)
+	}
+}
+
+func setTLSBrokerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("NVT_BROKER_URL", "https://nvt-broker:7347")
+	t.Setenv("NVT_BROKER_CA_SECRET", "nvt-broker-tls")
+}
+
+func TestTLSBrokerMediatedPodMountsBrokerCA(t *testing.T) {
+	setTLSBrokerEnv(t)
+	pod, err := DesiredAgentPod(multiGrantMediatedAgentRun(), testScheme(t))
+	if err != nil {
+		t.Fatalf("desired pod: %v", err)
+	}
+	caVolume := requireVolume(t, *pod, brokerCAVolumeName)
+	if caVolume.Secret == nil || caVolume.Secret.SecretName != "nvt-broker-tls" {
+		t.Fatalf("expected broker CA Secret volume, got %#v", caVolume)
+	}
+	// Only the public certificate may be projected — never the serving key.
+	if len(caVolume.Secret.Items) != 1 || caVolume.Secret.Items[0].Key != brokerCAKey {
+		t.Fatalf("broker CA volume must project only %s, got %#v", brokerCAKey, caVolume.Secret.Items)
+	}
+
+	agent := requireContainer(t, *pod, "agent")
+	assertVolumeMount(t, agent, brokerCAVolumeName, agentBrokerCAMount, "", true)
+	if envValue(agent, "NVT_BROKER_URL") != "https://nvt-broker:7347" {
+		t.Fatalf("expected https broker URL on agent, got %#v", agent.Env)
+	}
+	if envValue(agent, "NVT_BROKER_CA_FILE") != agentBrokerCAFile {
+		t.Fatalf("agent env missing NVT_BROKER_CA_FILE: %#v", agent.Env)
+	}
+
+	egressd := requireContainer(t, *pod, "egressd")
+	assertVolumeMount(t, egressd, brokerCAVolumeName, egressdBrokerCAMount, "", true)
+	if envValue(egressd, "NVT_BROKER_URL") != "https://nvt-broker:7347" {
+		t.Fatalf("expected https broker URL on egressd, got %#v", egressd.Env)
+	}
+}
+
+func TestTLSBrokerDirectPodGetsAgentCAOnly(t *testing.T) {
+	setTLSBrokerEnv(t)
+	pod, err := DesiredAgentPod(testAgentRun(), testScheme(t))
+	if err != nil {
+		t.Fatalf("desired pod: %v", err)
+	}
+	// Direct runs still talk to the broker via brokerctl, so the CA rides
+	// along even without the egressd sidecar.
+	requireVolume(t, *pod, brokerCAVolumeName)
+	agent := requireContainer(t, *pod, "agent")
+	assertVolumeMount(t, agent, brokerCAVolumeName, agentBrokerCAMount, "", true)
+	if envValue(agent, "NVT_BROKER_CA_FILE") != agentBrokerCAFile {
+		t.Fatalf("agent env missing NVT_BROKER_CA_FILE: %#v", agent.Env)
+	}
+	if _, found := findContainer(pod.Spec.Containers, "egressd"); found {
+		t.Fatalf("direct mode rendered egressd sidecar: %#v", pod.Spec.Containers)
+	}
+}
+
+func TestDefaultBrokerPodHasNoBrokerCAVolume(t *testing.T) {
+	pod, err := DesiredAgentPod(multiGrantMediatedAgentRun(), testScheme(t))
+	if err != nil {
+		t.Fatalf("desired pod: %v", err)
+	}
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == brokerCAVolumeName {
+			t.Fatalf("plaintext broker must not mount a broker CA volume: %#v", pod.Spec.Volumes)
+		}
+	}
+	agent := requireContainer(t, *pod, "agent")
+	if findEnvVar(agent, "NVT_BROKER_CA_FILE") != nil {
+		t.Fatalf("plaintext broker agent must not carry NVT_BROKER_CA_FILE: %#v", agent.Env)
+	}
+}
+
+func TestTLSBrokerRenderEgressdConfigPinsCA(t *testing.T) {
+	setTLSBrokerEnv(t)
+	agentRun := multiGrantMediatedAgentRun()
+	// The spec-level escape hatch must not weaken a CA-pinned broker leg.
+	agentRun.Spec.EgressAllowInsecureBroker = true
+	rendered, err := RenderEgressdConfigJSON(agentRun)
+	if err != nil {
+		t.Fatalf("render egressd config: %v", err)
+	}
+	if !strings.Contains(rendered, `"broker_url": "https://nvt-broker:7347"`) {
+		t.Fatalf("expected https broker_url:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `"broker_ca_file": "`+egressdBrokerCAFile+`"`) {
+		t.Fatalf("expected pinned broker_ca_file:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `"allow_insecure_broker": false`) {
+		t.Fatalf("CA-pinned broker leg must not allow insecure broker:\n%s", rendered)
+	}
+}
+
+func TestTLSBrokerValidationAcceptsMediatedWithoutInsecureFlag(t *testing.T) {
+	setTLSBrokerEnv(t)
+	agentRun := multiGrantMediatedAgentRun()
+	agentRun.Spec.EgressAllowInsecureBroker = false
+	if err := ValidateAgentRunEgressMode(agentRun); err != nil {
+		t.Fatalf("mediated over TLS broker must not require egressAllowInsecureBroker, got %v", err)
 	}
 }
 

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -53,6 +53,7 @@ PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 DEFAULT_EGRESS_CA_FILE = "/nvt-egress-ca/ca.crt"
 DEFAULT_EGRESS_CA_WAIT_SECONDS = 60
+DEFAULT_BROKER_WAIT_SECONDS = 180
 
 
 def load_bootstrap_config(path):
@@ -216,22 +217,39 @@ def scrub_git_state():
 
 
 def broker_routing(capability):
-    result = subprocess.run(
-        ["brokerctl", "injection", "routing", "--capability", capability],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise SystemExit(f"bootstrap: broker routing failed for {capability}: {result.stderr.strip() or result.stdout.strip()}")
+    # In k8s the operator registers this run's token in the broker agents
+    # ConfigMap right before creating the Pod, but the broker only sees the
+    # update after kubelet's ConfigMap sync (~1min worst case). Until then the
+    # broker answers "unauthorized" (or is not up yet), so those two failures
+    # are retried within a bounded window; everything else fails immediately.
     try:
-        payload = json.loads(result.stdout)
-    except json.JSONDecodeError as error:
-        raise SystemExit(f"bootstrap: broker routing response for {capability} was not JSON: {error}") from error
-    if not payload.get("ok"):
+        wait_seconds = float(os.environ.get("NVT_BROKER_WAIT_SECONDS") or DEFAULT_BROKER_WAIT_SECONDS)
+    except ValueError:
+        raise SystemExit("bootstrap: NVT_BROKER_WAIT_SECONDS must be a number")
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        result = subprocess.run(
+            ["brokerctl", "injection", "routing", "--capability", capability],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        payload = None
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+        if result.returncode == 0 and isinstance(payload, dict) and payload.get("ok"):
+            return payload
+        error = (payload or {}).get("error")
+        if error in {"unauthorized", "broker-unreachable"} and time.monotonic() < deadline:
+            print(f"bootstrap: broker not ready for {capability} ({error}); retrying", flush=True)
+            time.sleep(2)
+            continue
+        if payload is None:
+            raise SystemExit(f"bootstrap: broker routing failed for {capability}: {result.stderr.strip() or result.stdout.strip()}")
         raise SystemExit(f"bootstrap: broker routing denied for {capability}: {payload.get('message') or payload.get('error') or payload}")
-    return payload
 
 
 def apply_redirect_env(provider, grant, placeholder):

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -216,17 +216,22 @@ def scrub_git_state():
         path.unlink(missing_ok=True)
 
 
-def broker_routing(capability):
-    # In k8s the operator registers this run's token in the broker agents
-    # ConfigMap right before creating the Pod, but the broker only sees the
-    # update after kubelet's ConfigMap sync (~1min worst case). Until then the
-    # broker answers "unauthorized" (or is not up yet), so those two failures
-    # are retried within a bounded window; everything else fails immediately.
+def broker_wait_deadline():
+    # One shared window for the whole bootstrap pass: multiple grants must
+    # not multiply the startup wait.
     try:
         wait_seconds = float(os.environ.get("NVT_BROKER_WAIT_SECONDS") or DEFAULT_BROKER_WAIT_SECONDS)
     except ValueError:
         raise SystemExit("bootstrap: NVT_BROKER_WAIT_SECONDS must be a number")
-    deadline = time.monotonic() + wait_seconds
+    return time.monotonic() + wait_seconds
+
+
+def broker_routing(capability, deadline):
+    # In k8s the operator registers this run's token in the broker agents
+    # ConfigMap right before creating the Pod, but the broker only sees the
+    # update after kubelet's ConfigMap sync (~1min worst case). Until then the
+    # broker answers "unauthorized" (or is not up yet), so those two failures
+    # are retried until the shared deadline; everything else fails immediately.
     while True:
         result = subprocess.run(
             ["brokerctl", "injection", "routing", "--capability", capability],
@@ -237,10 +242,12 @@ def broker_routing(capability):
         )
         payload = None
         try:
-            payload = json.loads(result.stdout)
+            parsed = json.loads(result.stdout)
         except json.JSONDecodeError:
-            pass
-        if result.returncode == 0 and isinstance(payload, dict) and payload.get("ok"):
+            parsed = None
+        if isinstance(parsed, dict):
+            payload = parsed
+        if result.returncode == 0 and payload is not None and payload.get("ok"):
             return payload
         error = (payload or {}).get("error")
         if error in {"unauthorized", "broker-unreachable"} and time.monotonic() < deadline:
@@ -314,6 +321,7 @@ def apply_mediated_egress(egress):
     grants = egress.get("grants") or []
     if not isinstance(grants, list):
         raise SystemExit("egress.grants must be a list")
+    deadline = broker_wait_deadline()
     for index, grant in enumerate(grants):
         if not isinstance(grant, dict):
             raise SystemExit(f"egress.grants[{index}] must be an object")
@@ -325,7 +333,7 @@ def apply_mediated_egress(egress):
         base_url = grant.get("base-url")
         if not isinstance(base_url, str) or not base_url:
             raise SystemExit(f"egress mediated grant {provider} must include base-url")
-        routing = broker_routing(provider)
+        routing = broker_routing(provider, deadline)
         hosts = routing.get("hosts") or []
         if not hosts:
             raise SystemExit(f"bootstrap: mediated grant {provider} is not redirectable")

--- a/runtime/core/brokerctl.py
+++ b/runtime/core/brokerctl.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import ssl
 import sys
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -9,6 +10,16 @@ from urllib.request import Request, urlopen
 
 def broker_url():
     return os.environ.get("NVT_BROKER_URL", "http://127.0.0.1:7347").rstrip("/")
+
+
+def broker_ssl_context():
+    ca_file = os.environ.get("NVT_BROKER_CA_FILE", "").strip()
+    if not ca_file:
+        return None
+    if not os.path.isfile(ca_file):
+        print(f"brokerctl: NVT_BROKER_CA_FILE {ca_file!r} does not exist", file=sys.stderr)
+        raise SystemExit(2)
+    return ssl.create_default_context(cafile=ca_file)
 
 
 def request_json(path, payload=None, method="POST"):
@@ -23,7 +34,7 @@ def request_json(path, payload=None, method="POST"):
         headers["Authorization"] = f"Bearer {token}"
     request = Request(url, data=data, method=method, headers=headers)
     try:
-        with urlopen(request, timeout=30) as response:
+        with urlopen(request, timeout=30, context=broker_ssl_context()) as response:
             return json.loads(response.read().decode("utf-8")), response.status
     except HTTPError as error:
         try:

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -435,12 +435,56 @@ require_file "${CHART}/crds/nvt.dev_agentschedules.yaml"
 cmp -s "${ROOT}/operator/config/crd/bases/nvt.dev_agentruns.yaml" "${CHART}/crds/nvt.dev_agentruns.yaml"
 cmp -s "${ROOT}/operator/config/crd/bases/nvt.dev_agentschedules.yaml" "${CHART}/crds/nvt.dev_agentschedules.yaml"
 
+rendered_secret_names() {
+  local file="$1"
+  awk '
+    function reset_doc() {
+      kind = ""
+      name = ""
+      in_metadata = 0
+    }
+    function emit_doc() {
+      if (kind == "Secret" && name != "") {
+        print name
+      }
+    }
+    BEGIN {
+      reset_doc()
+    }
+    /^---[[:space:]]*$/ {
+      emit_doc()
+      reset_doc()
+      next
+    }
+    /^kind:[[:space:]]*/ {
+      kind = $2
+      next
+    }
+    /^metadata:[[:space:]]*$/ {
+      in_metadata = 1
+      next
+    }
+    in_metadata && /^[[:space:]]{2}name:[[:space:]]*/ {
+      name = $2
+      gsub(/^"|"$/, "", name)
+      in_metadata = 0
+      next
+    }
+    /^[^[:space:]]/ && $0 !~ /^metadata:/ {
+      in_metadata = 0
+    }
+    END {
+      emit_doc()
+    }
+  ' "${file}" | sort -u
+}
+
 # The generated broker TLS Secret is the single Secret the chart may render:
 # credential material must never pass through chart templates, but the broker
 # serving cert is chart-generated (self-signed) by design.
-require_resource "${DEFAULT_RENDER}" Secret nvt-broker-tls
-if [[ "$(grep -Ec '^kind:[[:space:]]*Secret$' "${DEFAULT_RENDER}")" != "1" ]]; then
-  echo "chart must not render Kubernetes Secrets by default beyond the broker TLS Secret" >&2
+default_secret_names="$(rendered_secret_names "${DEFAULT_RENDER}")"
+if [[ "${default_secret_names}" != "nvt-broker-tls" ]]; then
+  echo "chart must render exactly Secret nvt-broker-tls by default, got: ${default_secret_names:-none}" >&2
   exit 1
 fi
 grep -q 'tls.crt: ' "${DEFAULT_RENDER}"
@@ -454,6 +498,7 @@ grep -q 'secretName: "nvt-broker-tls"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_URL' "${DEFAULT_RENDER}"
 grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
+grep -q 'checksum/broker-tls: ' "${DEFAULT_RENDER}"
 
 missing_resource "${BROKER_TLS_DISABLED_RENDER}" Secret nvt-broker-tls
 if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_TLS_DISABLED_RENDER}"; then
@@ -464,14 +509,18 @@ if grep -Eq 'NVT_BROKER_TLS_CERT|NVT_BROKER_CA_SECRET|NVT_BROKER_URL' "${BROKER_
   echo "broker TLS disabled must not render TLS env" >&2
   exit 1
 fi
+if grep -q 'checksum/broker-tls' "${BROKER_TLS_DISABLED_RENDER}"; then
+  echo "broker TLS disabled must not render the TLS checksum annotation" >&2
+  exit 1
+fi
 
-missing_resource "${BROKER_TLS_EXISTING_RENDER}" Secret nvt-broker-tls
-if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_TLS_EXISTING_RENDER}"; then
+if [[ -n "$(rendered_secret_names "${BROKER_TLS_EXISTING_RENDER}")" ]]; then
   echo "broker.tls.existingSecret must not render a generated Secret" >&2
   exit 1
 fi
 grep -q 'secretName: "corp-broker-tls"' "${BROKER_TLS_EXISTING_RENDER}"
 grep -q 'value: "corp-broker-tls"' "${BROKER_TLS_EXISTING_RENDER}"
+grep -q 'checksum/broker-tls: ' "${BROKER_TLS_EXISTING_RENDER}"
 
 missing_resource "${BROKER_DISABLED_RENDER}" Secret nvt-broker-tls
 if grep -q 'NVT_BROKER_CA_SECRET' "${BROKER_DISABLED_RENDER}"; then
@@ -486,8 +535,7 @@ missing_resource "${BROKER_DISABLED_RENDER}" ConfigMap nvt-broker-agents
 require_resource "${BROKER_DISABLED_RENDER}" Deployment nvt-operator
 require_resource "${BROKER_DISABLED_RENDER}" Service nvt-operator
 
-missing_resource "${BROKER_SECRET_RENDER}" Secret nvt-broker-env
-if [[ "$(grep -Ec '^kind:[[:space:]]*Secret$' "${BROKER_SECRET_RENDER}")" != "1" ]]; then
+if [[ "$(rendered_secret_names "${BROKER_SECRET_RENDER}")" != "nvt-broker-tls" ]]; then
   echo "chart must reference existing broker env Secret without creating one" >&2
   exit 1
 fi

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -500,6 +500,39 @@ grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
 grep -q 'checksum/broker-tls: ' "${DEFAULT_RENDER}"
 
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+broker_tls_checksum() {
+  grep 'checksum/broker-tls: ' "$1" | head -1 | awk '{print $2}' | tr -d '"'
+}
+
+# The checksum annotation must hash the same material the Secret template
+# renders: without lookup (helm template) the cert regenerates per render, so
+# the checksum must match the rendered data and differ between renders —
+# otherwise a `helm template | kubectl apply` rotation applies a new Secret
+# while the running broker keeps serving the old cert.
+rendered_tls_crt="$(grep '^  tls.crt: ' "${DEFAULT_RENDER}" | head -1 | awk '{print $2}')"
+rendered_tls_key="$(grep '^  tls.key: ' "${DEFAULT_RENDER}" | head -1 | awk '{print $2}')"
+rendered_ca_crt="$(grep '^  ca.crt: ' "${DEFAULT_RENDER}" | head -1 | awk '{print $2}')"
+expected_checksum="$(printf '{"ca.crt":"%s","tls.crt":"%s","tls.key":"%s"}' \
+  "${rendered_ca_crt}" "${rendered_tls_crt}" "${rendered_tls_key}" | sha256_hex)"
+if [[ "$(broker_tls_checksum "${DEFAULT_RENDER}")" != "${expected_checksum}" ]]; then
+  echo "broker TLS checksum does not match the rendered Secret material" >&2
+  exit 1
+fi
+DEFAULT_RERENDER="${WORKDIR}/default-rerender.yaml"
+helm template nvt "${CHART}" -n custom-ns > "${DEFAULT_RERENDER}"
+if [[ "$(broker_tls_checksum "${DEFAULT_RENDER}")" == "$(broker_tls_checksum "${DEFAULT_RERENDER}")" ]]; then
+  echo "broker TLS checksum must change when the generated Secret material changes" >&2
+  exit 1
+fi
+
 missing_resource "${BROKER_TLS_DISABLED_RENDER}" Secret nvt-broker-tls
 if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_TLS_DISABLED_RENDER}"; then
   echo "chart must not render Kubernetes Secrets with broker TLS disabled" >&2

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -13,6 +13,8 @@ GATEWAY_OIDC_RENDER="${WORKDIR}/gateway-oidc.yaml"
 GATEWAY_OIDC_MISSING_SECRET_FAILURE="${WORKDIR}/gateway-oidc-missing-secret-failure.txt"
 BROKER_DISABLED_RENDER="${WORKDIR}/broker-disabled.yaml"
 BROKER_SECRET_RENDER="${WORKDIR}/broker-secret.yaml"
+BROKER_TLS_DISABLED_RENDER="${WORKDIR}/broker-tls-disabled.yaml"
+BROKER_TLS_EXISTING_RENDER="${WORKDIR}/broker-tls-existing.yaml"
 BROKER_PERSISTENCE_RENDER="${WORKDIR}/broker-persistence.yaml"
 BROKER_EXISTING_CLAIM_RENDER="${WORKDIR}/broker-existing-claim.yaml"
 BROKER_SEED_RENDER="${WORKDIR}/broker-seed.yaml"
@@ -48,6 +50,8 @@ helm template nvt "${CHART}" -n custom-ns \
   > "${GATEWAY_OIDC_RENDER}"
 helm template nvt "${CHART}" -n custom-ns --set broker.enabled=false > "${BROKER_DISABLED_RENDER}"
 helm template nvt "${CHART}" -n custom-ns --set broker.envSecretName=nvt-broker-env > "${BROKER_SECRET_RENDER}"
+helm template nvt "${CHART}" -n custom-ns --set broker.tls.enabled=false > "${BROKER_TLS_DISABLED_RENDER}"
+helm template nvt "${CHART}" -n custom-ns --set broker.tls.existingSecret=corp-broker-tls > "${BROKER_TLS_EXISTING_RENDER}"
 helm template nvt "${CHART}" -n custom-ns \
   --set broker.persistence.enabled=true \
   --set broker.persistence.size=2Gi \
@@ -431,8 +435,47 @@ require_file "${CHART}/crds/nvt.dev_agentschedules.yaml"
 cmp -s "${ROOT}/operator/config/crd/bases/nvt.dev_agentruns.yaml" "${CHART}/crds/nvt.dev_agentruns.yaml"
 cmp -s "${ROOT}/operator/config/crd/bases/nvt.dev_agentschedules.yaml" "${CHART}/crds/nvt.dev_agentschedules.yaml"
 
-if grep -Eq '^kind:[[:space:]]*Secret$' "${DEFAULT_RENDER}"; then
-  echo "chart must not render Kubernetes Secrets by default" >&2
+# The generated broker TLS Secret is the single Secret the chart may render:
+# credential material must never pass through chart templates, but the broker
+# serving cert is chart-generated (self-signed) by design.
+require_resource "${DEFAULT_RENDER}" Secret nvt-broker-tls
+if [[ "$(grep -Ec '^kind:[[:space:]]*Secret$' "${DEFAULT_RENDER}")" != "1" ]]; then
+  echo "chart must not render Kubernetes Secrets by default beyond the broker TLS Secret" >&2
+  exit 1
+fi
+grep -q 'tls.crt: ' "${DEFAULT_RENDER}"
+grep -q 'tls.key: ' "${DEFAULT_RENDER}"
+grep -q 'ca.crt: ' "${DEFAULT_RENDER}"
+grep -q 'name: NVT_BROKER_TLS_CERT' "${DEFAULT_RENDER}"
+grep -q 'value: /tls/tls.crt' "${DEFAULT_RENDER}"
+grep -q 'name: NVT_BROKER_TLS_KEY' "${DEFAULT_RENDER}"
+grep -q 'value: /tls/tls.key' "${DEFAULT_RENDER}"
+grep -q 'secretName: "nvt-broker-tls"' "${DEFAULT_RENDER}"
+grep -q 'name: NVT_BROKER_URL' "${DEFAULT_RENDER}"
+grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
+grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
+
+missing_resource "${BROKER_TLS_DISABLED_RENDER}" Secret nvt-broker-tls
+if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_TLS_DISABLED_RENDER}"; then
+  echo "chart must not render Kubernetes Secrets with broker TLS disabled" >&2
+  exit 1
+fi
+if grep -Eq 'NVT_BROKER_TLS_CERT|NVT_BROKER_CA_SECRET|NVT_BROKER_URL' "${BROKER_TLS_DISABLED_RENDER}"; then
+  echo "broker TLS disabled must not render TLS env" >&2
+  exit 1
+fi
+
+missing_resource "${BROKER_TLS_EXISTING_RENDER}" Secret nvt-broker-tls
+if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_TLS_EXISTING_RENDER}"; then
+  echo "broker.tls.existingSecret must not render a generated Secret" >&2
+  exit 1
+fi
+grep -q 'secretName: "corp-broker-tls"' "${BROKER_TLS_EXISTING_RENDER}"
+grep -q 'value: "corp-broker-tls"' "${BROKER_TLS_EXISTING_RENDER}"
+
+missing_resource "${BROKER_DISABLED_RENDER}" Secret nvt-broker-tls
+if grep -q 'NVT_BROKER_CA_SECRET' "${BROKER_DISABLED_RENDER}"; then
+  echo "broker disabled must not render operator broker TLS env" >&2
   exit 1
 fi
 
@@ -443,8 +486,9 @@ missing_resource "${BROKER_DISABLED_RENDER}" ConfigMap nvt-broker-agents
 require_resource "${BROKER_DISABLED_RENDER}" Deployment nvt-operator
 require_resource "${BROKER_DISABLED_RENDER}" Service nvt-operator
 
-if grep -Eq '^kind:[[:space:]]*Secret$' "${BROKER_SECRET_RENDER}"; then
-  echo "chart must reference existing broker Secret without creating one" >&2
+missing_resource "${BROKER_SECRET_RENDER}" Secret nvt-broker-env
+if [[ "$(grep -Ec '^kind:[[:space:]]*Secret$' "${BROKER_SECRET_RENDER}")" != "1" ]]; then
+  echo "chart must reference existing broker env Secret without creating one" >&2
   exit 1
 fi
 grep -q 'secretRef:' "${BROKER_SECRET_RENDER}"

--- a/tests/operator/kind/cases/mediated-egress.sh
+++ b/tests/operator/kind/cases/mediated-egress.sh
@@ -14,11 +14,53 @@ case_render() {
 case_kind_setup() {
   make -C "${ROOT}" \
     CLUSTER="${CLUSTER}" \
+    CREATE_CLUSTER="${CREATE_CLUSTER}" \
+    operator-kind-cluster
+
+  # The valid payload's grants reference real broker providers so bootstrap's
+  # injection-routing call succeeds end-to-end over the TLS broker leg. The
+  # static token is a smoke fixture, never a real credential.
+  kubectl_smoke create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl_smoke apply -f -
+  kubectl_smoke -n "${NAMESPACE}" create secret generic nvt-smoke-broker-env \
+    --from-literal=NVT_SMOKE_STATIC_TOKEN=nvt-smoke-fixture-token \
+    --dry-run=client -o yaml | kubectl_smoke apply -f -
+  write_broker_providers_values "${SMOKE_TMPDIR}/broker-providers.yaml"
+
+  make -C "${ROOT}" \
+    CLUSTER="${CLUSTER}" \
     NAMESPACE="${NAMESPACE}" \
     CREATE_CLUSTER="${CREATE_CLUSTER}" \
     ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
-    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
     operator-kind-setup
+}
+
+write_broker_providers_values() {
+  local output="$1"
+  cat >"${output}" <<'YAML'
+broker:
+  envSecretName: nvt-smoke-broker-env
+  config:
+    providers:
+      - name: static-bearer-main
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - api.example.test
+        allow:
+          repositories:
+            - example/*
+      - name: git-app
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - github.com
+        allow:
+          repositories:
+            - example/*
+YAML
 }
 
 case_run() {
@@ -27,6 +69,16 @@ case_run() {
   submit_rejected_admission "file-bundle" "file-bundle"
   submit_valid_admission
   assert_mediated_pod_shape
+  # Completing the run proves the TLS broker leg end-to-end: bootstrap only
+  # reaches the agent command after brokerctl succeeds against
+  # https://nvt-broker verified by the operator-distributed CA.
+  wait_for_phase_any "${RUN_NAME}-valid" "${RUN_TIMEOUT_SECONDS}" Completed Failed
+  local phase
+  phase="$(agentrun_phase "${RUN_NAME}-valid")"
+  if [[ "${phase}" != "Completed" ]]; then
+    kubectl_smoke logs "${RUN_NAME}-valid-agent" -n "${NAMESPACE}" -c agent --tail 20 >&2 || true
+    die "mediated run ended in phase ${phase}; bootstrap over the TLS broker leg failed"
+  fi
 }
 
 payload_file() {
@@ -38,13 +90,14 @@ generate_payload() {
   local variant="$1"
   local output="$2"
 
-  python3 - "${variant}" "${RUN_NAME}-${variant}" "${ACTIVE_DEADLINE_SECONDS}" >"${output}" <<'PY'
+  python3 - "${variant}" "${RUN_NAME}-${variant}" "${ACTIVE_DEADLINE_SECONDS}" "${NAMESPACE}" >"${output}" <<'PY'
 import json
 import sys
 
 variant = sys.argv[1]
 run_name = sys.argv[2]
 active_deadline_seconds = int(sys.argv[3])
+namespace = sys.argv[4]
 
 grant = {
     "provider": "static-bearer-main",
@@ -63,8 +116,9 @@ git_grant = {
 spec = {
     "runtime": {"type": "codex", "autonomy": "trusted-local"},
     "image": "nvt-agent-runtime:latest",
+    # No egressAllowInsecureBroker: the chart serves the broker over TLS by
+    # default, so mediated runs must pass admission without the escape hatch.
     "egress": "mediated",
-    "egressAllowInsecureBroker": True,
     "workspace": {"mode": "Ephemeral"},
     "broker": {"grants": [grant, git_grant]},
     "agent": {
@@ -73,10 +127,39 @@ spec = {
                 "command": "bash",
                 "args": ["-lc", 'echo "mediated smoke ready"; sleep infinity'],
             },
+            # Plugins run after bootstrap, so the smoke-complete event firing
+            # (and the run reaching Completed) proves bootstrap's brokerctl
+            # calls succeeded over the TLS broker leg.
+            "plugins": [
+                {
+                    "name": "event-webhook",
+                    "source": "builtin",
+                    "when": "after-agent",
+                    "restart": "always",
+                    "config": {
+                        "url": f"http://nvt-operator:8082/v1/agentruns/{namespace}/{run_name}/events",
+                        "auth": {"type": "bearer-env", "env": "NVT_OPERATOR_CALLBACK_TOKEN"},
+                        "filters": ["plugin.smoke."],
+                        "delivery": {"retry": {"backoff-seconds": 1}},
+                    },
+                },
+                {
+                    "name": "smoke-complete",
+                    "source": "builtin",
+                    "when": "after-agent",
+                    "restart": "never",
+                    "config": {
+                        "delaySeconds": 1,
+                        "event": "plugin.smoke.completed",
+                        "payload": {"ok": True},
+                    },
+                },
+            ],
             "tools": {"packages": [], "mise": [], "additional-paths": [], "shell": []},
             "code-server": {"extensions": []},
         }
     },
+    "lifecycle": {"completeOn": ["plugin.smoke.completed"], "failOn": []},
     "ttl": {"activeDeadlineSeconds": active_deadline_seconds},
 }
 
@@ -123,7 +206,8 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as file:
     valid = json.load(file)["agentRun"]["spec"]
 assert valid["egress"] == "mediated"
-assert valid["egressAllowInsecureBroker"] is True
+assert "egressAllowInsecureBroker" not in valid
+assert valid["lifecycle"]["completeOn"] == ["plugin.smoke.completed"]
 grant = valid["broker"]["grants"][0]
 assert grant["provider"] == "static-bearer-main"
 assert grant["materialization"] == "header-inject"
@@ -264,5 +348,28 @@ if not egressd_ca_mount or egressd_ca_mount.get("readOnly") is True:
 agent_plain_env = {env.get("name"): env.get("value") for env in agent.get("env", [])}
 if agent_plain_env.get("NVT_EGRESS_CA_FILE") != "/nvt-egress-ca/ca.crt":
     raise SystemExit(f"agent env missing NVT_EGRESS_CA_FILE: {agent_plain_env}")
+
+# Broker TLS: the run passed admission without egressAllowInsecureBroker, so
+# the broker leg must be https with the CA distributed to both containers —
+# and only the certificate item projected from the TLS Secret.
+if agent_plain_env.get("NVT_BROKER_URL") != "https://nvt-broker:7347":
+    raise SystemExit(f"agent env must use the TLS broker URL: {agent_plain_env}")
+if agent_plain_env.get("NVT_BROKER_CA_FILE") != "/etc/nvt-broker-ca/ca.crt":
+    raise SystemExit(f"agent env missing NVT_BROKER_CA_FILE: {agent_plain_env}")
+
+broker_ca_volume = volumes.get("broker-ca")
+if not broker_ca_volume or "secret" not in broker_ca_volume:
+    raise SystemExit(f"expected broker-ca Secret volume, got {sorted(volumes)}")
+items = broker_ca_volume["secret"].get("items") or []
+if [item.get("key") for item in items] != ["ca.crt"]:
+    raise SystemExit(f"broker-ca volume must project only ca.crt: {broker_ca_volume}")
+
+agent_broker_ca = agent_mounts.get("broker-ca")
+if not agent_broker_ca or agent_broker_ca.get("readOnly") is not True or agent_broker_ca.get("mountPath") != "/etc/nvt-broker-ca":
+    raise SystemExit(f"agent broker CA mount must be read-only at /etc/nvt-broker-ca: {agent_broker_ca}")
+
+egressd_broker_ca = egressd_mounts.get("broker-ca")
+if not egressd_broker_ca or egressd_broker_ca.get("readOnly") is not True or egressd_broker_ca.get("mountPath") != "/etc/nvt-egressd/broker-ca":
+    raise SystemExit(f"egressd broker CA mount must be read-only at /etc/nvt-egressd/broker-ca: {egressd_broker_ca}")
 PY
 }

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -373,6 +373,107 @@ code-server:
 	}
 }
 
+// TestMediatedBrokerRoutingNonObjectJSON pins clean failure when brokerctl
+// emits valid JSON that is not an object: bootstrap must exit with its own
+// error message, never a Python traceback.
+func TestMediatedBrokerRoutingNonObjectJSON(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("brokerctl", `#!/usr/bin/env bash
+printf '%s\n' '"error"'
+exit 1
+`)
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  grants:
+    - provider: api-main
+      materialization: header-inject
+      base-url: http://127.0.0.1:8471
+runtime:
+  command: bash
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_EGRESS_MODE=mediated",
+		"NVT_BROKER_WAIT_SECONDS=1",
+	}, config)
+	if !strings.Contains(output, "bootstrap: broker routing failed for api-main") {
+		t.Fatalf("expected clean broker routing failure, got:\n%s", output)
+	}
+	if strings.Contains(output, "Traceback") {
+		t.Fatalf("bootstrap crashed with a traceback on non-object broker JSON:\n%s", output)
+	}
+}
+
+// TestMediatedBrokerRoutingSharedRetryDeadline pins the shared retry window:
+// retries for transient broker errors are bounded once per bootstrap pass,
+// so a second grant must not get a fresh full window after the first grant
+// already consumed it.
+func TestMediatedBrokerRoutingSharedRetryDeadline(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("brokerctl", `#!/usr/bin/env bash
+set -euo pipefail
+capability="${!#}"
+count_file="${HOME}/routing-calls-${capability}"
+count=$(( $(cat "${count_file}" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "${count}" >"${count_file}"
+if [ "${capability}" = "api-first" ] && [ "${count}" -gt 2 ]; then
+  printf '%s\n' '{"ok":true,"hosts":["api.example.test"],"placeholder":"NVT-PLACEHOLDER-NOT-A-KEY"}'
+  exit 0
+fi
+printf '%s\n' '{"ok":false,"error":"unauthorized"}'
+exit 1
+`)
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  grants:
+    - provider: api-first
+      materialization: header-inject
+      base-url: http://127.0.0.1:8471
+    - provider: api-second
+      materialization: header-inject
+      base-url: http://127.0.0.1:8472
+runtime:
+  command: bash
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	// The first grant burns most of the 5s window on two unauthorized
+	// retries (2s sleep each) before succeeding; the second grant then hits
+	// the already-consumed deadline after at most one retry.
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_EGRESS_MODE=mediated",
+		"NVT_BROKER_WAIT_SECONDS=5",
+	}, config)
+	if !strings.Contains(output, "bootstrap: broker routing denied for api-second: unauthorized") {
+		t.Fatalf("expected api-second to fail after the shared deadline, got:\n%s", output)
+	}
+	firstCalls := mustReadFile(t, filepath.Join(f.home, "routing-calls-api-first"))
+	if firstCalls != "3" {
+		t.Fatalf("expected api-first to succeed on its third attempt, got %s calls", firstCalls)
+	}
+	secondCalls := mustReadFile(t, filepath.Join(f.home, "routing-calls-api-second"))
+	if secondCalls != "1" && secondCalls != "2" {
+		t.Fatalf("api-second got a fresh retry window (%s calls); the deadline must be shared across grants", secondCalls)
+	}
+}
+
 // TestMediatedPlaceholderInert pins the placeholder convention: the constant
 // satisfies CLI syntax checks but grants nothing upstream.
 //


### PR DESCRIPTION
Prerequisite PR for Phase 5 ([plan](docs/phase5-enforcement-plan.md)): production mediated mode no longer requires `egressAllowInsecureBroker`.

## What

- **Chart**: `broker.tls` values (default **enabled**). With no `existingSecret`, the chart generates a self-signed CA + serving cert into `nvt-broker-tls` (`lookup`-preserved across upgrades so the trust anchor is stable). The broker serves TLS via the existing `NVT_BROKER_TLS_CERT/KEY` support; the operator gets `NVT_BROKER_URL=https://nvt-broker:7347` and `NVT_BROKER_CA_SECRET`. The broker TLS Secret name resolves through one helper (`nvt.brokerTLSSecretName`) everywhere, and a `checksum/broker-tls` pod-template annotation restarts the broker when the Secret material changes.
- **Operator**: when the broker leg is TLS, agent Pods mount the CA — **only the `ca.crt` item is projected**, the serving key never enters the agent Pod. egressd gets `broker_ca_file` in its rendered config (and `allow_insecure_broker` is forced off); the agent gets `NVT_BROKER_CA_FILE`. Direct-mode runs get the CA too (brokerctl talks to the broker in both modes). Misconfiguration fails fast: https broker URL without `NVT_BROKER_CA_SECRET` aborts operator startup and rejects validation/render; a configured CA Secret is verified to exist and carry `ca.crt` before any Pod is created. Broker TLS decisions apply at run creation only — operator env changes never retroactively fail or rewrite runs whose Pod already exists.
- **Runtime**: `brokerctl` honors `NVT_BROKER_CA_FILE`; bootstrap retries `unauthorized`/`broker-unreachable` routing failures within one shared bounded window per bootstrap pass (`NVT_BROKER_WAIT_SECONDS`, default 180s) — the operator registers the run token in the broker agents ConfigMap right before Pod creation, and the broker only sees it after kubelet's ConfigMap sync. Non-object JSON from brokerctl fails cleanly instead of raising.
- **Kind smoke**: the mediated case runs the TLS path with no `egressAllowInsecureBroker`, provisions fixture broker providers, asserts the broker-CA pod shape, and drives the run to `Completed` — bootstrap only reaches the agent command after brokerctl succeeds against `https://nvt-broker` verified by the operator-distributed CA.

## Tests

- Operator: full suite green, including TLS pod/config/validation tests, https-without-CA-secret rejection, missing/incomplete CA Secret rejection, and the no-retroactive-rewrite guard.
- Runtime (`tests/runtime`, runs because `runtime/core` changed): full suite green, including new bootstrap tests for non-object broker JSON and the shared retry deadline across grants.
- Helm render suite: broker TLS Secret assertions (default / disabled / existingSecret / broker-disabled), checksum annotation presence/absence, and the default-render Secret set asserted to be exactly `nvt-broker-tls`.
- egressd + broker conformance suites: green.
- Kind smoke (`KIND_SMOKE_CASE=mediated-egress`): passed end-to-end — admission rejections, valid admission without the insecure flag, pod shape, run `Completed` over TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)