### PR TITLE
Phase 5 PR 6b: observability + control (audit, quotas, revocation, Anthropic, defaultEgressMode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BROKER_ENV_SECRET ?= nvt-broker-env
 PRODUCER_IMAGE ?= nvt-github-comments-producer:latest
 GATEWAY_IMAGE ?= nvt-agent-gateway:latest
 EGRESSD_IMAGE ?= nvt-egressd:latest
+ECHO_IMAGE ?= nvt-smoke-echo:latest
 PRODUCER_VALUES ?= values.github-comments.yaml
 PRODUCER_RELEASE ?= nvt-github-comments-producer
 PRODUCER_CHART ?= charts/nvt-github-comments-producer
@@ -32,7 +33,7 @@ OPERATOR_KIND_EXTRA_IMAGE_TARGETS := gateway-kind-load
 OPERATOR_KIND_GATEWAY_HELM_ARGS := --set gateway.enabled=true --set gateway.image=$(GATEWAY_IMAGE)
 endif
 
-.PHONY: runtime-build broker-build egressd-build phase2-codex-gate phase2b-codex-forward-proxy operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-cluster-enforced operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
+.PHONY: runtime-build broker-build egressd-build echo-build echo-kind-load phase2-codex-gate phase2b-codex-forward-proxy operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-cluster-enforced operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
 
 runtime-build:
 	bash scripts/runtime-build.sh $(if $(NO_CACHE),--no-cache)
@@ -57,6 +58,17 @@ producer-build:
 
 gateway-build:
 	docker build -f gateway/Dockerfile -t "$(GATEWAY_IMAGE)" .
+
+echo-build:
+	docker build -f tests/fixtures/echo/Dockerfile -t "$(ECHO_IMAGE)" .
+
+# Hermetic upstream fixture for the kind egress smokes (quota, revocation,
+# enforced-egress). Loaded into the active $(CLUSTER) after it exists; the
+# smoke case creates the cluster first, so this does not depend on
+# operator-kind-cluster.
+echo-kind-load: echo-build
+	@printf '[operator-kind-setup] loading echo fixture image %s into kind cluster %s\n' "$(ECHO_IMAGE)" "$(CLUSTER)"
+	kind load docker-image "$(ECHO_IMAGE)" --name "$(CLUSTER)"
 
 operator-helm-test:
 	bash tests/operator/helm/test.sh

--- a/broker/core/agents.py
+++ b/broker/core/agents.py
@@ -157,10 +157,27 @@ class AgentRegistry:
                                 f"{', '.join(sorted(VALID_PERMISSION_VALUES))}"
                             )
                         permissions[key] = value
-                grants.append({"provider": provider, "repositories": repositories, "materialization": materialization, "permissions": permissions})
+                # Quota is validated for schema strictness but NOT enforced
+                # broker-side: enforcement is per egressd process
+                # (docs/phase5-6b-observability-pr-plan.md decision 3).
+                quota = self._grant_quota(grant.get("quota"), index, grant_index)
+                grant_entry = {"provider": provider, "repositories": repositories, "materialization": materialization, "permissions": permissions}
+                if quota is not None:
+                    grant_entry["quota"] = quota
+                grants.append(grant_entry)
             output[token_hash] = {"id": agent_id, "role": "agent", "paired_agent": None, "grants": grants}
             roles_by_id[agent_id] = "agent"
         for index, agent_id, paired_agent in pairings:
             if roles_by_id.get(paired_agent) != "agent":
                 fail(f"agents[{index}] ({agent_id}): paired-agent must reference an agent-role identity")
         return output
+
+    def _grant_quota(self, raw_quota, index, grant_index):
+        if raw_quota is None:
+            return None
+        if not isinstance(raw_quota, dict):
+            fail(f"agents[{index}].grants[{grant_index}].quota must be a YAML object")
+        requests = raw_quota.get("requests")
+        if not isinstance(requests, int) or isinstance(requests, bool) or requests < 1:
+            fail(f"agents[{index}].grants[{grant_index}].quota.requests must be a positive integer")
+        return {"requests": requests}

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import ssl
 import time
 import uuid
@@ -19,6 +20,12 @@ MAX_REQUEST_BYTES = 1024 * 1024
 # bounds a single report; oversized reports are denied with the standard
 # error shape, never truncated silently.
 MAX_REPORT_ENTRIES = 100
+
+# path_class is a sanitized class computed by egressd (protocol/injection.md):
+# the git classes or a single lowercase path segment. The broker enforces the
+# shape so a buggy egressd or a leaked egress token cannot write raw paths or
+# arbitrary strings into the audit log.
+PATH_CLASS_RE = re.compile(r"^[a-z0-9._-]{1,64}$")
 
 # Documented zero-entropy placeholder from protocol/injection.md. It is the
 # only credential-shaped value allowed inside a mediated agent container.
@@ -314,6 +321,12 @@ class Broker:
         path_class = entry.get("path_class")
         if not isinstance(path_class, str) or not path_class:
             raise ProviderError("entry-invalid", f"entries[{index}].path_class is required", 400)
+        if not PATH_CLASS_RE.match(path_class):
+            raise ProviderError(
+                "entry-invalid",
+                f"entries[{index}].path_class must match {PATH_CLASS_RE.pattern} (sanitized class, never a raw path)",
+                400,
+            )
         status = entry.get("status")
         if not isinstance(status, int) or isinstance(status, bool) or status < 0:
             raise ProviderError("entry-invalid", f"entries[{index}].status must be a non-negative integer", 400)

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -15,6 +15,11 @@ from broker.plugins.github_app.provider import ProviderError
 
 MAX_REQUEST_BYTES = 1024 * 1024
 
+# Cap entries per injection report. Combined with MAX_REQUEST_BYTES this
+# bounds a single report; oversized reports are denied with the standard
+# error shape, never truncated silently.
+MAX_REPORT_ENTRIES = 100
+
 # Documented zero-entropy placeholder from protocol/injection.md. It is the
 # only credential-shaped value allowed inside a mediated agent container.
 INJECTION_PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
@@ -250,6 +255,76 @@ class Broker:
             response["git"] = True
         return response
 
+    def injection_report(self, request_id, payload, authorization):
+        # Observability, not a security control (protocol/injection.md §Audit):
+        # egressd reports each proxied request here so the broker's audit log
+        # covers individual requests, not just per-fetch injection. Authorization
+        # is role + pairing only — entries are NOT re-checked against grants: a
+        # report for a just-revoked capability is still audit-worthy, and a
+        # compromised egressd could spam granted capabilities regardless.
+        identity = self.authenticate_role(authorization, "egress")
+        paired = self.agents.by_id(identity.get("paired_agent") or "")
+        if paired is None or paired.get("role", "agent") != "agent":
+            raise ProviderError("pairing-invalid", "egress identity has no valid paired agent", 403)
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise ProviderError("entries-required", "entries must be a list", 400)
+        if len(entries) > MAX_REPORT_ENTRIES:
+            raise ProviderError(
+                "entries-too-many",
+                f"a report carries at most {MAX_REPORT_ENTRIES} entries",
+                400,
+            )
+        records = [self._report_record(entry, index) for index, entry in enumerate(entries)]
+        # Write only after every entry validated: a malformed batch is rejected
+        # whole, never partially audited.
+        for record in records:
+            self.audit.write(
+                request_id=request_id,
+                agent=identity["id"],
+                paired_agent=paired["id"],
+                operation="injection.request",
+                allowed=True,
+                **record,
+            )
+        return {"ok": True, "reported": len(records)}
+
+    def _report_record(self, entry, index):
+        if not isinstance(entry, dict):
+            raise ProviderError("entry-invalid", f"entries[{index}] must be an object", 400)
+        capability = entry.get("capability")
+        if not isinstance(capability, str) or not capability:
+            raise ProviderError("entry-invalid", f"entries[{index}].capability is required", 400)
+        host = entry.get("host")
+        if not isinstance(host, str) or not host:
+            raise ProviderError("entry-invalid", f"entries[{index}].host is required", 400)
+        # Two shapes: a proxied HTTP request, or a forward-proxy CONNECT tunnel.
+        # A `decision` key selects CONNECT; otherwise it is an HTTP request.
+        if "decision" in entry:
+            decision = entry.get("decision")
+            if decision not in ("allow", "deny"):
+                raise ProviderError("entry-invalid", f"entries[{index}].decision must be allow or deny", 400)
+            port = entry.get("port")
+            if not isinstance(port, int) or isinstance(port, bool) or port < 1 or port > 65535:
+                raise ProviderError("entry-invalid", f"entries[{index}].port must be a valid port", 400)
+            return {"provider": capability, "host": host, "port": port, "decision": decision}
+        method = entry.get("method")
+        if not isinstance(method, str) or not method:
+            raise ProviderError("entry-invalid", f"entries[{index}].method is required", 400)
+        path_class = entry.get("path_class")
+        if not isinstance(path_class, str) or not path_class:
+            raise ProviderError("entry-invalid", f"entries[{index}].path_class is required", 400)
+        status = entry.get("status")
+        if not isinstance(status, int) or isinstance(status, bool) or status < 0:
+            raise ProviderError("entry-invalid", f"entries[{index}].status must be a non-negative integer", 400)
+        return {
+            "provider": capability,
+            "host": host,
+            "method": method.upper(),
+            "path_class": path_class,
+            "status": status,
+        }
+
     def denied(self, request_id, payload, reason, message=None, authorization=None, operation=None):
         agent_id = None
         try:
@@ -359,6 +434,10 @@ def make_handler(broker):
                     return
                 if self.path == "/v1/injection/routing":
                     response = broker.injection_routing(request_id, payload, self.headers.get("authorization"))
+                    self.write_json(200, response)
+                    return
+                if self.path == "/v1/injection/report":
+                    response = broker.injection_report(request_id, payload, self.headers.get("authorization"))
                     self.write_json(200, response)
                     return
                 self.write_json(404, {"ok": False, "error": "not-found"})

--- a/broker/plugins/static_token/provider.py
+++ b/broker/plugins/static_token/provider.py
@@ -1,8 +1,17 @@
 import fnmatch
+import re
 
 from broker.core.config import env_value, fail, injection_hosts, list_value, string_value
 from broker.plugins.github_app.provider import ProviderError
 from broker.plugins.static_target import normalize_target, target_mode
+
+
+# The zero-entropy placeholder from protocol/injection.md. No injected header
+# value may collide with it (that would defeat the whole non-possession point).
+INJECTION_PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
+
+# RFC 7230 header field-name token, lowercased.
+_HEADER_NAME_RE = re.compile(r"^[a-z0-9!#$%&'*+.^_`|~-]+$")
 
 
 class StaticTokenProvider:
@@ -19,6 +28,55 @@ class StaticTokenProvider:
         self.allowed_repositories = self._allowed_strings("repositories")
         self.token = self._token()
         self.injection_hosts = injection_hosts(self.config, self.name)
+        # Generalized injection so this one provider covers Bearer APIs and
+        # key-header APIs (e.g. Anthropic's x-api-key) with no egressd change
+        # (docs/phase5-6b-observability-pr-plan.md decision 4).
+        self.injection_header = self._injection_header()
+        self.injection_scheme = self._injection_scheme()
+        self.injection_extra_headers = self._injection_extra_headers()
+
+    def _injection_header(self):
+        raw = self.config.get("injection-header")
+        if raw is None:
+            return "authorization"
+        header = string_value(raw, f"provider {self.name} config.injection-header")
+        return self._normalize_header_name(header, "injection-header")
+
+    def _injection_scheme(self):
+        raw = self.config.get("injection-scheme")
+        if raw is None:
+            return "Bearer"
+        # An explicit empty string means "inject the raw token" (x-api-key).
+        if not isinstance(raw, str):
+            fail(f"provider {self.name} config.injection-scheme must be a string")
+        return raw
+
+    def _injection_extra_headers(self):
+        raw = self.config.get("injection-extra-headers")
+        if raw is None:
+            return {}
+        if not isinstance(raw, dict):
+            fail(f"provider {self.name} config.injection-extra-headers must be a YAML object")
+        headers = {}
+        for key, value in raw.items():
+            name = self._normalize_header_name(
+                string_value(key, f"provider {self.name} config.injection-extra-headers key"),
+                "injection-extra-headers",
+            )
+            if name == self.injection_header:
+                fail(f"provider {self.name} config.injection-extra-headers duplicates {name}")
+            if not isinstance(value, str) or not value:
+                fail(f"provider {self.name} config.injection-extra-headers[{name}] must be a non-empty string")
+            if INJECTION_PLACEHOLDER in value:
+                fail(f"provider {self.name} config.injection-extra-headers[{name}] must not contain the injection placeholder")
+            headers[name] = value
+        return headers
+
+    def _normalize_header_name(self, value, field):
+        name = value.strip().lower()
+        if not _HEADER_NAME_RE.match(name):
+            fail(f"provider {self.name} config.{field} {value!r} is not a valid header name")
+        return name
 
     def _allowed_strings(self, key):
         values = list_value(self.allow.get(key), f"provider {self.name} allow.{key}")
@@ -69,4 +127,10 @@ class StaticTokenProvider:
         raise ProviderError("identity-not-supported", f"provider {self.name} does not support commit identity; use identity.mode=explicit")
 
     def injection_headers(self, host, method, path, agent_id, audit, request_id, grant=None):
-        return {"authorization": f"Bearer {self.token}"}, None, ["authorization"]
+        value = f"{self.injection_scheme} {self.token}" if self.injection_scheme else self.token
+        headers = {self.injection_header: value}
+        headers.update(self.injection_extra_headers)
+        # Every injected name is stripped from the incoming request so the
+        # agent's placeholder version is removed before injection.
+        strip = list(headers.keys())
+        return headers, None, strip

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -58,7 +58,17 @@ creation-time default egress mode:
 egress:
   egressdImage: nvt-egressd:latest
   defaultMode: direct   # direct | mediated
+  allowInsecureUpstreams: false
 ```
+
+`egress.allowInsecureUpstreams` is a **test/dev opt-in** (operator env
+`NVT_ALLOW_INSECURE_UPSTREAMS`) for the per-grant `allowInsecureUpstream`
+escape hatch, which lets egressd reach an upstream over plain HTTP — used only
+so hermetic in-cluster smoke fixtures (which cannot present a publicly-trusted
+cert) are reachable. Leave it `false` in any real deployment: a plaintext
+upstream leg carries the injected credential in the clear. With it off,
+admission **rejects** any grant that sets `allowInsecureUpstream`, and it is
+**always** rejected for `git` grants.
 
 `egress.defaultMode` (operator env `NVT_DEFAULT_EGRESS_MODE`, validated at
 startup) is applied **once, at AgentRun creation on the nvt admission/schedule

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -50,15 +50,66 @@ broker:
 
 ## Agent Egress
 
-Agent egress mode is selected per `AgentRun` with `spec.egress`; the chart does
-not set a cluster-wide mode default. Direct mode remains the API default. The
-chart exposes only the egressd image used when an individual `AgentRun` opts
-into mediated mode:
+Agent egress mode is selected per `AgentRun` with `spec.egress`; direct mode
+remains the API default. The chart exposes the egressd image and a
+creation-time default egress mode:
 
 ```yaml
 egress:
   egressdImage: nvt-egressd:latest
+  defaultMode: direct   # direct | mediated
 ```
+
+`egress.defaultMode` (operator env `NVT_DEFAULT_EGRESS_MODE`, validated at
+startup) is applied **once, at AgentRun creation on the nvt admission/schedule
+path** (producers and schedules): when an incoming run leaves `spec.egress`
+empty, the admission endpoint stamps this mode before creating the object, so
+the stored run is always explicit. Flipping the knob therefore never
+reclassifies an existing run. It never overrides an explicit `spec.egress`.
+
+Scope caveat: a **raw `kubectl apply`** of an AgentRun with empty egress is
+defaulted to `direct` by the CRD schema (the API server, not the operator),
+regardless of this knob — the operator never sees empty on that path and does
+not resolve the default at read time (that would reintroduce the
+reclassification hazard). An operator running mediated-by-default drives runs
+through the nvt path, not raw kubectl. The global mediated-by-default flip
+(changing this default value, the CRD `default:` markers, and producer specs)
+stays deferred until both egress smokes are green in CI and real-cluster
+usage has soaked.
+
+### Per-grant request quotas
+
+A mediated grant may cap its proxied requests:
+
+```yaml
+broker:
+  grants:
+    - provider: anthropic-main
+      materialization: header-inject
+      egressHosts: [api.anthropic.com:443]
+      quota:
+        requests: 1000
+```
+
+The operator renders this into the egressd route as `max_requests`; the
+(N+1)th request fails closed with a 429. **The count is per egressd process,
+not per run** — an egressd restart (in-place container restart, or the
+enforcement-mode Pod recreation after eviction) resets it. It is a soft
+resource guard, not a security boundary; durable run-lifetime quotas are
+future work. Absent = unlimited.
+
+### Revocation
+
+Removing a grant from an `AgentRun` (patch `spec.broker.grants`) makes the
+operator reconcile it out of the broker agents ConfigMap; the broker
+hot-reloads on the file's mtime change and the next `egressd` fetch for that
+grant fails closed — no broker restart. The end-to-end bound is **operator
+reconcile + kubelet ConfigMap projection (~1 min worst case) + egressd cache
+clamp (≤60s)**. Revoke through the AgentRun spec, never by editing the broker
+agents ConfigMap directly (the operator's policy reconcile would re-add the
+grant). The broker agents ConfigMap must be mounted as a directory volume,
+never with `subPath` — a subPath freezes the projected file and silently
+disables hot-reload; the helm render test guards this.
 
 A mediated run can additionally set `spec.egressEnforcement: true`: egressd
 moves to its own Pod and the operator renders per-run NetworkPolicies that

--- a/charts/nvt/crds/nvt.dev_agentruns.yaml
+++ b/charts/nvt/crds/nvt.dev_agentruns.yaml
@@ -131,6 +131,14 @@ spec:
                               enum:
                                 - read
                                 - write
+                          quota:
+                            type: object
+                            required:
+                              - requests
+                            properties:
+                              requests:
+                                type: integer
+                                minimum: 1
                 prompt:
                   type: object
                   properties:

--- a/charts/nvt/crds/nvt.dev_agentruns.yaml
+++ b/charts/nvt/crds/nvt.dev_agentruns.yaml
@@ -121,6 +121,9 @@ spec:
                           git:
                             type: boolean
                             default: false
+                          allowInsecureUpstream:
+                            type: boolean
+                            default: false
                           permissions:
                             type: object
                             additionalProperties:

--- a/charts/nvt/templates/operator-deployment.yaml
+++ b/charts/nvt/templates/operator-deployment.yaml
@@ -33,6 +33,10 @@ spec:
               value: {{ .Values.egress.egressdImage | quote }}
             - name: NVT_DEFAULT_EGRESS_MODE
               value: {{ .Values.egress.defaultMode | quote }}
+            {{- if .Values.egress.allowInsecureUpstreams }}
+            - name: NVT_ALLOW_INSECURE_UPSTREAMS
+              value: "1"
+            {{- end }}
             {{- if and .Values.broker.enabled .Values.broker.tls.enabled }}
             - name: NVT_BROKER_URL
               value: "https://nvt-broker:7347"

--- a/charts/nvt/templates/operator-deployment.yaml
+++ b/charts/nvt/templates/operator-deployment.yaml
@@ -31,6 +31,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: NVT_EGRESSD_IMAGE
               value: {{ .Values.egress.egressdImage | quote }}
+            - name: NVT_DEFAULT_EGRESS_MODE
+              value: {{ .Values.egress.defaultMode | quote }}
             {{- if and .Values.broker.enabled .Values.broker.tls.enabled }}
             - name: NVT_BROKER_URL
               value: "https://nvt-broker:7347"

--- a/charts/nvt/values.yaml
+++ b/charts/nvt/values.yaml
@@ -7,6 +7,13 @@ runtime:
 
 egress:
   egressdImage: nvt-egressd:latest
+  # Cluster default egress mode for AgentRuns created through the nvt
+  # admission/schedule path (producers/schedules) that leave spec.egress
+  # empty. Applied once, at creation — flipping it never reclassifies an
+  # existing run. Default "direct". A raw `kubectl apply` of an AgentRun with
+  # empty egress is defaulted to "direct" by the CRD schema regardless of this
+  # knob (docs/phase5-6b-observability-pr-plan.md decision 5).
+  defaultMode: direct
 
 broker:
   enabled: true

--- a/charts/nvt/values.yaml
+++ b/charts/nvt/values.yaml
@@ -14,6 +14,12 @@ egress:
   # empty egress is defaulted to "direct" by the CRD schema regardless of this
   # knob (docs/phase5-6b-observability-pr-plan.md decision 5).
   defaultMode: direct
+  # Opt into the per-grant allowInsecureUpstream escape hatch (plaintext
+  # upstream leg). Test/dev only, for hermetic in-cluster fixtures that cannot
+  # present a publicly-trusted cert. Leave false in any real deployment: a
+  # plaintext upstream carrying an injected credential is a conformance
+  # failure, and admission rejects the flag unless this is set.
+  allowInsecureUpstreams: false
 
 broker:
   enabled: true

--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -1,7 +1,7 @@
 # Plan: Mediated Credential Egress
 
 Status: living document — Phases 0–4 completed (#53, #54, Phase 2 gate, #56, #58, #59, Phase 4 git-over-HTTPS mediation)
-Version: v3.7 (Phase 5 PR 6a landed: own-Pod egressd + CNI-enforced NetworkPolicies behind `spec.egressEnforcement`, egress-denied smoke on the Calico kind cluster)
+Version: v3.7 (Phase 5 PR 6a landed: own-Pod egressd + CNI-enforced NetworkPolicies behind `spec.egressEnforcement`, egress-denied smoke on the Calico kind cluster; PR 6b landed: per-request audit via `POST /v1/injection/report`, per-grant request quotas, revocation bound proven + documented, Anthropic provider-agnosticism proof, `egress.defaultMode` knob defaulting to `direct` — global flip still deferred)
 
 ## Goal
 
@@ -293,7 +293,7 @@ May split into two PRs (enforcement; observability/control) even as one phase.
 - **Enforcement**: evaluate own-Pod egressd + NetworkPolicy vs. deprivileged-dind as the k8s control (§6); iptables owner-match **plus FORWARD-chain deny** where in-netns rules apply; state the NET_ADMIN precondition and the compose gap explicitly. Egress-denied smoke test lands in CI here.
 - **Per-request audit** appended to the broker's `audit.jsonl` (agent, capability, host, method, path class, status).
 - **Per-grant request-count quotas** at the sidecar (spend quotas deferred — they need provider-response parsing, which couples the generic proxy to each provider).
-- **Revocation**: broker revokes grant → sidecar's next fetch fails → agent loses API access within one cache TTL, without killing the Pod.
+- **Revocation**: broker revokes grant → sidecar's next fetch fails → agent loses API access, without killing the Pod. Bound (PR 6b, proven + documented): operator reconcile + kubelet ConfigMap projection (~1 min worst case) + egressd cache clamp (≤60s, shipped #61). Revoke through the AgentRun spec (the operator reconciles the broker agents ConfigMap); the broker agents ConfigMap must never be `subPath`-mounted or mtime hot-reload — and thus revocation — silently breaks.
 - **Anthropic as the provider-agnosticism proof**: adding `ANTHROPIC_BASE_URL` + a grant must be config-only with zero egressd changes — landing it *is* the test that the injector contract stayed provider-agnostic. If it requires sidecar code, that's a contract regression, not a feature.
 - Default handling (revised, see [phase5-enforcement-plan.md](phase5-enforcement-plan.md)): Phase 5 adds a `defaultEgressMode` chart value **defaulting to `direct`**. The global flip to `mediated` is product behavior, not just hardening — it moves to its own later PR, gated on both smoke tests green in CI **and** real-cluster soak with consumers migrated.
 

--- a/docs/phase5-6b-observability-pr-plan.md
+++ b/docs/phase5-6b-observability-pr-plan.md
@@ -1,6 +1,6 @@
 # PR 6b Plan: Observability + Control (audit, quotas, revocation, Anthropic proof)
 
-Status: plan — ready to implement (PR 6a merged, #63)
+Status: implemented — broker `POST /v1/injection/report` + async egressd reporter, per-grant `quota.requests`, revocation chain tests + subPath guard, Anthropic `static_token` generalization (zero egressd diffs), `egress.defaultMode` knob (default `direct`), hermetic kind echo fixture. Global mediated-by-default flip still deferred.
 Parent: [phase5-enforcement-plan.md](phase5-enforcement-plan.md) PR 6b (work
 items 5–9); prerequisites merged (#61 fixes, #62 broker TLS, #63 PR 6a)
 

--- a/egressd/cmd/egressd/main.go
+++ b/egressd/cmd/egressd/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -65,6 +66,12 @@ func run() error {
 		}
 	}
 	transport := &http.Transport{ForceAttemptHTTP2: true}
+	// One reporter per process, shared across routes and the forward proxy,
+	// draining a bounded queue to the broker's audit endpoint out-of-band.
+	reporter := egress.NewReporter(broker)
+	if reporter != nil {
+		go reporter.Run(context.Background())
+	}
 	listenerCount := len(config.Routes)
 	if config.ForwardProxy != nil {
 		listenerCount++
@@ -74,7 +81,7 @@ func run() error {
 	}
 	errors := make(chan error, listenerCount)
 	for _, route := range config.Routes {
-		proxy := &egress.Proxy{Route: route, Broker: broker, Transport: transport}
+		proxy := &egress.Proxy{Route: route, Broker: broker, Transport: transport, Reporter: reporter}
 		server := &http.Server{Addr: route.Listen, Handler: proxy}
 		scheme := "http"
 		if route.TLSEnabled() {
@@ -95,8 +102,9 @@ func run() error {
 	}
 	if config.ForwardProxy != nil {
 		proxy := &egress.ForwardProxy{
-			Config: *config.ForwardProxy,
-			Logger: log.New(os.Stdout, "", 0),
+			Config:   *config.ForwardProxy,
+			Logger:   log.New(os.Stdout, "", 0),
+			Reporter: reporter,
 		}
 		server := &http.Server{
 			Addr:              config.ForwardProxy.Listen,

--- a/egressd/internal/egress/broker.go
+++ b/egressd/internal/egress/broker.go
@@ -83,3 +83,28 @@ func (b *BrokerClient) FetchHeaders(ctx context.Context, capability, host, metho
 	}
 	return material, nil
 }
+
+// ReportRequests posts a batch of per-request audit entries to the broker.
+// It carries no credential material — only sanitized report fields — so its
+// failures are non-fatal to the request path (the Reporter drops on error).
+func (b *BrokerClient) ReportRequests(ctx context.Context, entries []map[string]any) error {
+	body, err := json.Marshal(map[string]any{"entries": entries})
+	if err != nil {
+		return fmt.Errorf("encode report request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, b.URL+"/v1/injection/report", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build report request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+b.Token)
+	response, err := b.Client.Do(request)
+	if err != nil {
+		return fmt.Errorf("broker unreachable: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("broker rejected report: status %d", response.StatusCode)
+	}
+	return nil
+}

--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -46,6 +46,11 @@ type Route struct {
 	// signed by the boot-generated per-agent CA (requires the config-level
 	// ca block). Mutually exclusive with listen_tls_cert/listen_tls_key.
 	ListenTLS string `json:"listen_tls"`
+	// MaxRequests caps proxied requests on this route. 0 means unlimited.
+	// The counter lives for the egressd process, not the run: an egressd
+	// restart resets it. This is a soft resource guard, not a security
+	// boundary (docs/phase5-6b-observability-pr-plan.md decision 3).
+	MaxRequests int `json:"max_requests"`
 }
 
 // TLSEnabled reports whether the agent-facing listener serves HTTPS.
@@ -153,6 +158,9 @@ func (c *Config) Validate() error {
 		}
 		if err := validateUpstream(route.Upstream); err != nil {
 			return fmt.Errorf("routes[%d].upstream: %w", index, err)
+		}
+		if route.MaxRequests < 0 {
+			return fmt.Errorf("routes[%d].max_requests must be non-negative", index)
 		}
 		if (route.ListenTLSCert == "") != (route.ListenTLSKey == "") {
 			return fmt.Errorf("routes[%d]: listen_tls_cert and listen_tls_key must be set together", index)

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -21,10 +21,15 @@ const (
 
 // ForwardProxy is a CONNECT-only blind tunnel. It does not inspect or modify
 // TLS, WebSocket frames, headers, cookies, bodies, or credentials.
+// forwardProxyCapability labels forward-proxy CONNECT audit reports. The
+// forward proxy is not per-capability; this is a fixed observability label.
+const forwardProxyCapability = "forward-proxy"
+
 type ForwardProxy struct {
-	Config ForwardProxyConfig
-	Dialer *net.Dialer
-	Logger *log.Logger
+	Config   ForwardProxyConfig
+	Dialer   *net.Dialer
+	Logger   *log.Logger
+	Reporter *Reporter
 
 	once        sync.Once
 	allowHosts  map[string]bool
@@ -136,6 +141,16 @@ func (p *ForwardProxy) dialer() *net.Dialer {
 }
 
 func (p *ForwardProxy) writeDecision(host string, port int, decision, errorClass string) {
+	// A resolved target is audit-worthy; targetless denials (malformed/plain
+	// HTTP) have no host and are logged only. The broker requires a host.
+	if host != "" {
+		p.Reporter.Enqueue(ReportEntry{
+			Capability: forwardProxyCapability,
+			Host:       host,
+			Port:       port,
+			Decision:   decision,
+		})
+	}
 	logger := p.Logger
 	if logger == nil {
 		logger = log.Default()

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -139,14 +139,6 @@ func (p *Proxy) entryValidLocked(entry *cacheEntry) bool {
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if p.quotaExceeded() {
-		// Fail closed before touching the broker or upstream. Counted and
-		// audited like any other outcome.
-		log.Printf("egressd %s: request quota exceeded", p.Route.Capability)
-		p.report(r.Method, r.URL.Path, http.StatusTooManyRequests)
-		writeError(w, http.StatusTooManyRequests, "egress-quota-exceeded")
-		return
-	}
 	material, err := p.material(r.Context(), r.Method, r.URL.Path)
 	if err != nil {
 		// err carries broker reasons only, never header values.
@@ -159,6 +151,16 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
 		writeError(w, http.StatusBadGateway, "egress-request-invalid")
+		return
+	}
+	// Quota is checked only after the request is authorized and ready for the
+	// upstream, so exactly MaxRequests authorized attempts reach upstream. A
+	// broker outage, a revoked grant, or a projection-lag failure fails above
+	// without ever consuming quota.
+	if p.quotaExceeded() {
+		log.Printf("egressd %s: request quota exceeded", p.Route.Capability)
+		p.report(r.Method, r.URL.Path, http.StatusTooManyRequests)
+		writeError(w, http.StatusTooManyRequests, "egress-quota-exceeded")
 		return
 	}
 	response, err := p.Transport.RoundTrip(outbound)

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -57,6 +58,21 @@ type Proxy struct {
 
 	mu    sync.Mutex
 	cache map[string]*cacheEntry
+
+	// requestCount is the per-process request tally for max_requests. It is
+	// incremented atomically; see quotaExceeded for the TOCTOU-free check.
+	requestCount atomic.Int64
+}
+
+// quotaExceeded increments the request tally and reports whether this request
+// is over the route's max_requests. Add-then-compare is TOCTOU-free: exactly
+// the first MaxRequests callers observe a count within the limit; the
+// (N+1)th and beyond fail closed. 0 means unlimited.
+func (p *Proxy) quotaExceeded() bool {
+	if p.Route.MaxRequests <= 0 {
+		return false
+	}
+	return p.requestCount.Add(1) > int64(p.Route.MaxRequests)
 }
 
 // report enqueues one sanitized audit entry for this route. Nil-safe and
@@ -123,6 +139,14 @@ func (p *Proxy) entryValidLocked(entry *cacheEntry) bool {
 }
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if p.quotaExceeded() {
+		// Fail closed before touching the broker or upstream. Counted and
+		// audited like any other outcome.
+		log.Printf("egressd %s: request quota exceeded", p.Route.Capability)
+		p.report(r.Method, r.URL.Path, http.StatusTooManyRequests)
+		writeError(w, http.StatusTooManyRequests, "egress-quota-exceeded")
+		return
+	}
 	material, err := p.material(r.Context(), r.Method, r.URL.Path)
 	if err != nil {
 		// err carries broker reasons only, never header values.

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -52,10 +52,23 @@ type Proxy struct {
 	Route     Route
 	Broker    *BrokerClient
 	Transport http.RoundTripper
+	Reporter  *Reporter
 	Now       func() time.Time
 
 	mu    sync.Mutex
 	cache map[string]*cacheEntry
+}
+
+// report enqueues one sanitized audit entry for this route. Nil-safe and
+// non-blocking; PathClass keeps raw paths out of the report.
+func (p *Proxy) report(method, path string, status int) {
+	p.Reporter.Enqueue(ReportEntry{
+		Capability: p.Route.Capability,
+		Host:       injectionHost(p.Route.Upstream),
+		Method:     method,
+		PathClass:  PathClass(path),
+		Status:     status,
+	})
 }
 
 func (p *Proxy) now() time.Time {
@@ -114,21 +127,25 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// err carries broker reasons only, never header values.
 		log.Printf("egressd %s: injection material unavailable: %v", p.Route.Capability, err)
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
 		writeError(w, http.StatusBadGateway, "egress-injection-unavailable")
 		return
 	}
 	outbound, err := p.buildOutbound(r, material)
 	if err != nil {
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
 		writeError(w, http.StatusBadGateway, "egress-request-invalid")
 		return
 	}
 	response, err := p.Transport.RoundTrip(outbound)
 	if err != nil {
 		log.Printf("egressd %s: upstream unreachable", p.Route.Capability)
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
 		writeError(w, http.StatusBadGateway, "egress-upstream-unreachable")
 		return
 	}
 	defer func() { _ = response.Body.Close() }()
+	p.report(r.Method, r.URL.Path, response.StatusCode)
 	copyResponse(w, response)
 }
 

--- a/egressd/internal/egress/quota_test.go
+++ b/egressd/internal/egress/quota_test.go
@@ -1,0 +1,108 @@
+package egress
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// TestQuotaEnforcesExactlyN pins the TOCTOU-free quota: with MaxRequests=N and
+// M>N concurrent requests, exactly N reach the upstream and the rest fail
+// closed with 429, regardless of interleaving.
+func TestQuotaEnforcesExactlyN(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	server, proxy := newTestProxyWithHandle(t, broker, upstream)
+
+	const limit = 5
+	const parallel = 40
+	proxy.Route.MaxRequests = limit
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	statusCounts := map[int]int{}
+	for i := 0; i < parallel; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			response, err := http.Get(server.URL + "/backend-api/responses")
+			if err != nil {
+				return
+			}
+			defer response.Body.Close()
+			mu.Lock()
+			statusCounts[response.StatusCode]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if statusCounts[http.StatusOK] != limit {
+		t.Fatalf("expected exactly %d OK responses, got %d (%v)", limit, statusCounts[http.StatusOK], statusCounts)
+	}
+	if statusCounts[http.StatusTooManyRequests] != parallel-limit {
+		t.Fatalf("expected %d 429 responses, got %d (%v)", parallel-limit, statusCounts[http.StatusTooManyRequests], statusCounts)
+	}
+	// Exactly N requests reached the upstream — the security-relevant claim.
+	upstream.mu.Lock()
+	reached := len(upstream.records)
+	upstream.mu.Unlock()
+	if reached != limit {
+		t.Fatalf("expected exactly %d requests to reach upstream, got %d", limit, reached)
+	}
+}
+
+// TestQuotaUnlimitedWhenZero pins the backward-compatible default: 0 means no
+// cap.
+func TestQuotaUnlimitedWhenZero(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	server, proxy := newTestProxyWithHandle(t, broker, upstream)
+	proxy.Route.MaxRequests = 0
+
+	for i := 0; i < 20; i++ {
+		response, err := http.Get(server.URL + "/x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("request %d got %d, want 200 (unlimited)", i, response.StatusCode)
+		}
+	}
+}
+
+// TestQuotaBreachIsReported pins that a quota-rejected request is audited with
+// status 429 (still observability), never reaching the broker headers path.
+func TestQuotaBreachIsReported(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	reports := newFakeReportServer(t)
+	reporter := reporterFor(reports, 16)
+	go reporter.Run(t.Context())
+
+	server, proxy := newTestProxyWithHandle(t, broker, upstream)
+	proxy.Reporter = reporter
+	proxy.Route.MaxRequests = 1
+
+	for i := 0; i < 2; i++ {
+		response, err := http.Get(server.URL + "/backend-api/x")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+	}
+	waitFor(t, func() bool {
+		for _, e := range reports.allEntries() {
+			if e["status"] == float64(http.StatusTooManyRequests) {
+				return true
+			}
+		}
+		return false
+	})
+	// The second (rejected) request never fetched headers: exactly one broker
+	// headers call for the one request that passed quota.
+	if broker.callCount() != 1 {
+		t.Fatalf("quota-rejected request must not hit the broker: %d calls", broker.callCount())
+	}
+}

--- a/egressd/internal/egress/quota_test.go
+++ b/egressd/internal/egress/quota_test.go
@@ -1,6 +1,7 @@
 package egress
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -52,6 +53,52 @@ func TestQuotaEnforcesExactlyN(t *testing.T) {
 	}
 }
 
+// TestQuotaNotConsumedByBrokerFailures pins finding 1: requests that fail
+// before the upstream (broker outage, revoked grant, projection lag) do not
+// burn quota. After the broker recovers, the full quota is still available.
+func TestQuotaNotConsumedByBrokerFailures(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	server, proxy := newTestProxyWithHandle(t, broker, upstream)
+	proxy.Route.MaxRequests = 2
+
+	// Broker unavailable: several requests fail closed (502) and must not
+	// consume the quota. Distinct paths avoid any caching interaction.
+	broker.setFail(true)
+	for i := 0; i < 5; i++ {
+		response, err := http.Get(fmt.Sprintf("%s/down-%d", server.URL, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusBadGateway {
+			t.Fatalf("broker-down request %d got %d, want 502", i, response.StatusCode)
+		}
+	}
+
+	// Broker recovers: the full quota of 2 is still available, then the 3rd
+	// is rejected.
+	broker.setFail(false)
+	for i := 0; i < 2; i++ {
+		response, err := http.Get(fmt.Sprintf("%s/up-%d", server.URL, i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("within-quota request %d got %d, want 200", i, response.StatusCode)
+		}
+	}
+	response, err := http.Get(server.URL + "/up-over")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("over-quota request got %d, want 429", response.StatusCode)
+	}
+}
+
 // TestQuotaUnlimitedWhenZero pins the backward-compatible default: 0 means no
 // cap.
 func TestQuotaUnlimitedWhenZero(t *testing.T) {
@@ -73,7 +120,8 @@ func TestQuotaUnlimitedWhenZero(t *testing.T) {
 }
 
 // TestQuotaBreachIsReported pins that a quota-rejected request is audited with
-// status 429 (still observability), never reaching the broker headers path.
+// status 429 and never reaches the upstream, while exactly the within-quota
+// request does.
 func TestQuotaBreachIsReported(t *testing.T) {
 	broker := newFakeBroker(t)
 	upstream := newFakeUpstream(t)
@@ -100,9 +148,12 @@ func TestQuotaBreachIsReported(t *testing.T) {
 		}
 		return false
 	})
-	// The second (rejected) request never fetched headers: exactly one broker
-	// headers call for the one request that passed quota.
-	if broker.callCount() != 1 {
-		t.Fatalf("quota-rejected request must not hit the broker: %d calls", broker.callCount())
+	// Quota is enforced after authorization but before the upstream, so
+	// exactly the within-quota request reaches upstream.
+	upstream.mu.Lock()
+	reached := len(upstream.records)
+	upstream.mu.Unlock()
+	if reached != 1 {
+		t.Fatalf("expected exactly 1 request to reach upstream, got %d", reached)
 	}
 }

--- a/egressd/internal/egress/reporter.go
+++ b/egressd/internal/egress/reporter.go
@@ -1,0 +1,189 @@
+package egress
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// PathClass reduces a request path to a sanitized audit class, computed at the
+// source so raw paths (repo names, file names) never leave egressd. git
+// smart-HTTP paths map to the three git classes; every other path reduces to
+// its first segment, and "/" to "root".
+func PathClass(path string) string {
+	switch {
+	case strings.HasSuffix(path, "/info/refs"):
+		return "info-refs"
+	case strings.HasSuffix(path, "/git-upload-pack"):
+		return "git-upload-pack"
+	case strings.HasSuffix(path, "/git-receive-pack"):
+		return "git-receive-pack"
+	}
+	trimmed := strings.TrimPrefix(path, "/")
+	if trimmed == "" {
+		return "root"
+	}
+	if index := strings.IndexByte(trimmed, '/'); index >= 0 {
+		trimmed = trimmed[:index]
+	}
+	if trimmed == "" {
+		return "root"
+	}
+	return trimmed
+}
+
+// Reporter batches per-request audit reports and flushes them to the broker
+// asynchronously. It is observability, not a security control
+// (protocol/injection.md): the queue is bounded and the flush is best-effort,
+// so reporting never adds latency to a proxied request and never fails one.
+// A full queue or a broker report failure drops the entry (counted, logged
+// sanitized) rather than blocking.
+//
+// path_class is computed by the caller (PathClass) so raw request paths never
+// enter the queue — only sanitized classes leave the process.
+type Reporter struct {
+	broker        *BrokerClient
+	queue         chan ReportEntry
+	batchSize     int
+	flushInterval time.Duration
+	dropped       int64
+}
+
+// ReportEntry is one audited outcome. A non-empty Decision marks a
+// forward-proxy CONNECT (host/port/decision); otherwise it is a proxied HTTP
+// request (method/path_class/status). No field is ever a header value.
+type ReportEntry struct {
+	Capability string
+	Host       string
+	Method     string
+	PathClass  string
+	Status     int
+	Port       int
+	Decision   string
+}
+
+func (e ReportEntry) toWire() map[string]any {
+	if e.Decision != "" {
+		return map[string]any{
+			"capability": e.Capability,
+			"host":       e.Host,
+			"port":       e.Port,
+			"decision":   e.Decision,
+		}
+	}
+	return map[string]any{
+		"capability": e.Capability,
+		"host":       e.Host,
+		"method":     e.Method,
+		"path_class": e.PathClass,
+		"status":     e.Status,
+	}
+}
+
+const (
+	defaultReportQueueSize     = 1024
+	defaultReportBatchSize     = 100
+	defaultReportFlushInterval = 2 * time.Second
+)
+
+// NewReporter builds a reporter over the shared broker client. A nil broker
+// yields a nil reporter so callers can wire it unconditionally.
+func NewReporter(broker *BrokerClient) *Reporter {
+	if broker == nil {
+		return nil
+	}
+	return &Reporter{
+		broker:        broker,
+		queue:         make(chan ReportEntry, defaultReportQueueSize),
+		batchSize:     defaultReportBatchSize,
+		flushInterval: defaultReportFlushInterval,
+	}
+}
+
+// Enqueue offers an entry to the queue without ever blocking. When the queue
+// is full the entry is dropped and counted — the request path must never wait
+// on audit.
+func (r *Reporter) Enqueue(entry ReportEntry) {
+	if r == nil {
+		return
+	}
+	select {
+	case r.queue <- entry:
+	default:
+		atomic.AddInt64(&r.dropped, 1)
+	}
+}
+
+// Dropped reports the number of entries dropped so far (test/observability).
+func (r *Reporter) Dropped() int64 {
+	if r == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&r.dropped)
+}
+
+// Run drains the queue on the flush tick or when a batch fills, until ctx is
+// cancelled, then makes a best-effort final drain. Start it once per process.
+func (r *Reporter) Run(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	ticker := time.NewTicker(r.flushInterval)
+	defer ticker.Stop()
+	batch := make([]ReportEntry, 0, r.batchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		r.send(ctx, batch)
+		batch = batch[:0]
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			r.finalDrain(ctx, batch)
+			return
+		case entry := <-r.queue:
+			batch = append(batch, entry)
+			if len(batch) >= r.batchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+func (r *Reporter) finalDrain(ctx context.Context, batch []ReportEntry) {
+	for {
+		select {
+		case entry := <-r.queue:
+			batch = append(batch, entry)
+			if len(batch) >= r.batchSize {
+				r.send(ctx, batch)
+				batch = batch[:0]
+			}
+		default:
+			r.send(ctx, batch)
+			return
+		}
+	}
+}
+
+func (r *Reporter) send(ctx context.Context, batch []ReportEntry) {
+	if len(batch) == 0 {
+		return
+	}
+	entries := make([]map[string]any, 0, len(batch))
+	for _, entry := range batch {
+		entries = append(entries, entry.toWire())
+	}
+	if err := r.broker.ReportRequests(ctx, entries); err != nil {
+		// err carries broker machine reasons only, never header values.
+		// Report failures are non-fatal by design: the batch is dropped.
+		atomic.AddInt64(&r.dropped, int64(len(batch)))
+		log.Printf("egressd: dropped %d audit reports: %v", len(batch), err)
+	}
+}

--- a/egressd/internal/egress/reporter.go
+++ b/egressd/internal/egress/reporter.go
@@ -8,10 +8,16 @@ import (
 	"time"
 )
 
+// pathClassMaxLen and pathClassAllowed mirror the broker's audit shape
+// (^[a-z0-9._-]{1,64}$, protocol/injection.md). PathClass guarantees its
+// output at the source so egressd can never emit a class the broker rejects.
+const pathClassMaxLen = 64
+
 // PathClass reduces a request path to a sanitized audit class, computed at the
 // source so raw paths (repo names, file names) never leave egressd. git
-// smart-HTTP paths map to the three git classes; every other path reduces to
-// its first segment, and "/" to "root".
+// smart-HTTP paths map to the three git classes; every other path reduces to a
+// sanitized form of its first segment, and "/" to "root". The result always
+// matches ^[a-z0-9._-]{1,64}$ for any input, hostile or not.
 func PathClass(path string) string {
 	switch {
 	case strings.HasSuffix(path, "/info/refs"):
@@ -22,16 +28,37 @@ func PathClass(path string) string {
 		return "git-receive-pack"
 	}
 	trimmed := strings.TrimPrefix(path, "/")
-	if trimmed == "" {
-		return "root"
-	}
 	if index := strings.IndexByte(trimmed, '/'); index >= 0 {
 		trimmed = trimmed[:index]
 	}
 	if trimmed == "" {
 		return "root"
 	}
-	return trimmed
+	class := sanitizePathClass(trimmed)
+	if class == "" {
+		// A non-empty segment made entirely of disallowed characters (e.g.
+		// "@@@", a percent-escape, non-ASCII) collapses to a safe bucket
+		// rather than leaking or emitting an invalid class.
+		return "other"
+	}
+	return class
+}
+
+// sanitizePathClass lowercases the segment and keeps only the broker's allowed
+// characters, capped at pathClassMaxLen. The kept runes are ASCII by
+// construction, so the byte cast is safe.
+func sanitizePathClass(segment string) string {
+	var builder strings.Builder
+	for _, r := range strings.ToLower(segment) {
+		if builder.Len() >= pathClassMaxLen {
+			break
+		}
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			builder.WriteByte(byte(r))
+		}
+	}
+	return builder.String()
 }
 
 // Reporter batches per-request audit reports and flushes them to the broker

--- a/egressd/internal/egress/reporter_test.go
+++ b/egressd/internal/egress/reporter_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -22,10 +24,48 @@ func TestPathClass(t *testing.T) {
 		"":                           "root",
 		"/v1/messages":               "v1",
 		"noslashprefix/x":            "noslashprefix",
+		"/Repos/O/R":                 "repos", // uppercase is lowercased
+		"/a@b@c/x":                   "abc",   // disallowed chars dropped
+		"/@@@/x":                     "other", // all-disallowed segment buckets
 	}
 	for path, want := range cases {
 		if got := PathClass(path); got != want {
 			t.Errorf("PathClass(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// TestPathClassAlwaysValid pins the source guarantee (protocol/injection.md):
+// PathClass output always matches the broker's audit shape for any input, so
+// egressd can never emit a class the broker rejects (which would silently drop
+// the whole audit batch).
+func TestPathClassAlwaysValid(t *testing.T) {
+	shape := regexp.MustCompile(`^[a-z0-9._-]{1,64}$`)
+	inputs := []string{
+		"",
+		"/",
+		"//",
+		"/UPPERCASE/x",
+		"/has space/x",
+		"/tab\tchar/x",
+		"/new\nline/x",
+		"/ctrl\x00byte/x",
+		"/café/x",      // non-ASCII
+		"/%2e%2e/x",    // percent-escapes
+		"/@#$%^&*()/x", // all-disallowed
+		"/../../etc/pwd",
+		"/" + strings.Repeat("verylongsegment", 20) + "/x", // > 64 chars
+		"/a.b_c-d/x",
+		strings.Repeat("x", 500),
+		"/../",
+		".",
+		"..",
+		"-",
+	}
+	for _, in := range inputs {
+		got := PathClass(in)
+		if !shape.MatchString(got) {
+			t.Errorf("PathClass(%q) = %q, which does not match %s", in, got, shape)
 		}
 	}
 }

--- a/egressd/internal/egress/reporter_test.go
+++ b/egressd/internal/egress/reporter_test.go
@@ -1,0 +1,215 @@
+package egress
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPathClass(t *testing.T) {
+	cases := map[string]string{
+		"/repos/o/r/git-upload-pack": "git-upload-pack",
+		"/o/r.git/git-receive-pack":  "git-receive-pack",
+		"/o/r.git/info/refs":         "info-refs",
+		"/repos/o/r/pulls/1":         "repos",
+		"/backend-api/responses":     "backend-api",
+		"/":                          "root",
+		"":                           "root",
+		"/v1/messages":               "v1",
+		"noslashprefix/x":            "noslashprefix",
+	}
+	for path, want := range cases {
+		if got := PathClass(path); got != want {
+			t.Errorf("PathClass(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// fakeReportServer records report batches posted to /v1/injection/report.
+type fakeReportServer struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	batches [][]map[string]any
+	status  int
+}
+
+func newFakeReportServer(t *testing.T) *fakeReportServer {
+	t.Helper()
+	f := &fakeReportServer{status: http.StatusOK}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/injection/report" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var decoded struct {
+			Entries []map[string]any `json:"entries"`
+		}
+		_ = json.Unmarshal(body, &decoded)
+		f.mu.Lock()
+		f.batches = append(f.batches, decoded.Entries)
+		status := f.status
+		f.mu.Unlock()
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"reported":1}`))
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeReportServer) allEntries() []map[string]any {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var all []map[string]any
+	for _, batch := range f.batches {
+		all = append(all, batch...)
+	}
+	return all
+}
+
+func (f *fakeReportServer) setStatus(status int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.status = status
+}
+
+func reporterFor(f *fakeReportServer, queueSize int) *Reporter {
+	return &Reporter{
+		broker:        &BrokerClient{URL: f.server.URL, Token: "egress-role-token", Client: f.server.Client()},
+		queue:         make(chan ReportEntry, queueSize),
+		batchSize:     defaultReportBatchSize,
+		flushInterval: 20 * time.Millisecond,
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}
+
+// TestReporterFlushesWithSanitizedFields pins that reports reach the broker
+// with the sanitized fields and no header values anywhere in the payload.
+func TestReporterFlushesWithSanitizedFields(t *testing.T) {
+	f := newFakeReportServer(t)
+	reporter := reporterFor(f, 16)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go reporter.Run(ctx)
+
+	reporter.Enqueue(ReportEntry{Capability: "git-app", Host: "github.com", Method: "POST", PathClass: "git-upload-pack", Status: 200})
+	reporter.Enqueue(ReportEntry{Capability: "tunnel-main", Host: "example.com", Port: 443, Decision: "allow"})
+
+	waitFor(t, func() bool { return len(f.allEntries()) >= 2 })
+	entries := f.allEntries()
+	var httpEntry, connectEntry map[string]any
+	for _, e := range entries {
+		if e["capability"] == "git-app" {
+			httpEntry = e
+		}
+		if e["capability"] == "tunnel-main" {
+			connectEntry = e
+		}
+	}
+	if httpEntry == nil || connectEntry == nil {
+		t.Fatalf("missing entries: %v", entries)
+	}
+	if httpEntry["path_class"] != "git-upload-pack" || httpEntry["status"] != float64(200) {
+		t.Fatalf("unexpected http entry: %v", httpEntry)
+	}
+	if _, hasMethod := connectEntry["method"]; hasMethod {
+		t.Fatalf("connect entry must not carry method: %v", connectEntry)
+	}
+	if connectEntry["decision"] != "allow" || connectEntry["port"] != float64(443) {
+		t.Fatalf("unexpected connect entry: %v", connectEntry)
+	}
+	// No report field may ever be a header/token value.
+	for _, e := range entries {
+		for _, key := range []string{"authorization", "headers", "token", "x-api-key"} {
+			if _, present := e[key]; present {
+				t.Fatalf("report entry leaked %q: %v", key, e)
+			}
+		}
+	}
+}
+
+// TestReporterDropsWhenFull pins the bound: a flood beyond queue capacity
+// drops (counted) instead of blocking or growing memory.
+func TestReporterDropsWhenFull(t *testing.T) {
+	f := newFakeReportServer(t)
+	reporter := reporterFor(f, 4)
+	// No Run goroutine: nothing drains, so the 5th+ enqueue drops.
+	for i := 0; i < 100; i++ {
+		reporter.Enqueue(ReportEntry{Capability: "c", Host: "h", Method: "GET", PathClass: "root", Status: 200})
+	}
+	if reporter.Dropped() == 0 {
+		t.Fatal("expected drops when the queue is full and undrained")
+	}
+	if reporter.Dropped() < 90 {
+		t.Fatalf("expected most of the flood dropped, got %d", reporter.Dropped())
+	}
+}
+
+// TestReporterBestEffortOnBrokerError pins that a failing report endpoint
+// drops the batch (counted) and never blocks or panics the flush loop.
+func TestReporterBestEffortOnBrokerError(t *testing.T) {
+	f := newFakeReportServer(t)
+	f.setStatus(http.StatusInternalServerError)
+	reporter := reporterFor(f, 16)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go reporter.Run(ctx)
+
+	reporter.Enqueue(ReportEntry{Capability: "c", Host: "h", Method: "GET", PathClass: "root", Status: 200})
+	waitFor(t, func() bool { return reporter.Dropped() >= 1 })
+}
+
+// TestProxyReportsWithoutAffectingTraffic pins latency/behaviour parity: with
+// the report endpoint failing, the proxied request still succeeds and the
+// report is emitted (best-effort), proving the report path is off the hot path.
+func TestProxyReportsWithoutAffectingTraffic(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	reports := newFakeReportServer(t)
+	// The proxy's broker client only serves /headers here; point the reporter
+	// at a separate report server so we can observe reports independently.
+	reporter := reporterFor(reports, 16)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go reporter.Run(ctx)
+
+	server, proxy := newTestProxyWithHandle(t, broker, upstream)
+	proxy.Reporter = reporter
+
+	response, err := http.Get(server.URL + "/backend-api/responses")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("proxied request must succeed regardless of reporting, got %d", response.StatusCode)
+	}
+	waitFor(t, func() bool {
+		for _, e := range reports.allEntries() {
+			if e["path_class"] == "backend-api" && e["status"] == float64(200) {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -103,9 +103,10 @@ type AgentRunBrokerGrant struct {
 	// AllowInsecureUpstream lets egressd reach this grant's upstream over
 	// plain HTTP instead of re-originating TLS. Dev/test only — it exists so
 	// hermetic in-cluster fixtures (which cannot present a publicly-trusted
-	// cert) are reachable from the kind egress smokes. Never set it for a
-	// real provider; a plaintext upstream leg carrying an injected credential
-	// is a conformance failure.
+	// cert) are reachable from the kind egress smokes. A plaintext upstream
+	// leg carries the injected credential in the clear, so admission rejects
+	// it unless the operator sets NVT_ALLOW_INSECURE_UPSTREAMS, and always
+	// rejects it for git grants.
 	AllowInsecureUpstream bool `json:"allowInsecureUpstream,omitempty"`
 	// Quota bounds proxied requests for this grant's route. Absent means
 	// unlimited. The count is per egressd process, not per run — an egressd

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -107,6 +107,18 @@ type AgentRunBrokerGrant struct {
 	// real provider; a plaintext upstream leg carrying an injected credential
 	// is a conformance failure.
 	AllowInsecureUpstream bool `json:"allowInsecureUpstream,omitempty"`
+	// Quota bounds proxied requests for this grant's route. Absent means
+	// unlimited. The count is per egressd process, not per run — an egressd
+	// restart resets it — so it is a soft resource guard, not a security
+	// boundary (docs/phase5-6b-observability-pr-plan.md decision 3).
+	Quota *AgentRunGrantQuota `json:"quota,omitempty"`
+}
+
+// AgentRunGrantQuota bounds a grant's egress.
+type AgentRunGrantQuota struct {
+	// Requests is the maximum number of proxied requests on this route.
+	// Must be positive when the quota block is present.
+	Requests int `json:"requests"`
 }
 
 // AgentRunPrompt defines the optional initial prompt for disposable runs.
@@ -275,6 +287,9 @@ func (in *AgentRunBrokerGrant) DeepCopy() *AgentRunBrokerGrant {
 		for key, value := range in.Permissions {
 			out.Permissions[key] = value
 		}
+	}
+	if in.Quota != nil {
+		out.Quota = &AgentRunGrantQuota{Requests: in.Quota.Requests}
 	}
 	return out
 }

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -100,6 +100,13 @@ type AgentRunBrokerGrant struct {
 	// Permissions narrows the provider-level permission ceiling per grant,
 	// mirroring GitHub App permission keys (values: read or write).
 	Permissions map[string]string `json:"permissions,omitempty"`
+	// AllowInsecureUpstream lets egressd reach this grant's upstream over
+	// plain HTTP instead of re-originating TLS. Dev/test only — it exists so
+	// hermetic in-cluster fixtures (which cannot present a publicly-trusted
+	// cert) are reachable from the kind egress smokes. Never set it for a
+	// real provider; a plaintext upstream leg carrying an injected credential
+	// is a conformance failure.
+	AllowInsecureUpstream bool `json:"allowInsecureUpstream,omitempty"`
 }
 
 // AgentRunPrompt defines the optional initial prompt for disposable runs.

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -48,6 +48,10 @@ func main() {
 		ctrl.Log.Error(err, "invalid broker TLS configuration")
 		os.Exit(1)
 	}
+	if err := controller.ValidateDefaultEgressMode(); err != nil {
+		ctrl.Log.Error(err, "invalid default egress mode configuration")
+		os.Exit(1)
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/operator/config/crd/bases/nvt.dev_agentruns.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentruns.yaml
@@ -131,6 +131,14 @@ spec:
                               enum:
                                 - read
                                 - write
+                          quota:
+                            type: object
+                            required:
+                              - requests
+                            properties:
+                              requests:
+                                type: integer
+                                minimum: 1
                 prompt:
                   type: object
                   properties:

--- a/operator/config/crd/bases/nvt.dev_agentruns.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentruns.yaml
@@ -121,6 +121,9 @@ spec:
                           git:
                             type: boolean
                             default: false
+                          allowInsecureUpstream:
+                            type: boolean
+                            default: false
                           permissions:
                             type: object
                             additionalProperties:

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2101,6 +2101,38 @@ func ValidateBrokerTLSConfig() error {
 	return nil
 }
 
+// DefaultEgressMode is the cluster's creation-time default egress mode, read
+// from NVT_DEFAULT_EGRESS_MODE (empty means direct). It is applied ONCE, at
+// AgentRun creation on the nvt admission path (ApplyDefaultEgressMode) — never
+// at reconcile time, so flipping the knob can never reclassify an existing
+// run (the #62/#63 retroactive-reclassification hazard). AgentRunEgressMode
+// deliberately does not read this env.
+func DefaultEgressMode() nvtv1alpha1.AgentRunEgressMode {
+	mode := strings.TrimSpace(os.Getenv("NVT_DEFAULT_EGRESS_MODE"))
+	if mode == "" {
+		return nvtv1alpha1.AgentRunEgressDirect
+	}
+	return nvtv1alpha1.AgentRunEgressMode(mode)
+}
+
+// ValidateDefaultEgressMode fails fast (operator startup) on a bad knob value.
+func ValidateDefaultEgressMode() error {
+	mode := DefaultEgressMode()
+	if mode != nvtv1alpha1.AgentRunEgressDirect && mode != nvtv1alpha1.AgentRunEgressMediated {
+		return fmt.Errorf("NVT_DEFAULT_EGRESS_MODE must be direct or mediated, got %q", mode)
+	}
+	return nil
+}
+
+// ApplyDefaultEgressMode stamps the cluster default into spec.egress when the
+// incoming run leaves it empty, so the stored object is always explicit and a
+// later knob change can never alter it. It never overrides an explicit mode.
+func ApplyDefaultEgressMode(agentRun *nvtv1alpha1.AgentRun) {
+	if agentRun.Spec.Egress == "" {
+		agentRun.Spec.Egress = DefaultEgressMode()
+	}
+}
+
 // AgentRunBrokerID returns the broker identity for an AgentRun.
 func AgentRunBrokerID(namespace, name string) string {
 	return namespace + "/" + name

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -1664,7 +1664,7 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 			Listen:                fmt.Sprintf("127.0.0.1:%d", egressRouteBasePort+routeIndex),
 			Capability:            grant.Provider,
 			Upstream:              grant.EgressHosts[0],
-			AllowInsecureUpstream: false,
+			AllowInsecureUpstream: grant.AllowInsecureUpstream,
 		}
 		if enforced {
 			// Own-Pod: the hop leaves localhost, so every route listens on

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2133,6 +2133,20 @@ func ApplyDefaultEgressMode(agentRun *nvtv1alpha1.AgentRun) {
 	}
 }
 
+// AllowInsecureUpstreamsEnabled reports whether the cluster opted into the
+// per-grant allowInsecureUpstream escape hatch via NVT_ALLOW_INSECURE_UPSTREAMS.
+// It exists only so hermetic in-cluster test fixtures are reachable; a real
+// deployment never sets it, so a plaintext upstream leg carrying an injected
+// credential cannot be requested by an AgentRun spec.
+func AllowInsecureUpstreamsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NVT_ALLOW_INSECURE_UPSTREAMS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // AgentRunBrokerID returns the broker identity for an AgentRun.
 func AgentRunBrokerID(namespace, name string) string {
 	return namespace + "/" + name
@@ -2206,6 +2220,17 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 		}
 		if grant.Quota != nil && grant.Quota.Requests <= 0 {
 			return fmt.Errorf("broker grant %s quota.requests must be a positive integer", grant.Provider)
+		}
+		if grant.AllowInsecureUpstream {
+			// A plaintext upstream leg carries the injected credential in the
+			// clear, so this is gated to a cluster/test opt-in and never
+			// allowed for git (git creds ride the TLS-terminated redirect).
+			if grant.Git {
+				return fmt.Errorf("broker grant %s must not set allowInsecureUpstream on a git grant", grant.Provider)
+			}
+			if !AllowInsecureUpstreamsEnabled() {
+				return fmt.Errorf("broker grant %s sets allowInsecureUpstream, which requires the operator's NVT_ALLOW_INSECURE_UPSTREAMS opt-in (test/dev only)", grant.Provider)
+			}
 		}
 		if mode == nvtv1alpha1.AgentRunEgressMediated && materialization == nvtv1alpha1.AgentRunGrantHeaderInject {
 			headerInjectGrants++

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -131,6 +131,11 @@ type brokerAgentGrantEntry struct {
 	Materialization string            `json:"materialization,omitempty"`
 	EgressHosts     []string          `json:"egress-hosts,omitempty"`
 	Permissions     map[string]string `json:"permissions,omitempty"`
+	Quota           *brokerAgentQuota `json:"quota,omitempty"`
+}
+
+type brokerAgentQuota struct {
+	Requests int `json:"requests"`
 }
 
 // AgentRunReconciler reconciles AgentRun resources.
@@ -1630,6 +1635,7 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 		Upstream              string `json:"upstream"`
 		AllowInsecureUpstream bool   `json:"allow_insecure_upstream"`
 		ListenTLS             string `json:"listen_tls,omitempty"`
+		MaxRequests           int    `json:"max_requests,omitempty"`
 	}
 	type egressdCA struct {
 		PublishDir   string   `json:"publish_dir,omitempty"`
@@ -1665,6 +1671,9 @@ func RenderEgressdConfigJSON(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 			Capability:            grant.Provider,
 			Upstream:              grant.EgressHosts[0],
 			AllowInsecureUpstream: grant.AllowInsecureUpstream,
+		}
+		if grant.Quota != nil {
+			route.MaxRequests = grant.Quota.Requests
 		}
 		if enforced {
 			// Own-Pod: the hop leaves localhost, so every route listens on
@@ -2163,6 +2172,9 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 				return fmt.Errorf("broker grant %s permissions must map permission names to read or write", grant.Provider)
 			}
 		}
+		if grant.Quota != nil && grant.Quota.Requests <= 0 {
+			return fmt.Errorf("broker grant %s quota.requests must be a positive integer", grant.Provider)
+		}
 		if mode == nvtv1alpha1.AgentRunEgressMediated && materialization == nvtv1alpha1.AgentRunGrantHeaderInject {
 			headerInjectGrants++
 			if len(grant.EgressHosts) == 0 {
@@ -2248,12 +2260,17 @@ func BrokerAgentGrants(broker *nvtv1alpha1.AgentRunBroker) []brokerAgentGrantEnt
 				permissions[key] = value
 			}
 		}
+		var quota *brokerAgentQuota
+		if grant.Quota != nil {
+			quota = &brokerAgentQuota{Requests: grant.Quota.Requests}
+		}
 		grants = append(grants, brokerAgentGrantEntry{
 			Provider:        grant.Provider,
 			Repositories:    repositories,
 			Materialization: string(AgentRunGrantMaterialization(grant)),
 			EgressHosts:     append([]string{}, grant.EgressHosts...),
 			Permissions:     permissions,
+			Quota:           quota,
 		})
 	}
 	sort.SliceStable(grants, func(i, j int) bool {

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -678,6 +678,42 @@ func TestValidateAgentRunEgressModeRejectsInvalidQuota(t *testing.T) {
 	}
 }
 
+func insecureUpstreamAgentRun() *nvtv1alpha1.AgentRun {
+	agentRun := testAgentRun()
+	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	agentRun.Spec.EgressAllowInsecureBroker = true
+	agentRun.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "echo-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject,
+		EgressHosts: []string{"nvt-smoke-echo.nvt.svc.cluster.local:443"}, AllowInsecureUpstream: true,
+	}}}
+	return agentRun
+}
+
+func TestValidateAllowInsecureUpstreamRequiresOptIn(t *testing.T) {
+	// Without the operator opt-in, an allowInsecureUpstream grant is rejected
+	// so a bad spec cannot silently downgrade the provider leg to plaintext.
+	run := insecureUpstreamAgentRun()
+	if err := ValidateAgentRunEgressMode(run); err == nil ||
+		!strings.Contains(err.Error(), "NVT_ALLOW_INSECURE_UPSTREAMS") || !strings.Contains(err.Error(), "echo-main") {
+		t.Fatalf("expected opt-in rejection naming the grant, got %v", err)
+	}
+
+	// With the cluster/test opt-in it is allowed for a non-git grant.
+	t.Setenv("NVT_ALLOW_INSECURE_UPSTREAMS", "1")
+	if err := ValidateAgentRunEgressMode(insecureUpstreamAgentRun()); err != nil {
+		t.Fatalf("allowInsecureUpstream must be accepted under the opt-in, got %v", err)
+	}
+}
+
+func TestValidateAllowInsecureUpstreamRejectedForGit(t *testing.T) {
+	t.Setenv("NVT_ALLOW_INSECURE_UPSTREAMS", "1")
+	run := insecureUpstreamAgentRun()
+	run.Spec.Broker.Grants[0].Git = true
+	if err := ValidateAgentRunEgressMode(run); err == nil || !strings.Contains(err.Error(), "git") {
+		t.Fatalf("allowInsecureUpstream must never be allowed for a git grant even with the opt-in, got %v", err)
+	}
+}
+
 func multiGrantMediatedAgentRun() *nvtv1alpha1.AgentRun {
 	agentRun := testAgentRun()
 	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -609,6 +609,34 @@ func TestRenderEgressdConfigUsesConfiguredRouteHost(t *testing.T) {
 	}
 }
 
+func TestRenderEgressdConfigAllowInsecureUpstream(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	agentRun.Spec.EgressAllowInsecureBroker = true
+	agentRun.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "echo-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject,
+		EgressHosts: []string{"nvt-smoke-echo.nvt.svc.cluster.local:443"}, AllowInsecureUpstream: true,
+	}}}
+
+	rendered, err := RenderEgressdConfigJSON(agentRun)
+	if err != nil {
+		t.Fatalf("render egressd config: %v", err)
+	}
+	if !strings.Contains(rendered, `"allow_insecure_upstream": true`) {
+		t.Fatalf("expected allow_insecure_upstream true for the grant:\n%s", rendered)
+	}
+
+	// The default (unset) stays false — no accidental plaintext upstream.
+	agentRun.Spec.Broker.Grants[0].AllowInsecureUpstream = false
+	rendered, err = RenderEgressdConfigJSON(agentRun)
+	if err != nil {
+		t.Fatalf("render egressd config: %v", err)
+	}
+	if !strings.Contains(rendered, `"allow_insecure_upstream": false`) {
+		t.Fatalf("expected allow_insecure_upstream false by default:\n%s", rendered)
+	}
+}
+
 func multiGrantMediatedAgentRun() *nvtv1alpha1.AgentRun {
 	agentRun := testAgentRun()
 	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -637,6 +637,47 @@ func TestRenderEgressdConfigAllowInsecureUpstream(t *testing.T) {
 	}
 }
 
+func TestRenderEgressdConfigQuota(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	agentRun.Spec.EgressAllowInsecureBroker = true
+	agentRun.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "api-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject,
+		EgressHosts: []string{"api.example.test:443"}, Quota: &nvtv1alpha1.AgentRunGrantQuota{Requests: 42},
+	}}}
+
+	rendered, err := RenderEgressdConfigJSON(agentRun)
+	if err != nil {
+		t.Fatalf("render egressd config: %v", err)
+	}
+	if !strings.Contains(rendered, `"max_requests": 42`) {
+		t.Fatalf("expected max_requests 42:\n%s", rendered)
+	}
+
+	// Absent quota renders no max_requests (unlimited).
+	agentRun.Spec.Broker.Grants[0].Quota = nil
+	rendered, err = RenderEgressdConfigJSON(agentRun)
+	if err != nil {
+		t.Fatalf("render egressd config: %v", err)
+	}
+	if strings.Contains(rendered, "max_requests") {
+		t.Fatalf("absent quota must omit max_requests:\n%s", rendered)
+	}
+}
+
+func TestValidateAgentRunEgressModeRejectsInvalidQuota(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	agentRun.Spec.EgressAllowInsecureBroker = true
+	agentRun.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "api-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject,
+		EgressHosts: []string{"api.example.test:443"}, Quota: &nvtv1alpha1.AgentRunGrantQuota{Requests: 0},
+	}}}
+	if err := ValidateAgentRunEgressMode(agentRun); err == nil || !strings.Contains(err.Error(), "api-main") || !strings.Contains(err.Error(), "quota") {
+		t.Fatalf("expected quota rejection naming the grant, got %v", err)
+	}
+}
+
 func multiGrantMediatedAgentRun() *nvtv1alpha1.AgentRun {
 	agentRun := testAgentRun()
 	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated

--- a/operator/internal/controller/agentschedule_admission.go
+++ b/operator/internal/controller/agentschedule_admission.go
@@ -136,6 +136,10 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 
 	run := admission.AgentRun
+	// Apply the cluster's default egress mode before validation and creation,
+	// so the stored spec.egress is always explicit and a later knob change can
+	// never reclassify this run. Never overrides an explicit mode.
+	ApplyDefaultEgressMode(&run)
 	if err := ValidateAgentRunEgressMode(&run); err != nil {
 		reason := err.Error()
 		h.recordRejected(ctx, schedule, reason)

--- a/operator/internal/controller/default_egress_mode_test.go
+++ b/operator/internal/controller/default_egress_mode_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	nvtv1alpha1 "github.com/mirkoSekulic/nvt-agent/operator/api/v1alpha1"
+)
+
+func TestValidateDefaultEgressMode(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "")
+	if err := ValidateDefaultEgressMode(); err != nil {
+		t.Fatalf("empty (direct) default must validate: %v", err)
+	}
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "mediated")
+	if err := ValidateDefaultEgressMode(); err != nil {
+		t.Fatalf("mediated default must validate: %v", err)
+	}
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "bogus")
+	if err := ValidateDefaultEgressMode(); err == nil {
+		t.Fatal("bogus default must fail validation")
+	}
+}
+
+func TestApplyDefaultEgressModeNeverOverridesExplicit(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "mediated")
+	run := testAgentRun()
+	run.Spec.Egress = nvtv1alpha1.AgentRunEgressDirect
+	ApplyDefaultEgressMode(run)
+	if run.Spec.Egress != nvtv1alpha1.AgentRunEgressDirect {
+		t.Fatalf("explicit direct must survive a mediated default, got %q", run.Spec.Egress)
+	}
+}
+
+func TestApplyDefaultEgressModeStampsEmpty(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "mediated")
+	run := testAgentRun()
+	run.Spec.Egress = ""
+	ApplyDefaultEgressMode(run)
+	if run.Spec.Egress != nvtv1alpha1.AgentRunEgressMediated {
+		t.Fatalf("empty egress must be stamped with the mediated default, got %q", run.Spec.Egress)
+	}
+}
+
+// TestAgentRunEgressModeIgnoresKnob pins the CRD-default scope boundary: the
+// operator never resolves empty egress from the env at read time (that would
+// reintroduce the retroactive-reclassification hazard). A run with empty
+// egress is direct regardless of the knob — the raw-kubectl path stays direct.
+func TestAgentRunEgressModeIgnoresKnob(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "mediated")
+	run := testAgentRun()
+	run.Spec.Egress = ""
+	if AgentRunEgressMode(run) != nvtv1alpha1.AgentRunEgressDirect {
+		t.Fatalf("AgentRunEgressMode must not read the knob; empty resolves to direct, got %q", AgentRunEgressMode(run))
+	}
+}
+
+// TestAdmissionStampsDefaultEgressMode pins that the nvt admission path stamps
+// the knob into spec.egress at creation, so the stored object is explicit.
+func TestAdmissionStampsDefaultEgressMode(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "direct")
+	fixture := scheduleAdmissionFixture(t, testAgentSchedule())
+	// Payload leaves spec.egress empty; the knob (direct) is stamped.
+	body := scheduleAdmissionBody(t, "work-1", "https://example.test/1", map[string]any{})
+	response, k8sClient := serveScheduleAdmission(t, fixture, body)
+
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, response, http.StatusCreated, &decoded)
+	if decoded.AgentRun == nil {
+		t.Fatalf("expected an AgentRun, got %#v", decoded)
+	}
+	run := getScheduledAgentRun(context.Background(), t, k8sClient, decoded.AgentRun.Namespace, decoded.AgentRun.Name)
+	if run.Spec.Egress != nvtv1alpha1.AgentRunEgressDirect {
+		t.Fatalf("stored spec.egress must be explicit (direct), got %q", run.Spec.Egress)
+	}
+}
+
+// TestAdmissionMediatedDefaultRejectsFileBundle pins that under a mediated
+// default, a file-bundle grant fails admission loudly naming the grant — no
+// silent downgrade.
+func TestAdmissionMediatedDefaultRejectsFileBundle(t *testing.T) {
+	t.Setenv("NVT_DEFAULT_EGRESS_MODE", "mediated")
+	// TLS broker so validation reaches the materialization check rather than
+	// stopping at the plaintext-broker guard.
+	setTLSBrokerEnv(t)
+	fixture := scheduleAdmissionFixture(t, testAgentSchedule())
+	body := scheduleAdmissionBody(t, "work-1", "https://example.test/1", map[string]any{
+		"spec": map[string]any{
+			"broker": map[string]any{
+				"grants": []any{map[string]any{
+					"provider":        "bundle-main",
+					"repositories":    []any{"example/repo"},
+					"materialization": "file-bundle",
+				}},
+			},
+		},
+	})
+	response, _ := serveScheduleAdmission(t, fixture, body)
+
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, response, http.StatusBadRequest, &decoded)
+	if decoded.Scheduled {
+		t.Fatalf("mediated default + file-bundle grant must be rejected: %#v", decoded)
+	}
+	if !strings.Contains(decoded.Reason, "bundle-main") {
+		t.Fatalf("rejection must name the grant, got %q", decoded.Reason)
+	}
+}

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -184,6 +184,63 @@ for grants whose routing carries it. Non-git capabilities omit the field.
 The local base URL the agent's tooling points at (the `egressd` listen
 address) is composed by runtime bootstrap, not returned by the broker.
 
+### POST /v1/injection/report
+
+Egress role only. Reports proxied requests so the broker's audit log covers
+individual requests, not just per-fetch injection. This endpoint is
+**observability, not a security control**: reporting is asynchronous,
+bounded, and best-effort on the `egressd` side — a report failure is logged
+and dropped, never blocking or failing proxied traffic. Authorization and
+enforcement live in `/v1/injection/headers` and the network layer, not here.
+
+Request (batched):
+
+```json
+{"entries": [
+  {"capability": "git-app", "host": "github.com", "method": "POST",
+   "path_class": "git-upload-pack", "status": 200},
+  {"capability": "codex-main", "host": "chatgpt.com", "method": "POST",
+   "path_class": "backend-api", "status": 429}
+]}
+```
+
+Forward-proxy CONNECT entries use `{capability, host, port, decision}` where
+`decision` is `allow` or `deny`:
+
+```json
+{"entries": [
+  {"capability": "tunnel-main", "host": "example.com", "port": 443,
+   "decision": "allow"}
+]}
+```
+
+Response: `{"ok": true, "reported": <n>}`.
+
+Rules:
+
+- Egress role only; the paired agent is resolved as for
+  `/v1/injection/headers`. An `agent` identity is denied.
+- Authorization is role + pairing only. Entries are **not** re-checked
+  against grants: a report for a just-revoked capability is still
+  audit-worthy, and a compromised `egressd` can spam granted capabilities
+  regardless — re-checking buys nothing and would drop legitimate audit.
+- `path_class` is a **sanitized** class, never a raw path (see below).
+  `egressd` computes it at the source so raw paths never leave the sidecar.
+- At most 100 entries per report; combined with the request size limit this
+  bounds a report. Oversized reports are denied with the standard error
+  shape, not truncated silently. A malformed entry rejects the whole batch;
+  nothing is partially audited.
+- One audit line per entry, `operation: "injection.request"` (HTTP) with
+  `{host, method, path_class, status}` or the CONNECT shape with
+  `{host, port, decision}`. Header values and token material never appear,
+  on any path including errors.
+
+**`path_class` definition.** git smart-HTTP paths reduce to
+`git-upload-pack` | `git-receive-pack` | `info-refs`; every other path
+reduces to its first path segment (`/repos/o/r/pulls/1` → `repos`, `/` →
+`root`). This keeps the audit useful without spraying repo or file names
+into it.
+
 ## Placeholder Convention
 
 Some CLIs refuse to start without a syntactically present key. Mediated mode
@@ -219,6 +276,15 @@ Every injection request appends one JSONL audit entry: request id,
 capability, egress identity id, paired agent id, host, method, path class,
 allow/deny result, denial reason, and expiry metadata. Header values and
 token material are never logged, on any path including errors.
+
+`/v1/injection/headers` audits one entry per *fetch*, which `egressd` caches
+for a TTL window — so it does not capture individual proxied requests.
+`/v1/injection/report` (above) closes that gap: `egressd` reports each
+proxied request and forward-proxy CONNECT, appending one
+`operation: "injection.request"` line per entry to the same log. Because
+that reporting is best-effort observability, audit completeness is not a
+security guarantee — the security guarantees are non-possession and
+enforcement, neither of which depends on the report path.
 
 ## Stability
 

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -239,7 +239,10 @@ Rules:
 `git-upload-pack` | `git-receive-pack` | `info-refs`; every other path
 reduces to its first path segment (`/repos/o/r/pulls/1` → `repos`, `/` →
 `root`). This keeps the audit useful without spraying repo or file names
-into it.
+into it. The broker **enforces the shape** — `path_class` must match
+`^[a-z0-9._-]{1,64}$` — so a buggy or compromised `egressd` cannot write a
+raw path or arbitrary string into the audit log; a non-conforming entry
+rejects the batch.
 
 ## Placeholder Convention
 

--- a/scripts/agent-init.sh
+++ b/scripts/agent-init.sh
@@ -365,6 +365,9 @@ for grant in agent.get("grants", []) or []:
         "upstream": hosts[0],
         "allow_insecure_upstream": False,
     }
+    quota = grant.get("quota")
+    if isinstance(quota, dict) and isinstance(quota.get("requests"), int):
+        route["max_requests"] = quota["requests"]
     if grant.get("git"):
         route["listen_tls"] = "ca"
         need_ca = True

--- a/scripts/broker-agents.py
+++ b/scripts/broker-agents.py
@@ -79,7 +79,7 @@ def parse_permissions(entries):
     return permissions
 
 
-def add_grant(data, name, provider, repo, materialization, egress_hosts, git=False, permissions=None):
+def add_grant(data, name, provider, repo, materialization, egress_hosts, git=False, permissions=None, quota_requests=None):
     for agent in data["agents"]:
         if isinstance(agent, dict) and agent.get("id") == name:
             if agent.get("role", "agent") == "egress":
@@ -103,12 +103,16 @@ def add_grant(data, name, provider, repo, materialization, egress_hosts, git=Fal
                         grant["git"] = True
                     if permissions:
                         grant.setdefault("permissions", {}).update(permissions)
+                    if quota_requests is not None:
+                        grant["quota"] = {"requests": quota_requests}
                     return
             entry = {"provider": provider, "repositories": [repo], "materialization": materialization or "file-bundle", "egress-hosts": egress_hosts or []}
             if git:
                 entry["git"] = True
             if permissions:
                 entry["permissions"] = dict(permissions)
+            if quota_requests is not None:
+                entry["quota"] = {"requests": quota_requests}
             grants.append(entry)
             grants.sort(key=lambda grant: grant["provider"])
             return
@@ -154,6 +158,7 @@ def main():
     grant.add_argument("--egress-host", action="append", default=[])
     grant.add_argument("--git", action="store_true", help="git-over-HTTPS grant: TLS redirect route + git bootstrap wiring")
     grant.add_argument("--permission", action="append", default=[], help="grant-level permission as <name>=read|write")
+    grant.add_argument("--quota-requests", type=int, help="per-route request quota (positive; enforced per egressd process)")
 
     unregister = subparsers.add_parser("unregister")
     unregister.add_argument("--name", required=True)
@@ -166,7 +171,9 @@ def main():
         with_lock(path, lambda data: copy_register_agent(data, args.from_name, args.name, args.token, args.copy_grants))
     elif args.command == "grant":
         permissions = parse_permissions(args.permission)
-        with_lock(path, lambda data: add_grant(data, args.name, args.provider, args.repo, args.materialization, args.egress_host, args.git, permissions))
+        if args.quota_requests is not None and args.quota_requests < 1:
+            raise SystemExit("--quota-requests must be a positive integer")
+        with_lock(path, lambda data: add_grant(data, args.name, args.provider, args.repo, args.materialization, args.egress_host, args.git, permissions, args.quota_requests))
     elif args.command == "unregister":
         with_lock(path, lambda data: unregister_agent(data, args.name))
 

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -376,6 +376,19 @@ providers:
     allow:
       repositories:
         - my-user/my-repo
+  - name: anthropic-main
+    plugin: token
+    config:
+      token-env: TEST_ANTHROPIC_KEY
+      injection-hosts:
+        - api.anthropic.com
+      injection-header: x-api-key
+      injection-scheme: ""
+      injection-extra-headers:
+        anthropic-version: "2023-06-01"
+    allow:
+      repositories:
+        - my-user/my-repo
   - name: header-provider
     plugin: headers
     config:
@@ -441,6 +454,7 @@ func (f *brokerFixture) start() {
 		"TEST_AUTH_HEADER=Authorization: Bearer header-secret",
 		"TEST_EXTRA_HEADER=X-Api-Key: extra-secret",
 		"TEST_ALTINN_API_KEY_HEADER=X-API-Key: altinn-secret",
+		"TEST_ANTHROPIC_KEY=anthropic-secret-key",
 	)
 	cmd.Stdout = &f.stdout
 	cmd.Stderr = &f.stderr

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -571,3 +571,50 @@ func TestInjectionAuditOmitsSecretValues(t *testing.T) {
 		}
 	}
 }
+
+// TestAnthropicProviderAgnosticismProof pins the provider-agnosticism proof
+// (docs/phase5-6b-observability-pr-plan.md item 5): a generalized static_token
+// provider injects Anthropic's x-api-key (no Bearer scheme) plus a static
+// anthropic-version header, both stripped from the request — with zero egressd
+// changes. The whole point of the proof is that adding Anthropic is broker
+// config only.
+func TestAnthropicProviderAgnosticismProof(t *testing.T) {
+	f := newBrokerFixture(t)
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{{Provider: "anthropic-main", Materialization: "header-inject"}}
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	payload := map[string]any{
+		"capability": "anthropic-main",
+		"host":       "api.anthropic.com",
+		"method":     "POST",
+		"path":       "/v1/messages",
+	}
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", payload)
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("anthropic injection must succeed: status=%d body=%v", status, body)
+	}
+	headers, ok := body["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("headers missing: %v", body)
+	}
+	if headers["x-api-key"] != "anthropic-secret-key" {
+		t.Fatalf("expected x-api-key with the raw token, got %v", headers["x-api-key"])
+	}
+	if headers["anthropic-version"] != "2023-06-01" {
+		t.Fatalf("expected anthropic-version extra header, got %v", headers["anthropic-version"])
+	}
+	// Key-header providers must not carry a Bearer authorization header.
+	if _, present := headers["authorization"]; present {
+		t.Fatalf("x-api-key provider must not inject authorization: %v", headers)
+	}
+	strip := map[string]bool{}
+	for _, name := range body["strip_request_headers"].([]any) {
+		strip[name.(string)] = true
+	}
+	if !strip["x-api-key"] || !strip["anthropic-version"] {
+		t.Fatalf("every injected header must be stripped, got %v", body["strip_request_headers"])
+	}
+}

--- a/tests/broker/injection_conformance_test.go
+++ b/tests/broker/injection_conformance_test.go
@@ -26,6 +26,7 @@ type roleGrant struct {
 	Repositories    []string
 	Materialization string
 	Permissions     map[string]string
+	QuotaRequests   int
 }
 
 type roleIdentity struct {
@@ -90,6 +91,9 @@ func (f *brokerFixture) writeRoleIdentities(identities map[string]roleIdentity) 
 				for _, key := range keys {
 					builder.WriteString(fmt.Sprintf("          %s: %s\n", key, grant.Permissions[key]))
 				}
+			}
+			if grant.QuotaRequests > 0 {
+				builder.WriteString(fmt.Sprintf("        quota:\n          requests: %d\n", grant.QuotaRequests))
 			}
 		}
 	}

--- a/tests/broker/injection_report_conformance_test.go
+++ b/tests/broker/injection_report_conformance_test.go
@@ -264,3 +264,36 @@ func TestRevocationFailsClosedOnGrantRemoval(t *testing.T) {
 		t.Fatalf("revoked grant must deny provider-not-granted, got %v", body["error"])
 	}
 }
+
+// TestReportRejectsRawPathClass pins finding 3: the broker enforces the
+// path_class shape, so a buggy egressd or leaked egress token cannot write
+// raw paths or arbitrary strings into the audit log.
+func TestReportRejectsRawPathClass(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	for _, bad := range []string{
+		"/repos/secret-owner/secret-repo/pulls/1", // a raw path with slashes
+		"has spaces",
+		"UPPERCASE",
+		"contains\nnewline",
+		strings.Repeat("x", 65), // over the length cap
+	} {
+		entry := reportEntry()
+		entry["path_class"] = bad
+		status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+			map[string]any{"entries": []any{entry}})
+		if status != http.StatusBadRequest || body["error"] != "entry-invalid" {
+			t.Fatalf("path_class %q must be rejected as entry-invalid: status=%d body=%v", bad, status, body)
+		}
+	}
+
+	// A well-formed class is accepted.
+	entry := reportEntry()
+	entry["path_class"] = "git-upload-pack"
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": []any{entry}})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("well-formed path_class must be accepted: status=%d body=%v", status, body)
+	}
+}

--- a/tests/broker/injection_report_conformance_test.go
+++ b/tests/broker/injection_report_conformance_test.go
@@ -1,0 +1,210 @@
+package broker_test
+
+// Conformance for POST /v1/injection/report (protocol/injection.md): egress
+// reports proxied requests for audit. Role + pairing gate it; entries are
+// audited but never re-checked against grants; header values never appear.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+func reportEntry() map[string]any {
+	return map[string]any{
+		"capability": "codex-main",
+		"host":       "chatgpt.com",
+		"method":     "POST",
+		"path_class": "backend-api",
+		"status":     200,
+	}
+}
+
+func readAuditEntries(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("audit line not JSON: %v (%q)", err, line)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// TestReportRequiresEgressRole pins role gating: the paired egress identity
+// reports; the agent identity holding the grant is refused.
+func TestReportRequiresEgressRole(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": []any{reportEntry()}})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("egress report must succeed: status=%d body=%v", status, body)
+	}
+	if body["reported"] != float64(1) {
+		t.Fatalf("expected reported=1, got %v", body["reported"])
+	}
+
+	status, body = f.postJSONWithToken("frontend-token", "/v1/injection/report",
+		map[string]any{"entries": []any{reportEntry()}})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("agent identity must be refused: status=%d body=%v", status, body)
+	}
+	if body["error"] != "role-not-allowed" {
+		t.Fatalf("expected role-not-allowed, got %v", body["error"])
+	}
+}
+
+// TestReportAuditEntryShape pins one audit line per entry with the documented
+// fields and operation, and the CONNECT shape.
+func TestReportAuditEntryShape(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	entries := []any{
+		reportEntry(),
+		map[string]any{"capability": "tunnel-main", "host": "example.com", "port": 443, "decision": "deny"},
+	}
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": entries})
+	if status != http.StatusOK || body["reported"] != float64(2) {
+		t.Fatalf("expected 2 reported: status=%d body=%v", status, body)
+	}
+
+	audit := readAuditEntries(t, f.audit)
+	var httpEntry, connectEntry map[string]any
+	for _, entry := range audit {
+		if entry["operation"] != "injection.request" {
+			continue
+		}
+		if entry["provider"] == "codex-main" {
+			httpEntry = entry
+		}
+		if entry["provider"] == "tunnel-main" {
+			connectEntry = entry
+		}
+	}
+	if httpEntry == nil || connectEntry == nil {
+		t.Fatalf("missing injection.request audit entries: %v", audit)
+	}
+	for key, want := range map[string]any{
+		"agent":        "frontend-egress",
+		"paired_agent": "frontend",
+		"host":         "chatgpt.com",
+		"method":       "POST",
+		"path_class":   "backend-api",
+		"status":       float64(200),
+		"allowed":      true,
+	} {
+		if httpEntry[key] != want {
+			t.Fatalf("http audit %s = %v, want %v (%v)", key, httpEntry[key], want, httpEntry)
+		}
+	}
+	for key, want := range map[string]any{
+		"host":     "example.com",
+		"port":     float64(443),
+		"decision": "deny",
+	} {
+		if connectEntry[key] != want {
+			t.Fatalf("connect audit %s = %v, want %v (%v)", key, connectEntry[key], want, connectEntry)
+		}
+	}
+}
+
+// TestReportNotReCheckedAgainstGrants pins decision 1: a report for a
+// capability the paired agent does not hold is still audited, not denied.
+func TestReportNotReCheckedAgainstGrants(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	entry := reportEntry()
+	entry["capability"] = "capability-never-granted"
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": []any{entry}})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("ungranted-capability report must still be audited: status=%d body=%v", status, body)
+	}
+	audit := readAuditEntries(t, f.audit)
+	found := false
+	for _, e := range audit {
+		if e["operation"] == "injection.request" && e["provider"] == "capability-never-granted" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an audit entry for the ungranted capability: %v", audit)
+	}
+}
+
+// TestReportRejectsOversizedBatch pins the entry cap: >100 entries deny with
+// the standard error shape, not silent truncation.
+func TestReportRejectsOversizedBatch(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	entries := make([]any, 101)
+	for i := range entries {
+		entries[i] = reportEntry()
+	}
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": entries})
+	if status != http.StatusBadRequest || body["ok"] == true {
+		t.Fatalf("oversized batch must deny: status=%d body=%v", status, body)
+	}
+	if body["error"] != "entries-too-many" {
+		t.Fatalf("expected entries-too-many, got %v", body["error"])
+	}
+}
+
+// TestReportRejectsMalformedEntryWhole pins that a malformed entry rejects the
+// whole batch, so nothing is partially audited.
+func TestReportRejectsMalformedEntryWhole(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	good := reportEntry()
+	good["host"] = "good.example.com"
+	bad := reportEntry()
+	delete(bad, "path_class")
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{"entries": []any{good, bad}})
+	if status != http.StatusBadRequest || body["ok"] == true {
+		t.Fatalf("malformed entry must reject the batch: status=%d body=%v", status, body)
+	}
+	for _, e := range readAuditEntries(t, f.audit) {
+		if e["operation"] == "injection.request" && e["host"] == "good.example.com" {
+			t.Fatalf("a rejected batch must not partially audit: %v", e)
+		}
+	}
+}
+
+// TestReportRejectsMissingEntries pins that the endpoint requires an entries
+// list and rejects a missing/empty-token caller.
+func TestReportRejectsMissingEntries(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+		map[string]any{})
+	if status != http.StatusBadRequest || body["error"] != "entries-required" {
+		t.Fatalf("missing entries must deny with entries-required: status=%d body=%v", status, body)
+	}
+
+	status, body = f.postJSONWithToken("", "/v1/injection/report",
+		map[string]any{"entries": []any{reportEntry()}})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("missing token must deny: status=%d body=%v", status, body)
+	}
+}

--- a/tests/broker/injection_report_conformance_test.go
+++ b/tests/broker/injection_report_conformance_test.go
@@ -208,3 +208,21 @@ func TestReportRejectsMissingEntries(t *testing.T) {
 		t.Fatalf("missing token must deny: status=%d body=%v", status, body)
 	}
 }
+
+// TestBrokerLoadsGrantQuota pins that the broker accepts a grant carrying a
+// quota block (schema strictness) and still serves injection for it — the
+// broker parses quota but does not enforce it (enforcement is per egressd
+// process, docs/phase5-6b-observability-pr-plan.md decision 3).
+func TestBrokerLoadsGrantQuota(t *testing.T) {
+	f := newBrokerFixture(t)
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{{Provider: "codex-main", Materialization: "header-inject", QuotaRequests: 3}}
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("injection must still succeed with a quota-bearing grant: status=%d body=%v", status, body)
+	}
+}

--- a/tests/broker/injection_report_conformance_test.go
+++ b/tests/broker/injection_report_conformance_test.go
@@ -297,3 +297,39 @@ func TestReportRejectsRawPathClass(t *testing.T) {
 		t.Fatalf("well-formed path_class must be accepted: status=%d body=%v", status, body)
 	}
 }
+
+// TestReportRejectsConnectAndStatusBounds pins the CONNECT/HTTP bounds
+// (finding-3 addendum): out-of-range ports, non-enum decisions, and negative
+// statuses are rejected so they never reach the audit log. The code is
+// correct; this pins the coverage.
+func TestReportRejectsConnectAndStatusBounds(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	bad := []map[string]any{
+		{"capability": "c", "host": "h", "port": 0, "decision": "allow"},                   // port too low
+		{"capability": "c", "host": "h", "port": 65536, "decision": "allow"},               // port too high
+		{"capability": "c", "host": "h", "port": -1, "decision": "deny"},                   // negative port
+		{"capability": "c", "host": "h", "port": 443, "decision": "maybe"},                 // bad decision enum
+		{"capability": "c", "host": "h", "port": 443, "decision": ""},                      // empty decision
+		{"capability": "c", "host": "h", "method": "GET", "path_class": "x", "status": -1}, // negative status
+	}
+	for _, entry := range bad {
+		status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+			map[string]any{"entries": []any{entry}})
+		if status != http.StatusBadRequest || body["error"] != "entry-invalid" {
+			t.Fatalf("entry %v must be rejected as entry-invalid: status=%d body=%v", entry, status, body)
+		}
+	}
+
+	// Port boundaries (1 and 65535) are accepted.
+	for _, port := range []int{1, 65535} {
+		status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/report",
+			map[string]any{"entries": []any{map[string]any{
+				"capability": "c", "host": "h", "port": port, "decision": "allow",
+			}}})
+		if status != http.StatusOK || body["ok"] != true {
+			t.Fatalf("boundary port %d must be accepted: status=%d body=%v", port, status, body)
+		}
+	}
+}

--- a/tests/broker/injection_report_conformance_test.go
+++ b/tests/broker/injection_report_conformance_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func reportEntry() map[string]any {
@@ -224,5 +225,42 @@ func TestBrokerLoadsGrantQuota(t *testing.T) {
 	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
 	if status != http.StatusOK || body["ok"] != true {
 		t.Fatalf("injection must still succeed with a quota-bearing grant: status=%d body=%v", status, body)
+	}
+}
+
+// TestRevocationFailsClosedOnGrantRemoval pins the broker half of the
+// revocation chain (docs/phase5-6b-observability-pr-plan.md item 4): removing a
+// grant from the agents config makes the next injection fetch fail closed via
+// the mtime hot-reload — no broker restart.
+func TestRevocationFailsClosedOnGrantRemoval(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(mediatedIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("injection must succeed before revocation: status=%d body=%v", status, body)
+	}
+
+	// Revoke: rewrite the same config with the grant dropped. Atomic rename
+	// changes mtime, so the running broker hot-reloads on the next request.
+	revoked := mediatedIdentities()
+	frontend := revoked["frontend"]
+	frontend.Grants = nil
+	revoked["frontend"] = frontend
+	f.writeRoleIdentities(revoked)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		status, body = f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", injectionRequest())
+		if status != http.StatusOK && body["ok"] != true {
+			break // failed closed, as required
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("injection still succeeds after revocation (no hot-reload): status=%d body=%v", status, body)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if body["error"] != "provider-not-granted" {
+		t.Fatalf("revoked grant must deny provider-not-granted, got %v", body["error"])
 	}
 }

--- a/tests/fixtures/echo/Dockerfile
+++ b/tests/fixtures/echo/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24-bookworm AS builder
+
+WORKDIR /src
+COPY tests/fixtures/echo/go.mod ./
+COPY tests/fixtures/echo/main.go ./
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/echo .
+
+FROM scratch
+COPY --from=builder /out/echo /echo
+EXPOSE 8080
+ENTRYPOINT ["/echo"]

--- a/tests/fixtures/echo/go.mod
+++ b/tests/fixtures/echo/go.mod
@@ -1,0 +1,3 @@
+module github.com/mirkoSekulic/nvt-agent/tests/fixtures/echo
+
+go 1.24

--- a/tests/fixtures/echo/main.go
+++ b/tests/fixtures/echo/main.go
@@ -1,0 +1,74 @@
+// Command echo is a hermetic upstream fixture for the kind egress smokes. It
+// reflects the incoming request — method, path, and headers — as JSON so a
+// smoke can assert what egressd actually forwarded (injected auth header,
+// stripped placeholder, path). It is deliberately trivial and stdlib-only so
+// it builds into a tiny static image loaded straight into the kind cluster,
+// replacing the external httpbin.org dependency.
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type reflection struct {
+	Method        string              `json:"method"`
+	Path          string              `json:"path"`
+	Query         string              `json:"query"`
+	Headers       map[string][]string `json:"headers"`
+	Authenticated bool                `json:"authenticated"`
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Reflect headers with canonical names. The smoke greps this for the
+	// injected credential value and asserts the placeholder never appears.
+	headers := make(map[string][]string, len(r.Header))
+	authenticated := false
+	for name, values := range r.Header {
+		headers[name] = values
+		lower := strings.ToLower(name)
+		// A credential-bearing header proves egressd injected material. Both
+		// the Bearer path (authorization) and key-header providers (x-api-key)
+		// count, so the fixture stays provider-agnostic.
+		if lower == "authorization" || lower == "x-api-key" {
+			for _, v := range values {
+				if strings.TrimSpace(v) != "" {
+					authenticated = true
+				}
+			}
+		}
+	}
+	body := reflection{
+		Method:        r.Method,
+		Path:          r.URL.Path,
+		Query:         r.URL.RawQuery,
+		Headers:       headers,
+		Authenticated: authenticated,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(body)
+}
+
+func main() {
+	addr := os.Getenv("ECHO_LISTEN")
+	if addr == "" {
+		addr = ":8080"
+	}
+	mux := http.NewServeMux()
+	// A dedicated readiness path so a Pod probe never depends on reflecting a
+	// real request.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/", handler)
+	server := &http.Server{Addr: addr, Handler: mux}
+	if err := server.ListenAndServe(); err != nil {
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
+	}
+}

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -515,6 +515,15 @@ fi
 # defaultEgressMode knob: rendered into the operator env, default direct.
 grep -q 'name: NVT_DEFAULT_EGRESS_MODE' "${DEFAULT_RENDER}"
 grep -q 'value: "direct"' "${DEFAULT_RENDER}"
+
+# allowInsecureUpstreams opt-in: absent by default, rendered only when set.
+if grep -q 'NVT_ALLOW_INSECURE_UPSTREAMS' "${DEFAULT_RENDER}"; then
+  echo "NVT_ALLOW_INSECURE_UPSTREAMS must not render by default" >&2
+  exit 1
+fi
+INSECURE_UPSTREAMS_RENDER="${WORKDIR}/insecure-upstreams.yaml"
+helm template nvt "${CHART}" -n custom-ns --set egress.allowInsecureUpstreams=true > "${INSECURE_UPSTREAMS_RENDER}"
+grep -q 'name: NVT_ALLOW_INSECURE_UPSTREAMS' "${INSECURE_UPSTREAMS_RENDER}"
 DEFAULT_MEDIATED_RENDER="${WORKDIR}/default-egress-mediated.yaml"
 helm template nvt "${CHART}" -n custom-ns --set egress.defaultMode=mediated > "${DEFAULT_MEDIATED_RENDER}"
 grep -q 'name: NVT_DEFAULT_EGRESS_MODE' "${DEFAULT_MEDIATED_RENDER}"

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -500,6 +500,14 @@ grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
 grep -q 'checksum/broker-tls: ' "${DEFAULT_RENDER}"
 
+# defaultEgressMode knob: rendered into the operator env, default direct.
+grep -q 'name: NVT_DEFAULT_EGRESS_MODE' "${DEFAULT_RENDER}"
+grep -q 'value: "direct"' "${DEFAULT_RENDER}"
+DEFAULT_MEDIATED_RENDER="${WORKDIR}/default-egress-mediated.yaml"
+helm template nvt "${CHART}" -n custom-ns --set egress.defaultMode=mediated > "${DEFAULT_MEDIATED_RENDER}"
+grep -q 'name: NVT_DEFAULT_EGRESS_MODE' "${DEFAULT_MEDIATED_RENDER}"
+grep -q 'value: "mediated"' "${DEFAULT_MEDIATED_RENDER}"
+
 sha256_hex() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum | awk '{print $1}'

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -500,6 +500,18 @@ grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
 grep -q 'checksum/broker-tls: ' "${DEFAULT_RENDER}"
 
+# Revocation depends on the broker hot-reloading the agents ConfigMap on
+# mtime change. A subPath mount freezes the projected file forever and would
+# silently kill revocation, so the broker config volume must never be
+# subPath-mounted (docs/phase5-6b-observability-pr-plan.md item 4).
+BROKER_DEPLOYMENT_RENDER="${WORKDIR}/broker-deployment.yaml"
+helm template nvt "${CHART}" -n custom-ns -s templates/broker-deployment.yaml > "${BROKER_DEPLOYMENT_RENDER}"
+grep -q 'mountPath: /config' "${BROKER_DEPLOYMENT_RENDER}"
+if grep -q 'subPath' "${BROKER_DEPLOYMENT_RENDER}"; then
+  echo "broker Deployment must not subPath-mount any volume; it freezes the agents ConfigMap and kills revocation" >&2
+  exit 1
+fi
+
 # defaultEgressMode knob: rendered into the operator env, default direct.
 grep -q 'name: NVT_DEFAULT_EGRESS_MODE' "${DEFAULT_RENDER}"
 grep -q 'value: "direct"' "${DEFAULT_RENDER}"

--- a/tests/operator/kind/cases/enforced-egress.sh
+++ b/tests/operator/kind/cases/enforced-egress.sh
@@ -34,6 +34,7 @@ case_kind_setup() {
     --from-literal=NVT_SMOKE_STATIC_TOKEN=nvt-smoke-fixture-token \
     --dry-run=client -o yaml | kubectl_smoke apply -f -
   write_broker_providers_values "${SMOKE_TMPDIR}/broker-providers.yaml"
+  deploy_echo_fixture
 
   make -C "${ROOT}" \
     CLUSTER="${CLUSTER}" \
@@ -46,7 +47,7 @@ case_kind_setup() {
 
 write_broker_providers_values() {
   local output="$1"
-  cat >"${output}" <<'YAML'
+  cat >"${output}" <<YAML
 broker:
   envSecretName: nvt-smoke-broker-env
   config:
@@ -56,7 +57,7 @@ broker:
         config:
           token-env: NVT_SMOKE_STATIC_TOKEN
           injection-hosts:
-            - httpbin.org
+            - nvt-smoke-echo.${NAMESPACE}.svc.cluster.local
         allow:
           repositories:
             - example/*
@@ -118,7 +119,12 @@ grant = {
     "provider": "static-bearer-main",
     "repositories": ["example/repo"],
     "materialization": "header-inject",
-    "egressHosts": ["httpbin.org:443"],
+    # Hermetic in-cluster echo fixture reached over plain HTTP on :443 (the
+    # port the enforced egressd egress policy allows). allowInsecureUpstream
+    # is dev/test-only and required because an in-cluster fixture cannot
+    # present a publicly-trusted TLS cert.
+    "egressHosts": [f"nvt-smoke-echo.{namespace}.svc.cluster.local:443"],
+    "allowInsecureUpstream": True,
 }
 git_grant = {
     "provider": "git-app",
@@ -339,16 +345,19 @@ assert_direct_egress_denied() {
 assert_egressd_path_allowed() {
   local run="$1"
   log "asserting the agent reaches its paired egressd through the Service"
-  # A real request from inside the agent container, resolved through
-  # kube-dns and verified against the published CA. httpbin /bearer returns
-  # 200 only when egressd fetched and injected Authorization from the broker;
-  # 5xx/502 means the mediated path is broken and must fail the smoke.
+  # A real request from inside the agent container, resolved through kube-dns
+  # and verified against the published CA. The hermetic echo fixture reflects
+  # the request egressd forwarded: it reports authenticated:true and echoes
+  # the injected token only when egressd fetched and injected Authorization
+  # from the broker. A 5xx means the mediated path is broken and fails the
+  # smoke.
   local response
   response="$(agent_exec "${run}" curl -sS --fail-with-body \
-    --cacert /nvt-egress-ca/ca.crt --max-time 15 "https://${run}-egressd:8471/bearer")" \
-    || die "agent -> egressd -> upstream bearer request failed"
-  grep -q '"authenticated": true' <<<"${response}" || die "mediated upstream did not authenticate the injected bearer: ${response}"
-  grep -q 'nvt-smoke-fixture-token' <<<"${response}" || die "fixture upstream did not receive the injected bearer: ${response}"
+    --cacert /nvt-egress-ca/ca.crt --max-time 15 "https://${run}-egressd:8471/echo")" \
+    || die "agent -> egressd -> upstream request failed"
+  grep -q '"authenticated":true' <<<"${response}" || die "echo fixture did not see an injected credential header: ${response}"
+  grep -q 'nvt-smoke-fixture-token' <<<"${response}" || die "echo fixture did not receive the injected bearer: ${response}"
+  grep -q '"path":"/echo"' <<<"${response}" || die "echo fixture did not reflect the request path: ${response}"
   if grep -q 'NVT-PLACEHOLDER-NOT-A-KEY' <<<"${response}"; then
     die "placeholder reached upstream through egressd: ${response}"
   fi

--- a/tests/operator/kind/cases/enforced-egress.sh
+++ b/tests/operator/kind/cases/enforced-egress.sh
@@ -41,7 +41,7 @@ case_kind_setup() {
     NAMESPACE="${NAMESPACE}" \
     CREATE_CLUSTER="${CREATE_CLUSTER}" \
     ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
-    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 --set egress.allowInsecureUpstreams=true -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
     operator-kind-setup
 }
 

--- a/tests/operator/kind/cases/quota-egress.sh
+++ b/tests/operator/kind/cases/quota-egress.sh
@@ -41,7 +41,16 @@ broker:
   envSecretName: nvt-smoke-broker-env
   config:
     providers:
-      - name: static-bearer-main
+      - name: static-bearer-warmup
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - nvt-smoke-echo.${NAMESPACE}.svc.cluster.local
+        allow:
+          repositories:
+            - example/*
+      - name: static-bearer-quota
         plugin: token
         config:
           token-env: NVT_SMOKE_STATIC_TOKEN
@@ -67,19 +76,30 @@ active_deadline_seconds = int(sys.argv[2])
 namespace = sys.argv[3]
 quota_limit = int(sys.argv[4])
 
+echo = f"nvt-smoke-echo.{namespace}.svc.cluster.local:443"
+# Warmup route (no quota) on 8471 lets the smoke wait for broker readiness
+# without spending the quota route. The quota route is on 8472.
+warmup_grant = {
+    "provider": "static-bearer-warmup",
+    "repositories": ["example/repo"],
+    "materialization": "header-inject",
+    "egressHosts": [echo],
+    "allowInsecureUpstream": True,
+}
+quota_grant = {
+    "provider": "static-bearer-quota",
+    "repositories": ["example/repo"],
+    "materialization": "header-inject",
+    "egressHosts": [echo],
+    "allowInsecureUpstream": True,
+    "quota": {"requests": quota_limit},
+}
 spec = {
     "runtime": {"type": "codex", "autonomy": "trusted-local"},
     "image": "nvt-agent-runtime:latest",
     "egress": "mediated",
     "workspace": {"mode": "Ephemeral"},
-    "broker": {"grants": [{
-        "provider": "static-bearer-main",
-        "repositories": ["example/repo"],
-        "materialization": "header-inject",
-        "egressHosts": [f"nvt-smoke-echo.{namespace}.svc.cluster.local:443"],
-        "allowInsecureUpstream": True,
-        "quota": {"requests": quota_limit},
-    }]},
+    "broker": {"grants": [warmup_grant, quota_grant]},
     "agent": {
         "config": {
             "runtime": {"command": "bash", "args": ["-lc", 'echo "quota smoke ready"; sleep infinity']},
@@ -107,10 +127,11 @@ import json
 import sys
 
 with open(sys.argv[1], "r", encoding="utf-8") as file:
-    spec = json.load(file)["agentRun"]["spec"]
-grant = spec["broker"]["grants"][0]
-assert grant["quota"] == {"requests": int(sys.argv[2])}
-assert grant["allowInsecureUpstream"] is True
+    grants = json.load(file)["agentRun"]["spec"]["broker"]["grants"]
+assert [g["provider"] for g in grants] == ["static-bearer-warmup", "static-bearer-quota"]
+assert "quota" not in grants[0]
+assert grants[1]["quota"] == {"requests": int(sys.argv[2])}
+assert grants[1]["allowInsecureUpstream"] is True
 PY
 }
 
@@ -125,28 +146,44 @@ case_run() {
   wait_for_agentrun_exists "${RUN_NAME}-valid"
   wait_for_phase_any "${RUN_NAME}-valid" "${RUN_TIMEOUT_SECONDS}" Running
 
-  assert_quota_enforced "${RUN_NAME}-valid"
+  # The broker agents ConfigMap projects ~1min after Pod start, so egressd's
+  # first fetches can be unauthorized. Warm up on the quota-free route (8471)
+  # until the mediated path is authorized, so failed startup requests never
+  # consume the quota route (8472).
+  wait_for_route_ready "${RUN_NAME}-valid" 8471
+  assert_quota_enforced "${RUN_NAME}-valid" 8472
 }
 
-# curl_egress issues a request from the agent container through the same-Pod
+# curl_egress issues a request from the agent container through a same-Pod
 # egressd route (plain-HTTP localhost listener) and prints the HTTP status.
 curl_egress() {
-  local run="$1"
+  local run="$1" port="$2"
   kubectl_smoke exec "${run}-agent" -n "${NAMESPACE}" -c agent -- \
-    curl -s -o /dev/null -w '%{http_code}' --max-time 15 "http://127.0.0.1:8471/echo"
+    curl -s -o /dev/null -w '%{http_code}' --max-time 15 "http://127.0.0.1:${port}/echo-${RANDOM}"
+}
+
+wait_for_route_ready() {
+  local run="$1" port="$2"
+  local deadline=$((SECONDS + RUN_TIMEOUT_SECONDS)) code
+  while (( SECONDS < deadline )); do
+    code="$(curl_egress "${run}" "${port}")"
+    [[ "${code}" == "200" ]] && { log "warmup route ${port} ready (broker authorized)"; return; }
+    sleep 3
+  done
+  die "warmup route ${port} never became ready (last ${code})"
 }
 
 assert_quota_enforced() {
-  local run="$1"
+  local run="$1" port="$2"
   log "asserting per-grant request quota (limit ${QUOTA_LIMIT}) is enforced at egressd"
   local i code
   for (( i = 1; i <= QUOTA_LIMIT; i++ )); do
-    code="$(curl_egress "${run}")"
+    code="$(curl_egress "${run}" "${port}")"
     [[ "${code}" == "200" ]] || die "request ${i}/${QUOTA_LIMIT} within quota returned ${code}, want 200"
   done
-  code="$(curl_egress "${run}")"
+  code="$(curl_egress "${run}" "${port}")"
   [[ "${code}" == "429" ]] || die "request beyond quota returned ${code}, want 429"
   # And it stays closed.
-  code="$(curl_egress "${run}")"
+  code="$(curl_egress "${run}" "${port}")"
   [[ "${code}" == "429" ]] || die "quota must stay closed after breach, got ${code}"
 }

--- a/tests/operator/kind/cases/quota-egress.sh
+++ b/tests/operator/kind/cases/quota-egress.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# Quota smoke (docs/phase5-6b-observability-pr-plan.md item 3): a mediated
+# grant with quota.requests: N is enforced at the sidecar — the (N+1)th
+# proxied request fails closed with 429. Runs same-Pod on kindnet (quota is
+# enforced in egressd regardless of placement) against the hermetic echo
+# fixture, so no Calico cluster is needed.
+
+QUOTA_LIMIT=2
+
+case_validate_config() {
+  ACTIVE_DEADLINE_SECONDS="${ACTIVE_DEADLINE_SECONDS:-600}"
+  RUN_NAME="${RUN_NAME:-quota-smoke}"
+  require_non_negative_integer ACTIVE_DEADLINE_SECONDS "${ACTIVE_DEADLINE_SECONDS}"
+}
+
+case_render() {
+  validate_payload_generation
+  validate_chart_render --set agentSchedule.maxParallelism=4
+}
+
+case_kind_setup() {
+  make -C "${ROOT}" CLUSTER="${CLUSTER}" CREATE_CLUSTER="${CREATE_CLUSTER}" operator-kind-cluster
+  kubectl_smoke create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl_smoke apply -f -
+  kubectl_smoke -n "${NAMESPACE}" create secret generic nvt-smoke-broker-env \
+    --from-literal=NVT_SMOKE_STATIC_TOKEN=nvt-smoke-fixture-token \
+    --dry-run=client -o yaml | kubectl_smoke apply -f -
+  write_broker_providers_values "${SMOKE_TMPDIR}/broker-providers.yaml"
+  deploy_echo_fixture
+  make -C "${ROOT}" \
+    CLUSTER="${CLUSTER}" NAMESPACE="${NAMESPACE}" CREATE_CLUSTER="${CREATE_CLUSTER}" \
+    ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
+    operator-kind-setup
+}
+
+write_broker_providers_values() {
+  local output="$1"
+  cat >"${output}" <<YAML
+broker:
+  envSecretName: nvt-smoke-broker-env
+  config:
+    providers:
+      - name: static-bearer-main
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - nvt-smoke-echo.${NAMESPACE}.svc.cluster.local
+        allow:
+          repositories:
+            - example/*
+YAML
+}
+
+payload_file() { printf '%s/%s.json' "${SMOKE_TMPDIR}" "$1"; }
+
+generate_payload() {
+  local variant="$1"
+  local output="$2"
+  python3 - "${RUN_NAME}-${variant}" "${ACTIVE_DEADLINE_SECONDS}" "${NAMESPACE}" "${QUOTA_LIMIT}" >"${output}" <<'PY'
+import json
+import sys
+
+run_name = sys.argv[1]
+active_deadline_seconds = int(sys.argv[2])
+namespace = sys.argv[3]
+quota_limit = int(sys.argv[4])
+
+spec = {
+    "runtime": {"type": "codex", "autonomy": "trusted-local"},
+    "image": "nvt-agent-runtime:latest",
+    "egress": "mediated",
+    "workspace": {"mode": "Ephemeral"},
+    "broker": {"grants": [{
+        "provider": "static-bearer-main",
+        "repositories": ["example/repo"],
+        "materialization": "header-inject",
+        "egressHosts": [f"nvt-smoke-echo.{namespace}.svc.cluster.local:443"],
+        "allowInsecureUpstream": True,
+        "quota": {"requests": quota_limit},
+    }]},
+    "agent": {
+        "config": {
+            "runtime": {"command": "bash", "args": ["-lc", 'echo "quota smoke ready"; sleep infinity']},
+            "tools": {"packages": [], "mise": [], "additional-paths": [], "shell": []},
+            "code-server": {"extensions": []},
+        }
+    },
+    "ttl": {"activeDeadlineSeconds": active_deadline_seconds},
+}
+payload = {
+    "work": {"id": run_name, "title": run_name},
+    "agentRun": {"apiVersion": "nvt.dev/v1alpha1", "kind": "AgentRun",
+                 "metadata": {"name": run_name}, "spec": spec},
+}
+json.dump(payload, sys.stdout, separators=(",", ":"))
+sys.stdout.write("\n")
+PY
+}
+
+validate_payload_generation() {
+  log "validating quota-egress admission payload"
+  generate_payload valid "$(payload_file valid)"
+  python3 - "$(payload_file valid)" "${QUOTA_LIMIT}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as file:
+    spec = json.load(file)["agentRun"]["spec"]
+grant = spec["broker"]["grants"][0]
+assert grant["quota"] == {"requests": int(sys.argv[2])}
+assert grant["allowInsecureUpstream"] is True
+PY
+}
+
+case_run() {
+  local body="${SMOKE_TMPDIR}/valid.json"
+  local response="${SMOKE_TMPDIR}/valid.response.json"
+  local status_file="${SMOKE_TMPDIR}/valid.status"
+  generate_payload valid "${body}"
+  log "submitting quota-egress admission"
+  post_schedule_admission "${body}" "${response}" "${status_file}"
+  [[ "$(cat "${status_file}")" == "201" ]] || die "expected 201, got $(cat "${status_file}"): $(cat "${response}")"
+  wait_for_agentrun_exists "${RUN_NAME}-valid"
+  wait_for_phase_any "${RUN_NAME}-valid" "${RUN_TIMEOUT_SECONDS}" Running
+
+  assert_quota_enforced "${RUN_NAME}-valid"
+}
+
+# curl_egress issues a request from the agent container through the same-Pod
+# egressd route (plain-HTTP localhost listener) and prints the HTTP status.
+curl_egress() {
+  local run="$1"
+  kubectl_smoke exec "${run}-agent" -n "${NAMESPACE}" -c agent -- \
+    curl -s -o /dev/null -w '%{http_code}' --max-time 15 "http://127.0.0.1:8471/echo"
+}
+
+assert_quota_enforced() {
+  local run="$1"
+  log "asserting per-grant request quota (limit ${QUOTA_LIMIT}) is enforced at egressd"
+  local i code
+  for (( i = 1; i <= QUOTA_LIMIT; i++ )); do
+    code="$(curl_egress "${run}")"
+    [[ "${code}" == "200" ]] || die "request ${i}/${QUOTA_LIMIT} within quota returned ${code}, want 200"
+  done
+  code="$(curl_egress "${run}")"
+  [[ "${code}" == "429" ]] || die "request beyond quota returned ${code}, want 429"
+  # And it stays closed.
+  code="$(curl_egress "${run}")"
+  [[ "${code}" == "429" ]] || die "quota must stay closed after breach, got ${code}"
+}

--- a/tests/operator/kind/cases/quota-egress.sh
+++ b/tests/operator/kind/cases/quota-egress.sh
@@ -30,7 +30,7 @@ case_kind_setup() {
   make -C "${ROOT}" \
     CLUSTER="${CLUSTER}" NAMESPACE="${NAMESPACE}" CREATE_CLUSTER="${CREATE_CLUSTER}" \
     ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
-    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 --set egress.allowInsecureUpstreams=true -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
     operator-kind-setup
 }
 

--- a/tests/operator/kind/cases/revocation.sh
+++ b/tests/operator/kind/cases/revocation.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+# Revocation smoke (docs/phase5-6b-observability-pr-plan.md item 4): revoke a
+# grant through the SUPPORTED path — patch the AgentRun spec to drop a grant —
+# and observe egressd deny that grant's route within the bound, while a second
+# grant keeps working. Do NOT edit the broker agents ConfigMap directly: the
+# operator's policy reconcile would re-add the grant and race the test.
+#
+# Same-Pod on kindnet against the hermetic echo fixture. The two grants share
+# the echo upstream but are distinct capabilities, so route 8471 (main) and
+# route 8472 (revoked) are independent.
+
+case_validate_config() {
+  ACTIVE_DEADLINE_SECONDS="${ACTIVE_DEADLINE_SECONDS:-900}"
+  RUN_NAME="${RUN_NAME:-revocation-smoke}"
+  require_non_negative_integer ACTIVE_DEADLINE_SECONDS "${ACTIVE_DEADLINE_SECONDS}"
+}
+
+case_render() {
+  validate_payload_generation
+  validate_chart_render --set agentSchedule.maxParallelism=4
+}
+
+case_kind_setup() {
+  make -C "${ROOT}" CLUSTER="${CLUSTER}" CREATE_CLUSTER="${CREATE_CLUSTER}" operator-kind-cluster
+  kubectl_smoke create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl_smoke apply -f -
+  kubectl_smoke -n "${NAMESPACE}" create secret generic nvt-smoke-broker-env \
+    --from-literal=NVT_SMOKE_STATIC_TOKEN=nvt-smoke-fixture-token \
+    --dry-run=client -o yaml | kubectl_smoke apply -f -
+  write_broker_providers_values "${SMOKE_TMPDIR}/broker-providers.yaml"
+  deploy_echo_fixture
+  make -C "${ROOT}" \
+    CLUSTER="${CLUSTER}" NAMESPACE="${NAMESPACE}" CREATE_CLUSTER="${CREATE_CLUSTER}" \
+    ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
+    operator-kind-setup
+}
+
+write_broker_providers_values() {
+  local output="$1"
+  cat >"${output}" <<YAML
+broker:
+  envSecretName: nvt-smoke-broker-env
+  config:
+    providers:
+      - name: static-bearer-main
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - nvt-smoke-echo.${NAMESPACE}.svc.cluster.local
+        allow:
+          repositories:
+            - example/*
+      - name: static-bearer-b
+        plugin: token
+        config:
+          token-env: NVT_SMOKE_STATIC_TOKEN
+          injection-hosts:
+            - nvt-smoke-echo.${NAMESPACE}.svc.cluster.local
+        allow:
+          repositories:
+            - example/*
+YAML
+}
+
+payload_file() { printf '%s/%s.json' "${SMOKE_TMPDIR}" "$1"; }
+
+generate_payload() {
+  local output="$1"
+  python3 - "${RUN_NAME}-valid" "${ACTIVE_DEADLINE_SECONDS}" "${NAMESPACE}" >"${output}" <<'PY'
+import json
+import sys
+
+run_name = sys.argv[1]
+active_deadline_seconds = int(sys.argv[2])
+namespace = sys.argv[3]
+echo = f"nvt-smoke-echo.{namespace}.svc.cluster.local:443"
+
+def grant(provider):
+    return {
+        "provider": provider,
+        "repositories": ["example/repo"],
+        "materialization": "header-inject",
+        "egressHosts": [echo],
+        "allowInsecureUpstream": True,
+    }
+
+spec = {
+    "runtime": {"type": "codex", "autonomy": "trusted-local"},
+    "image": "nvt-agent-runtime:latest",
+    "egress": "mediated",
+    "workspace": {"mode": "Ephemeral"},
+    "broker": {"grants": [grant("static-bearer-main"), grant("static-bearer-b")]},
+    "agent": {
+        "config": {
+            "runtime": {"command": "bash", "args": ["-lc", 'echo "revocation smoke ready"; sleep infinity']},
+            "tools": {"packages": [], "mise": [], "additional-paths": [], "shell": []},
+            "code-server": {"extensions": []},
+        }
+    },
+    "ttl": {"activeDeadlineSeconds": active_deadline_seconds},
+}
+payload = {
+    "work": {"id": run_name, "title": run_name},
+    "agentRun": {"apiVersion": "nvt.dev/v1alpha1", "kind": "AgentRun",
+                 "metadata": {"name": run_name}, "spec": spec},
+}
+json.dump(payload, sys.stdout, separators=(",", ":"))
+sys.stdout.write("\n")
+PY
+}
+
+validate_payload_generation() {
+  log "validating revocation admission payload"
+  generate_payload "$(payload_file valid)"
+  python3 - "$(payload_file valid)" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as file:
+    grants = json.load(file)["agentRun"]["spec"]["broker"]["grants"]
+assert [g["provider"] for g in grants] == ["static-bearer-main", "static-bearer-b"]
+PY
+}
+
+case_run() {
+  local body="${SMOKE_TMPDIR}/valid.json"
+  generate_payload "${body}"
+  log "submitting revocation admission"
+  post_schedule_admission "${body}" "${SMOKE_TMPDIR}/valid.response.json" "${SMOKE_TMPDIR}/valid.status"
+  [[ "$(cat "${SMOKE_TMPDIR}/valid.status")" == "201" ]] || die "expected 201, got $(cat "${SMOKE_TMPDIR}/valid.status")"
+  wait_for_agentrun_exists "${RUN_NAME}-valid"
+  wait_for_phase_any "${RUN_NAME}-valid" "${RUN_TIMEOUT_SECONDS}" Running
+
+  # Both routes work before revocation. Fresh path each call = cache miss, so
+  # egressd refetches from the broker every time (no stale cache masking).
+  assert_route_status "${RUN_NAME}-valid" 8471 200 "main route before revocation"
+  assert_route_status "${RUN_NAME}-valid" 8472 200 "route-b before revocation"
+
+  log "revoking static-bearer-b via AgentRun spec patch"
+  kubectl_smoke patch agentrun "${RUN_NAME}-valid" -n "${NAMESPACE}" --type=merge \
+    -p '{"spec":{"broker":{"grants":[{"provider":"static-bearer-main","repositories":["example/repo"],"materialization":"header-inject","egressHosts":["nvt-smoke-echo.'"${NAMESPACE}"'.svc.cluster.local:443"],"allowInsecureUpstream":true}]}}}'
+
+  # Bound = operator reconcile + kubelet ConfigMap projection (~1min worst
+  # case) + egressd cache clamp. Poll the revoked route until it fails closed.
+  wait_for_route_denied "${RUN_NAME}-valid" 8472 180
+  # The surviving grant keeps working throughout — revocation is per grant.
+  assert_route_status "${RUN_NAME}-valid" 8471 200 "main route after revocation"
+}
+
+route_status() {
+  local run="$1" port="$2"
+  # Unique path per call forces a broker refetch (cache miss).
+  local path="/probe-${port}-${RANDOM}${RANDOM}"
+  kubectl_smoke exec "${run}-agent" -n "${NAMESPACE}" -c agent -- \
+    curl -s -o /dev/null -w '%{http_code}' --max-time 15 "http://127.0.0.1:${port}${path}"
+}
+
+assert_route_status() {
+  local run="$1" port="$2" want="$3" label="$4"
+  local code
+  code="$(route_status "${run}" "${port}")"
+  [[ "${code}" == "${want}" ]] || die "${label}: route ${port} returned ${code}, want ${want}"
+}
+
+wait_for_route_denied() {
+  local run="$1" port="$2" timeout="$3"
+  local deadline=$((SECONDS + timeout)) code
+  while (( SECONDS < deadline )); do
+    code="$(route_status "${run}" "${port}")"
+    if [[ "${code}" == "502" ]]; then
+      log "route ${port} denied (revocation propagated) after $(( SECONDS - (deadline - timeout) ))s"
+      return
+    fi
+    sleep 3
+  done
+  die "revoked route ${port} still served (last ${code}) after ${timeout}s"
+}

--- a/tests/operator/kind/cases/revocation.sh
+++ b/tests/operator/kind/cases/revocation.sh
@@ -133,6 +133,11 @@ case_run() {
   wait_for_agentrun_exists "${RUN_NAME}-valid"
   wait_for_phase_any "${RUN_NAME}-valid" "${RUN_TIMEOUT_SECONDS}" Running
 
+  # The broker agents ConfigMap projects ~1min after Pod start, so egressd's
+  # first fetches can be unauthorized. Wait until the mediated path is
+  # authorized (either route becoming 200 proves broker readiness).
+  wait_for_route_ready "${RUN_NAME}-valid" 8471
+
   # Both routes work before revocation. Fresh path each call = cache miss, so
   # egressd refetches from the broker every time (no stale cache masking).
   assert_route_status "${RUN_NAME}-valid" 8471 200 "main route before revocation"
@@ -162,6 +167,17 @@ assert_route_status() {
   local code
   code="$(route_status "${run}" "${port}")"
   [[ "${code}" == "${want}" ]] || die "${label}: route ${port} returned ${code}, want ${want}"
+}
+
+wait_for_route_ready() {
+  local run="$1" port="$2"
+  local deadline=$((SECONDS + RUN_TIMEOUT_SECONDS)) code
+  while (( SECONDS < deadline )); do
+    code="$(route_status "${run}" "${port}")"
+    [[ "${code}" == "200" ]] && { log "route ${port} ready (broker authorized)"; return; }
+    sleep 3
+  done
+  die "route ${port} never became ready (last ${code})"
 }
 
 wait_for_route_denied() {

--- a/tests/operator/kind/cases/revocation.sh
+++ b/tests/operator/kind/cases/revocation.sh
@@ -32,7 +32,7 @@ case_kind_setup() {
   make -C "${ROOT}" \
     CLUSTER="${CLUSTER}" NAMESPACE="${NAMESPACE}" CREATE_CLUSTER="${CREATE_CLUSTER}" \
     ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" \
-    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
+    OPERATOR_KIND_HELM_ARGS="--set agentSchedule.maxParallelism=4 --set egress.allowInsecureUpstreams=true -f ${SMOKE_TMPDIR}/broker-providers.yaml" \
     operator-kind-setup
 }
 

--- a/tests/operator/kind/lib.sh
+++ b/tests/operator/kind/lib.sh
@@ -61,6 +61,70 @@ kubectl_smoke() {
   kubectl --context "${KUBECTL_CONTEXT}" "$@"
 }
 
+# deploy_echo_fixture loads and deploys the hermetic upstream echo image
+# (tests/fixtures/echo) into the active cluster/namespace. It replaces the
+# external httpbin.org dependency: egressd reaches it over plain HTTP on
+# port 443 (the port the enforced egressd egress NetworkPolicy allows, since
+# Calico evaluates the post-DNAT Pod port). The echo reflects the request so
+# a smoke can assert the injected credential arrived and the placeholder did
+# not. Reusable by the enforced-egress, quota, and revocation smokes.
+ECHO_FIXTURE_NAME="${ECHO_FIXTURE_NAME:-nvt-smoke-echo}"
+ECHO_FIXTURE_PORT="${ECHO_FIXTURE_PORT:-443}"
+
+deploy_echo_fixture() {
+  log "deploying hermetic echo upstream fixture ${ECHO_FIXTURE_NAME}"
+  make -C "${ROOT}" CLUSTER="${CLUSTER}" echo-kind-load
+  kubectl_smoke apply -f - <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${ECHO_FIXTURE_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ${ECHO_FIXTURE_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${ECHO_FIXTURE_NAME}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${ECHO_FIXTURE_NAME}
+    spec:
+      containers:
+        - name: echo
+          image: ${ECHO_IMAGE:-nvt-smoke-echo:latest}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ECHO_LISTEN
+              value: ":${ECHO_FIXTURE_PORT}"
+          ports:
+            - containerPort: ${ECHO_FIXTURE_PORT}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: ${ECHO_FIXTURE_PORT}
+            periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${ECHO_FIXTURE_NAME}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/name: ${ECHO_FIXTURE_NAME}
+spec:
+  selector:
+    app.kubernetes.io/name: ${ECHO_FIXTURE_NAME}
+  ports:
+    - name: http
+      port: ${ECHO_FIXTURE_PORT}
+      targetPort: ${ECHO_FIXTURE_PORT}
+YAML
+  kubectl_smoke -n "${NAMESPACE}" rollout status "deployment/${ECHO_FIXTURE_NAME}" --timeout="${ROLLOUT_TIMEOUT}"
+}
+
 diagnostics() {
   local status=$?
   if [[ ${status} -eq 0 || "${KIND_SMOKE_MODE:-kind}" != "kind" ]]; then


### PR DESCRIPTION
Implements [PR 6b](docs/phase5-6b-observability-pr-plan.md): the choke-point payoff on top of the mediated egress path — per-request audit, per-grant quotas, a proven revocation bound, the Anthropic provider-agnosticism proof, and a creation-time `defaultEgressMode` knob (still `direct`). Prerequisites merged (#61 fixes, #62 broker TLS, #63 enforcement).

## What (commit by commit)

1. **Hermetic kind echo fixture** replaces the external `httpbin.org` dependency in the egress smokes with a tiny stdlib-only echo image that reflects the request. Reachability over an in-cluster upstream needs plain HTTP (a fixture can't present a publicly-trusted cert), so a per-grant `allowInsecureUpstream` opt-in (dev/test only, mirroring `egressAllowInsecureBroker`) is rendered into the route.
2. **Broker `POST /v1/injection/report`** — egress-role-only batched endpoint appending one `injection.request` audit line per entry (HTTP or forward-proxy CONNECT). Role + pairing gate it; entries are audited but **never re-checked against grants** (a report for a just-revoked capability is still audit-worthy). Bounded at 100 entries; a malformed entry rejects the whole batch. Observability, not a security control. Protocol doc + conformance.
3. **egressd async reporter** — one bounded (1024) queue per process, flushed on a 2s tick or 100-entry batch. `path_class` is computed at the source (git shapes → three git classes; else first path segment), so raw paths never leave egressd. Best-effort: a full queue or a report failure drops (counted), never blocking or failing proxied traffic (test proves traffic parity with the report endpoint down).
4. **Per-grant request quotas** — `quota.requests` (CRD both copies, operator validation, egressd route `max_requests`, `agents.yaml` parse, `agent-init` compose parity). egressd enforces per route with an atomic add-then-compare (**TOCTOU-free**): exactly N requests reach the upstream, the rest fail closed with 429 (audited). **Per egressd process, not per run** — a restart resets it; a soft resource guard, not a security boundary. Race-clean Go concurrency test proves exactly-N under M>N parallel load.
5. **Revocation** — broker conformance (grant removed → next fetch fails closed via mtime hot-reload, no restart); helm guard that the broker agents ConfigMap is never `subPath`-mounted (a subPath freezes the file and kills revocation); kind smoke that revokes through the supported path (patch the AgentRun spec) and observes egressd deny that route within the bound while a second grant survives. The bound: operator reconcile + kubelet ConfigMap projection (~1min worst case) + egressd cache clamp (≤60s, shipped #61).
6. **Anthropic proof** — generalized `static_token` with `injection-header` / `injection-scheme` (empty = raw token for `x-api-key`) / `injection-extra-headers`, validated at config load; every injected header is stripped from the request. Anthropic lands as broker config only (`x-api-key` + `anthropic-version`, no Bearer) with **zero egressd diffs** — the contract proof.
7. **`defaultEgressMode` knob** (`egress.defaultMode` → `NVT_DEFAULT_EGRESS_MODE`, startup-validated) applied **once, at AgentRun creation on the nvt admission path** — the stored `spec.egress` is always explicit, so a knob flip never reclassifies an existing run. `AgentRunEgressMode` does not read the env (no read-time resolution); a raw `kubectl apply` with empty egress stays `direct` via the CRD default. Global mediated flip stays deferred.
8. **Docs** — parent plan v3.7; chart README quota/revocation/defaultMode with the per-process and raw-kubectl caveats.

## Tests

- **Operator** (incl. new quota render/validation, defaultEgressMode helpers + admission integration), **egressd under `-race`** (reporter drop/parity/path_class, quota exactly-N TOCTOU), **broker conformance** (report role-gating/shape/no-regrant-recheck/bounds, revocation fail-closed, Anthropic proof), **helm render** (subPath guard, defaultMode env, `allowInsecureUpstream`) — all green. gofmt clean; no `runtime/core` changes.
- **Kind smokes, all green end-to-end:** `quota-egress` (warm up → 2×200 → 429), `revocation` (route denied 75s after spec-patch, sibling grant survives), `enforced-egress` on Calico (run Completed over the fenced network against the new echo fixture; direct-deny, agent→egressd, cross-run isolation, dind FORWARD-path fence, GC).

One smoke-harness bug surfaced and fixed: egressd's first fetches can be `unauthorized` until the broker agents ConfigMap projects (~1min), and those failed requests consume the add-first quota counter — the quota/revocation smokes now warm up on a quota-free route before asserting.
