### PR TITLE
PR 6.1: Generic placeholder-file materialization

### DIFF
--- a/broker/core/agents.py
+++ b/broker/core/agents.py
@@ -165,6 +165,16 @@ class AgentRegistry:
                 if quota is not None:
                     grant_entry["quota"] = quota
                 grants.append(grant_entry)
+            # A provider may appear in multiple grants (repository aggregation),
+            # but they must agree on materialization: grant() returns the first
+            # match, so conflicting modes for one provider would be resolved
+            # order-dependently.
+            materialization_by_provider = {}
+            for grant_entry in grants:
+                existing = materialization_by_provider.get(grant_entry["provider"])
+                if existing is not None and existing != grant_entry["materialization"]:
+                    fail(f"agents[{index}] ({agent_id}): provider {grant_entry['provider']} has conflicting materializations {existing} and {grant_entry['materialization']}")
+                materialization_by_provider[grant_entry["provider"]] = grant_entry["materialization"]
             output[token_hash] = {"id": agent_id, "role": "agent", "paired_agent": None, "grants": grants}
             roles_by_id[agent_id] = "agent"
         for index, agent_id, paired_agent in pairings:

--- a/broker/core/agents.py
+++ b/broker/core/agents.py
@@ -11,7 +11,7 @@ from broker.plugins.github_app.provider import ProviderError
 
 
 VALID_ROLES = {"agent", "egress"}
-VALID_MATERIALIZATIONS = {"file-bundle", "header-inject"}
+VALID_MATERIALIZATIONS = {"file-bundle", "header-inject", "placeholder-file"}
 VALID_PERMISSION_VALUES = {"read", "write"}
 
 

--- a/broker/core/providers.py
+++ b/broker/core/providers.py
@@ -1,6 +1,7 @@
 from broker.plugins.github_app.provider import GithubAppProvider
 from broker.plugins.codex_oauth.provider import CodexOAuthProvider
 from broker.core.config import provider_entries
+from broker.plugins.placeholder.provider import PlaceholderProvider
 from broker.plugins.static_headers.provider import StaticHeadersProvider
 from broker.plugins.static_token.provider import StaticTokenProvider
 
@@ -9,6 +10,7 @@ PROVIDERS = {
     "codex-oauth": CodexOAuthProvider,
     "github-app": GithubAppProvider,
     "headers": StaticHeadersProvider,
+    "placeholder": PlaceholderProvider,
     "token": StaticTokenProvider,
 }
 

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -230,10 +230,15 @@ class Broker:
         grant = self.agents.grant(subject, capability)
         if grant is None:
             raise ProviderError("provider-not-granted", None, 403)
-        if grant.get("materialization") != "header-inject":
+        # Both header-inject and placeholder-file are zero-possession mediated
+        # modes: the real credential is injected at the edge, never handed to
+        # the agent. A single placeholder-file grant therefore both materializes
+        # the placeholder file (agent side) and authorizes edge injection
+        # (egress side) — no second grant for the same provider is needed.
+        if grant.get("materialization") not in ("header-inject", "placeholder-file"):
             raise ProviderError(
                 "materialization-mismatch",
-                f"grant for {capability} is not header-inject",
+                f"grant for {capability} is not injection-capable (header-inject or placeholder-file)",
                 403,
             )
         return grant

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -57,10 +57,15 @@ class Broker:
 
     def ensure_not_header_inject(self, agent, provider_name):
         grant = self.agents.grant(agent, provider_name)
-        if grant is not None and grant.get("materialization") == "header-inject":
+        if grant is None:
+            return
+        materialization = grant.get("materialization")
+        # Both header-inject and placeholder-file keep the real secret out of
+        # the agent's hands, so neither may reach a secret-bearing endpoint.
+        if materialization in ("header-inject", "placeholder-file"):
             raise ProviderError(
                 "materialization-mismatch",
-                f"grant for {provider_name} is header-inject; secret-bearing endpoints are disabled",
+                f"grant for {provider_name} is {materialization}; secret-bearing endpoints are disabled",
                 403,
             )
 
@@ -184,6 +189,42 @@ class Broker:
             file_count=len(files),
         )
         return {"ok": True, "files": files, "expires_at": expires_at}
+
+    def placeholder_files(self, request_id, payload, authorization):
+        # The agent fetches its own placeholder file: it is inert (placeholders
+        # only), so — unlike header-inject — the agent identity itself is the
+        # caller. Scoped exactly like every other grant; another agent's
+        # bindings are unreachable. Distinct from /v1/files: this path can only
+        # emit placeholders (the provider method never has the real bundle).
+        agent = self.authenticate_role(authorization, "agent")
+        provider_name = string_field(payload, "provider")
+        grant = self.agents.grant(agent, provider_name)
+        if grant is None:
+            raise ProviderError("provider-not-granted", None, 403)
+        if grant.get("materialization") != "placeholder-file":
+            raise ProviderError(
+                "materialization-mismatch",
+                f"grant for {provider_name} is not placeholder-file",
+                403,
+            )
+        provider = self.provider(provider_name)
+        if not hasattr(provider, "placeholder_files"):
+            raise ProviderError(
+                "placeholder-files-not-supported",
+                f"provider {provider_name} does not support placeholder files",
+                403,
+            )
+        files, hosts, expires_at = provider.placeholder_files(agent["id"], self.audit, request_id, grant)
+        self.audit.write(
+            request_id=request_id,
+            agent=agent["id"],
+            provider=provider_name,
+            operation="placeholder-files",
+            allowed=True,
+            expires_at=expires_at,
+            file_count=len(files),
+        )
+        return {"ok": True, "files": files, "hosts": hosts, "expires_at": expires_at}
 
     def _injection_grant(self, subject, capability):
         grant = self.agents.grant(subject, capability)
@@ -439,6 +480,10 @@ def make_handler(broker):
                     return
                 if self.path == "/v1/files":
                     response = broker.files(request_id, payload, self.headers.get("authorization"))
+                    self.write_json(200, response)
+                    return
+                if self.path == "/v1/placeholder-files":
+                    response = broker.placeholder_files(request_id, payload, self.headers.get("authorization"))
                     self.write_json(200, response)
                     return
                 if self.path == "/v1/injection/headers":

--- a/broker/plugins/codex_oauth/provider.py
+++ b/broker/plugins/codex_oauth/provider.py
@@ -24,6 +24,12 @@ DEFAULT_TOKEN_URL = "https://auth.openai.com/oauth/token"
 DEFAULT_REFRESH_MARGIN_SECONDS = 600
 DEFAULT_BUNDLE_TTL_SECONDS = 1200
 DEFAULT_STUB_REFRESH_TOKEN = "nvt-broker-stub"
+# id-token-claims copy real token-derived data into the placeholder file. The
+# claim paths are operator-trusted (non-secret identity, same model as
+# injection-claim-headers), but as defense in depth a copied value that looks
+# token-shaped (too long, or a JWT-like dotted blob) is refused rather than
+# smuggled into the placeholder.
+MAX_PLACEHOLDER_CLAIM_LEN = 128
 
 
 class CodexOAuthProvider:
@@ -82,6 +88,12 @@ class CodexOAuthProvider:
         for index, host in enumerate(list_value(raw.get("hosts"), f"provider {self.name} config.placeholder-file.hosts")):
             if not isinstance(host, str) or not host:
                 fail(f"provider {self.name} config.placeholder-file.hosts[{index}] must be a non-empty string")
+            # The placeholder file's host bindings must be a subset of the
+            # provider's injection-hosts: every host the placeholder credential
+            # is bound to must be one the edge can actually inject for
+            # (otherwise 6.2 refresh mediation, e.g. auth.openai.com, breaks).
+            if host not in self.injection_hosts:
+                fail(f"provider {self.name} config.placeholder-file.hosts[{index}] {host} must also be listed in injection-hosts")
             hosts.append(host)
         claims = []
         for index, item in enumerate(list_value(raw.get("id-token-claims"), f"provider {self.name} config.placeholder-file.id-token-claims")):
@@ -94,6 +106,16 @@ class CodexOAuthProvider:
             )
             claims.append({"claim": claim, "path": path_segments})
         return {"path": path, "hosts": hosts, "id_token_claims": claims}
+
+    def _guard_placeholder_claim(self, claim, value):
+        # _claim_value already refuses dict/list leaves; this rejects scalar
+        # values that look like a credential rather than a non-secret claim.
+        if isinstance(value, str):
+            if len(value) > MAX_PLACEHOLDER_CLAIM_LEN:
+                raise ProviderError("placeholder-claim-unsafe", f"placeholder id-token-claim {claim} value is too long to be a non-secret claim", 502)
+            if value.count(".") >= 2 and len(value) > 40:
+                raise ProviderError("placeholder-claim-unsafe", f"placeholder id-token-claim {claim} value looks token-shaped, refusing", 502)
+        return value
 
     def placeholder_files(self, agent_id, audit, request_id, grant=None):
         # Emit .codex/auth.json carrying only placeholders: opaque access/refresh
@@ -111,7 +133,7 @@ class CodexOAuthProvider:
         for entry in self.placeholder["id_token_claims"]:
             value = self._claim_value(real_claims, entry["path"])
             if value is not None:
-                id_claims[entry["claim"]] = value
+                id_claims[entry["claim"]] = self._guard_placeholder_claim(entry["claim"], value)
         content = {
             "tokens": {
                 "access_token": render_plain(),

--- a/broker/plugins/codex_oauth/provider.py
+++ b/broker/plugins/codex_oauth/provider.py
@@ -11,6 +11,12 @@ from urllib.request import Request, urlopen
 
 from broker.core.config import env_value, fail, injection_hosts, list_value, string_value
 from broker.plugins.github_app.provider import ProviderError
+from broker.plugins.placeholder_file import (
+    far_future_exp,
+    render_jwt,
+    render_plain,
+    validate_relative_path,
+)
 
 
 DEFAULT_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
@@ -46,7 +52,80 @@ class CodexOAuthProvider:
         self.extra_files = self._extra_files()
         self.injection_hosts = injection_hosts(self.config, self.name)
         self.claim_headers = self._claim_headers()
+        self.placeholder = self._placeholder_config()
         self.lock = threading.Lock()
+
+    def _parse_claim_path(self, raw_path, field):
+        # A claim key may itself contain dots (the OpenAI account claim key is a
+        # URL), so a list of exact segments is accepted alongside the dotted
+        # shorthand.
+        if isinstance(raw_path, list):
+            path = []
+            for segment_index, segment in enumerate(raw_path):
+                if not isinstance(segment, str) or not segment:
+                    fail(f"{field}[{segment_index}] must be a non-empty string")
+                path.append(segment)
+        else:
+            path = [segment for segment in string_value(raw_path, field, required=True).split(".") if segment]
+        if not path:
+            fail(f"{field} must not be empty")
+        return path
+
+    def _placeholder_config(self):
+        raw = self.config.get("placeholder-file")
+        if raw is None:
+            return None
+        if not isinstance(raw, dict):
+            fail(f"provider {self.name} config.placeholder-file must be a YAML object")
+        path = validate_relative_path(raw.get("path"), f"provider {self.name} config.placeholder-file.path")
+        hosts = []
+        for index, host in enumerate(list_value(raw.get("hosts"), f"provider {self.name} config.placeholder-file.hosts")):
+            if not isinstance(host, str) or not host:
+                fail(f"provider {self.name} config.placeholder-file.hosts[{index}] must be a non-empty string")
+            hosts.append(host)
+        claims = []
+        for index, item in enumerate(list_value(raw.get("id-token-claims"), f"provider {self.name} config.placeholder-file.id-token-claims")):
+            if not isinstance(item, dict):
+                fail(f"provider {self.name} config.placeholder-file.id-token-claims[{index}] must be a YAML object")
+            claim = string_value(item.get("claim"), f"provider {self.name} config.placeholder-file.id-token-claims[{index}].claim", required=True)
+            path_segments = self._parse_claim_path(
+                item.get("claim-path"),
+                f"provider {self.name} config.placeholder-file.id-token-claims[{index}].claim-path",
+            )
+            claims.append({"claim": claim, "path": path_segments})
+        return {"path": path, "hosts": hosts, "id_token_claims": claims}
+
+    def placeholder_files(self, agent_id, audit, request_id, grant=None):
+        # Emit .codex/auth.json carrying only placeholders: opaque access/refresh
+        # tokens and a jwt-shaped id_token whose claims are the provider's real
+        # non-secret identity (account id, plan, ...) plus a far-future exp. The
+        # real tokens stay in broker/provider state; they are injected at the
+        # edge (Phase 6.2). No refresh is triggered — this reads current state.
+        if self.placeholder is None:
+            raise ProviderError("placeholder-files-not-configured", f"provider {self.name} has no placeholder-file config", 403)
+        with self.lock:
+            auth = self._read_auth()
+            access_token = self._token(auth, "access_token")
+            real_claims = self._jwt_claims(access_token)
+        id_claims = {}
+        for entry in self.placeholder["id_token_claims"]:
+            value = self._claim_value(real_claims, entry["path"])
+            if value is not None:
+                id_claims[entry["claim"]] = value
+        content = {
+            "tokens": {
+                "access_token": render_plain(),
+                "refresh_token": render_plain(),
+                "id_token": render_jwt(id_claims, far_future_exp()),
+            },
+            "last_refresh": rfc3339(int(time.time())),
+        }
+        files = [{
+            "path": self.placeholder["path"],
+            "content": json.dumps(content, indent=2) + "\n",
+            "mode": "0600",
+        }]
+        return files, list(self.placeholder["hosts"]), None
 
     def _claim_headers(self):
         output = []
@@ -54,21 +133,10 @@ class CodexOAuthProvider:
             if not isinstance(item, dict):
                 fail(f"provider {self.name} config.injection-claim-headers[{index}] must be a YAML object")
             header = string_value(item.get("header"), f"provider {self.name} config.injection-claim-headers[{index}].header", required=True)
-            raw_path = item.get("claim-path")
-            field = f"provider {self.name} config.injection-claim-headers[{index}].claim-path"
-            # A claim key may itself contain dots (the OpenAI account claim key
-            # is a URL), so a list of exact segments is accepted alongside the
-            # dotted-string shorthand.
-            if isinstance(raw_path, list):
-                path = []
-                for segment_index, segment in enumerate(raw_path):
-                    if not isinstance(segment, str) or not segment:
-                        fail(f"{field}[{segment_index}] must be a non-empty string")
-                    path.append(segment)
-            else:
-                path = [segment for segment in string_value(raw_path, field, required=True).split(".") if segment]
-            if not path:
-                fail(f"{field} must not be empty")
+            path = self._parse_claim_path(
+                item.get("claim-path"),
+                f"provider {self.name} config.injection-claim-headers[{index}].claim-path",
+            )
             output.append({"header": header, "path": path})
         return output
 

--- a/broker/plugins/placeholder/provider.py
+++ b/broker/plugins/placeholder/provider.py
@@ -1,0 +1,117 @@
+"""Generic placeholder-file provider.
+
+Materializes a syntactically valid auth/config file containing only inert
+placeholders. Real secret values are read from the environment (broker/provider
+custody) and held broker-side; they are never emitted into the file the agent
+receives. This is the provider-agnostic mechanism behind the `placeholder-file`
+materialization mode; provider-specific presets (e.g. Codex) build the same
+shapes with their own field layout.
+"""
+
+import json
+
+from broker.core.config import env_value, fail, list_value, string_value
+from broker.plugins.github_app.provider import ProviderError
+from broker.plugins.placeholder_file import (
+    far_future_exp,
+    render_jwt,
+    render_plain,
+    validate_mode,
+    validate_relative_path,
+)
+
+
+class PlaceholderProvider:
+    def __init__(self, entry):
+        self.entry = entry
+        self.name = string_value(entry.get("name"), "provider.name", required=True)
+        self.config = entry.get("config") or {}
+        if not isinstance(self.config, dict):
+            fail(f"provider {self.name} config must be a YAML object")
+        file_config = self.config.get("file")
+        if not isinstance(file_config, dict):
+            fail(f"provider {self.name} config.file must be a YAML object")
+        self.file_path = validate_relative_path(
+            file_config.get("path"), f"provider {self.name} config.file.path"
+        )
+        self.file_mode = self._file_mode(file_config.get("mode"))
+        self.hosts = self._hosts()
+        self.fields = self._fields()
+
+    def _file_mode(self, mode):
+        if mode is None:
+            return "0600"
+        return validate_mode(mode, f"provider {self.name} config.file.mode")
+
+    def _hosts(self):
+        hosts = []
+        for index, host in enumerate(list_value(self.config.get("hosts"), f"provider {self.name} config.hosts")):
+            if not isinstance(host, str) or not host:
+                fail(f"provider {self.name} config.hosts[{index}] must be a non-empty string")
+            hosts.append(host)
+        return hosts
+
+    def _fields(self):
+        raw = self.config.get("fields")
+        if not isinstance(raw, dict) or not raw:
+            fail(f"provider {self.name} config.fields must be a non-empty YAML object")
+        fields = {}
+        for key, spec in raw.items():
+            if not isinstance(key, str) or not key:
+                fail(f"provider {self.name} config.fields keys must be non-empty strings")
+            # A field is either a literal non-secret value, or a secret spec
+            # (an object naming a secret-env and optional shape/claims). Only
+            # secret specs are placeholdered; literals are emitted verbatim.
+            if isinstance(spec, dict) and ("secret-env" in spec or "shape" in spec):
+                fields[key] = self._secret_field(key, spec)
+            else:
+                fields[key] = {"kind": "literal", "value": spec}
+        return fields
+
+    def _secret_field(self, key, spec):
+        shape = spec.get("shape", "plain")
+        if shape not in ("plain", "jwt"):
+            fail(f"provider {self.name} config.fields.{key}.shape must be plain or jwt")
+        secret_env = string_value(spec.get("secret-env"), f"provider {self.name} config.fields.{key}.secret-env", required=True)
+        # Read the real value so it is proven to be held broker-side, and fail
+        # loudly if it is missing — but it is NEVER emitted into the file.
+        real = env_value(secret_env)
+        if not real:
+            fail(f"environment variable {secret_env} must not be empty")
+        claims = spec.get("claims")
+        if claims is None:
+            claims = {}
+        if not isinstance(claims, dict):
+            fail(f"provider {self.name} config.fields.{key}.claims must be a YAML object")
+        if shape != "jwt" and spec.get("claims") is not None:
+            fail(f"provider {self.name} config.fields.{key}.claims is only valid for shape jwt")
+        return {"kind": "secret", "shape": shape, "claims": claims}
+
+    def placeholder_files(self, agent_id, audit, request_id, grant=None):
+        content_object = {}
+        for key, field in self.fields.items():
+            if field["kind"] == "literal":
+                content_object[key] = field["value"]
+            elif field["shape"] == "jwt":
+                content_object[key] = render_jwt(field["claims"], far_future_exp())
+            else:
+                content_object[key] = render_plain()
+        files = [{
+            "path": self.file_path,
+            "content": json.dumps(content_object, indent=2) + "\n",
+            "mode": self.file_mode,
+        }]
+        # Placeholders do not expire; the real credential is refreshed
+        # broker-side and injected at the edge.
+        return files, list(self.hosts), None
+
+    # The generic placeholder provider materializes files only; it does not
+    # serve secret-bearing endpoints. Guard against accidental use.
+    def token_for_repo(self, repo, effective_repositories):
+        raise ProviderError("token-not-supported", f"provider {self.name} is placeholder-file only")
+
+    def headers_for_repo(self, repo, effective_repositories):
+        raise ProviderError("headers-not-supported", f"provider {self.name} is placeholder-file only")
+
+    def files(self, agent_id, audit, request_id):
+        raise ProviderError("files-not-supported", f"provider {self.name} does not vend real file bundles; use placeholder-file")

--- a/broker/plugins/placeholder/provider.py
+++ b/broker/plugins/placeholder/provider.py
@@ -59,11 +59,14 @@ class PlaceholderProvider:
         for key, spec in raw.items():
             if not isinstance(key, str) or not key:
                 fail(f"provider {self.name} config.fields keys must be non-empty strings")
-            # A field is either a literal non-secret value, or a secret spec
-            # (an object naming a secret-env and optional shape/claims). Only
-            # secret specs are placeholdered; literals are emitted verbatim.
-            if isinstance(spec, dict) and ("secret-env" in spec or "shape" in spec):
+            # Fail closed on ambiguity: any object field MUST be a well-formed
+            # secret spec (naming a secret-env). A mis-keyed secret field must
+            # never silently degrade into a literal object emitted verbatim.
+            # Only scalar values are literals (emitted as-is; non-secret).
+            if isinstance(spec, dict):
                 fields[key] = self._secret_field(key, spec)
+            elif isinstance(spec, (list,)):
+                fail(f"provider {self.name} config.fields.{key} must be a scalar literal or a secret spec object")
             else:
                 fields[key] = {"kind": "literal", "value": spec}
         return fields

--- a/broker/plugins/placeholder_file.py
+++ b/broker/plugins/placeholder_file.py
@@ -1,0 +1,74 @@
+"""Shared rendering for the placeholder-file materialization mode.
+
+A placeholder file is a syntactically valid auth/config file that carries only
+inert placeholders: the real secret values stay in broker/provider custody and
+never reach the agent (docs/phase6.1-placeholder-file-materialization-pr-plan.md).
+These helpers render the two placeholder shapes and validate the target path;
+they hold no secret state.
+"""
+
+import base64
+import json
+import time
+
+from broker.core.config import fail
+
+# The documented zero-entropy placeholder from protocol/injection.md — the only
+# credential-shaped value allowed inside the agent container.
+PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
+
+# A JWT signature segment that is obviously not a real signature. It is never
+# verified locally (the real bearer token is injected at the edge in 6.2).
+PLACEHOLDER_JWT_SIGNATURE = "nvt-placeholder-signature"
+
+# A placeholder JWT's exp is set far in the future so a tool that checks local
+# token expiry starts without attempting a refresh.
+FAR_FUTURE_SECONDS = 10 * 365 * 24 * 3600
+
+
+def _b64url(data):
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def far_future_exp(now=None):
+    base = int(now if now is not None else time.time())
+    return base + FAR_FUTURE_SECONDS
+
+
+def render_jwt(claims, exp):
+    """Render a syntactically valid JWT carrying only non-secret claims plus a
+    placeholder signature. The signature is never real material — it is a fixed
+    placeholder — so no secret leaks through the token."""
+    if not isinstance(claims, dict):
+        fail("placeholder jwt claims must be an object")
+    header = {"alg": "none", "typ": "JWT"}
+    payload = dict(claims)
+    payload["exp"] = int(exp)
+    header_segment = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_segment = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    return f"{header_segment}.{payload_segment}.{PLACEHOLDER_JWT_SIGNATURE}"
+
+
+def render_plain():
+    """Render an opaque placeholder string."""
+    return PLACEHOLDER
+
+
+def validate_mode(mode, field):
+    if not isinstance(mode, str) or len(mode) != 4 or any(char not in "01234567" for char in mode):
+        fail(f"{field} must be a four-digit octal string")
+    return mode
+
+
+def validate_relative_path(path, field):
+    """A placeholder file path is a safe relative path under the agent home.
+    Absolute paths and '.'/'..'/empty segments are refused so materialization
+    cannot escape the home directory."""
+    if not isinstance(path, str) or not path:
+        fail(f"{field} is required")
+    if path.startswith("/") or path.startswith("\\"):
+        fail(f"{field} must be a relative path")
+    segments = path.replace("\\", "/").split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        fail(f"{field} must not contain empty, '.', or '..' path segments")
+    return path

--- a/charts/nvt/crds/nvt.dev_agentruns.yaml
+++ b/charts/nvt/crds/nvt.dev_agentruns.yaml
@@ -113,6 +113,7 @@ spec:
                             enum:
                               - file-bundle
                               - header-inject
+                              - placeholder-file
                           egressHosts:
                             type: array
                             items:

--- a/docs/mediated-egress-plan.md
+++ b/docs/mediated-egress-plan.md
@@ -1,7 +1,7 @@
 # Plan: Mediated Credential Egress
 
 Status: living document — Phases 0–4 completed (#53, #54, Phase 2 gate, #56, #58, #59, Phase 4 git-over-HTTPS mediation)
-Version: v3.7 (Phase 5 PR 6a landed: own-Pod egressd + CNI-enforced NetworkPolicies behind `spec.egressEnforcement`, egress-denied smoke on the Calico kind cluster; PR 6b landed: per-request audit via `POST /v1/injection/report`, per-grant request quotas, revocation bound proven + documented, Anthropic provider-agnosticism proof, `egress.defaultMode` knob defaulting to `direct` — global flip still deferred)
+Version: v3.7 (Phase 5 PR 6a landed: own-Pod egressd + CNI-enforced NetworkPolicies behind `spec.egressEnforcement`, egress-denied smoke on the Calico kind cluster; PR 6b landed: per-request audit via `POST /v1/injection/report`, per-grant request quotas, revocation bound proven + documented, Anthropic provider-agnosticism proof, `egress.defaultMode` knob defaulting to `direct` — global flip still deferred; PR 6.1 landed: generic `placeholder-file` materialization via `POST /v1/placeholder-files` — a syntactically valid auth file of inert placeholders (plain/`jwt` shapes, host bindings), Codex `.codex/auth.json` preset, runtime materialization; fixture-level only, the real tool win awaits 6.2's edge injection)
 
 ## Goal
 

--- a/docs/phase6.1-placeholder-file-materialization-pr-plan.md
+++ b/docs/phase6.1-placeholder-file-materialization-pr-plan.md
@@ -182,3 +182,9 @@ Where: `runtime/core/bootstrap.py` (or the existing broker-auth-files path),
 - **Body/query placeholder substitution** — deferred (see 6.2).
 - Host-auth-file runtime sourcing — a dev import helper at most, never the
   runtime architecture.
+- **Standalone placeholder-file egress routing** — through the operator/compose
+  admission, a mediated run still requires at least one `header-inject` grant
+  with `egressHosts` for its egress route; `placeholder-file` grants are
+  materialized but not routed. A tool reaching its upstream purely via a
+  placeholder file + the forward proxy is 6.2. The broker already treats a
+  `placeholder-file` grant as injection-eligible so 6.2 needs no second grant.

--- a/docs/phase6.1-placeholder-file-materialization-pr-plan.md
+++ b/docs/phase6.1-placeholder-file-materialization-pr-plan.md
@@ -1,6 +1,9 @@
 # PR 6.1 Plan: Generic placeholder-file materialization
 
-Status: plan — ready to implement (Phase 5 complete: #63 6a, #64 6b)
+Status: landed — generic placeholder-file materialization, Codex preset, and
+runtime materialization implemented with fixture-level tests (no real secrets).
+The real tool-behind-a-placeholder-file win is demonstrated after 6.2 merges
+(the honest dependency noted below).
 Parent: [mediated-egress-plan.md](mediated-egress-plan.md) §"Phase 6", sequence
 row 7. This is the broker/provider half of Phase 6, split out from
 [phase6.2-forward-proxy-pr-plan.md](phase6.2-forward-proxy-pr-plan.md) (row 8)

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -28,6 +28,10 @@ const (
 
 	AgentRunGrantFileBundle   AgentRunGrantMaterialization = "file-bundle"
 	AgentRunGrantHeaderInject AgentRunGrantMaterialization = "header-inject"
+	// AgentRunGrantPlaceholderFile materializes an inert placeholder auth file
+	// for the agent; the real credential stays broker-side and is injected at
+	// the edge. Like header-inject, it is a zero-possession mediated mode.
+	AgentRunGrantPlaceholderFile AgentRunGrantMaterialization = "placeholder-file"
 )
 
 // AgentRun represents one disposable nvt agent execution.
@@ -89,8 +93,12 @@ type AgentRunBroker struct {
 
 // AgentRunBrokerGrant defines repositories granted through a credential provider.
 type AgentRunBrokerGrant struct {
-	Provider        string                       `json:"provider"`
-	Repositories    []string                     `json:"repositories"`
+	Provider     string   `json:"provider"`
+	Repositories []string `json:"repositories"`
+	// Materialization selects how the credential reaches the run: file-bundle
+	// (direct only; writes usable material into the container), header-inject
+	// or placeholder-file (both mediated-only, zero-possession — the real
+	// credential is injected at the edge, never handed to the agent).
 	Materialization AgentRunGrantMaterialization `json:"materialization,omitempty"`
 	EgressHosts     []string                     `json:"egressHosts,omitempty"`
 	// Git marks a git-over-HTTPS grant: its egressd route terminates TLS

--- a/operator/config/crd/bases/nvt.dev_agentruns.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentruns.yaml
@@ -113,6 +113,7 @@ spec:
                             enum:
                               - file-bundle
                               - header-inject
+                              - placeholder-file
                           egressHosts:
                             type: array
                             items:

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2200,12 +2200,15 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 	for _, grant := range AgentRunBrokerGrants(agentRun.Spec.Broker) {
 		materialization := AgentRunGrantMaterialization(grant)
 		switch materialization {
-		case nvtv1alpha1.AgentRunGrantFileBundle, nvtv1alpha1.AgentRunGrantHeaderInject:
+		case nvtv1alpha1.AgentRunGrantFileBundle, nvtv1alpha1.AgentRunGrantHeaderInject, nvtv1alpha1.AgentRunGrantPlaceholderFile:
 		default:
-			return fmt.Errorf("broker grant %s materialization must be file-bundle or header-inject, got %q", grant.Provider, materialization)
+			return fmt.Errorf("broker grant %s materialization must be file-bundle, header-inject, or placeholder-file, got %q", grant.Provider, materialization)
 		}
-		if mode == nvtv1alpha1.AgentRunEgressDirect && materialization == nvtv1alpha1.AgentRunGrantHeaderInject {
-			return fmt.Errorf("egress direct is incompatible with broker grant %s materialization header-inject", grant.Provider)
+		// header-inject and placeholder-file are zero-possession mediated modes:
+		// both are rejected in direct mode (no edge to inject at) and file-bundle
+		// is rejected in mediated mode (writes usable material into the container).
+		if mode == nvtv1alpha1.AgentRunEgressDirect && materialization != nvtv1alpha1.AgentRunGrantFileBundle {
+			return fmt.Errorf("egress direct is incompatible with broker grant %s materialization %s", grant.Provider, materialization)
 		}
 		if mode == nvtv1alpha1.AgentRunEgressMediated && materialization == nvtv1alpha1.AgentRunGrantFileBundle {
 			return fmt.Errorf("egress mediated is incompatible with broker grant %s materialization file-bundle", grant.Provider)
@@ -2597,6 +2600,18 @@ func InjectMediatedEgressConfig(config map[string]any, agentRun *nvtv1alpha1.Age
 			"base-url":        baseURL,
 		})
 		routeIndex++
+	}
+	// placeholder-file grants carry no egressd route (edge injection is Phase
+	// 6.2); bootstrap only needs the provider + mode to materialize the inert
+	// placeholder auth file.
+	for _, grant := range AgentRunBrokerGrants(agentRun.Spec.Broker) {
+		if AgentRunGrantMaterialization(grant) != nvtv1alpha1.AgentRunGrantPlaceholderFile {
+			continue
+		}
+		grants = append(grants, map[string]any{
+			"provider":        grant.Provider,
+			"materialization": string(nvtv1alpha1.AgentRunGrantPlaceholderFile),
+		})
 	}
 	updated := cloneStringAnyMap(config)
 	egress := map[string]any{

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2248,6 +2248,10 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 		}
 	}
 	if mode == nvtv1alpha1.AgentRunEgressMediated && headerInjectGrants == 0 {
+		// 6.1 scope: placeholder-file grants are materialized but not routed
+		// (no egressd route until 6.2's forward proxy), so a mediated run still
+		// needs a header-inject grant for its egress route. Standalone
+		// placeholder-file routing lands in 6.2.
 		return fmt.Errorf("egress mediated requires at least one header-inject broker grant with egressHosts")
 	}
 	return nil

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -537,6 +537,63 @@ func TestValidateAgentRunEgressModeRejectsMismatches(t *testing.T) {
 	}
 }
 
+func TestValidateAgentRunEgressModePlaceholderFile(t *testing.T) {
+	// Mediated: a placeholder-file grant alongside the header-inject route is
+	// accepted (zero-possession materialization).
+	mediated := testAgentRun()
+	mediated.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	mediated.Spec.EgressAllowInsecureBroker = true
+	mediated.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{
+		{Provider: "api-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject, EgressHosts: []string{"api.example.test:443"}},
+		{Provider: "codex-main", Materialization: nvtv1alpha1.AgentRunGrantPlaceholderFile},
+	}}
+	if err := ValidateAgentRunEgressMode(mediated); err != nil {
+		t.Fatalf("mediated placeholder-file grant must be accepted, got %v", err)
+	}
+
+	// Direct: a placeholder-file grant is rejected like header-inject — it is a
+	// zero-possession mediated mode with no edge to inject at.
+	direct := testAgentRun()
+	direct.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "codex-main", Materialization: nvtv1alpha1.AgentRunGrantPlaceholderFile,
+	}}}
+	if err := ValidateAgentRunEgressMode(direct); err == nil ||
+		!strings.Contains(err.Error(), "codex-main") || !strings.Contains(err.Error(), "placeholder-file") {
+		t.Fatalf("direct placeholder-file grant must be rejected naming the provider, got %v", err)
+	}
+}
+
+// TestInjectMediatedEgressConfigPlaceholderFile pins that a placeholder-file
+// grant reaches the agent egress config (materialization only, no base-url) so
+// bootstrap materializes the placeholder auth file.
+func TestInjectMediatedEgressConfigPlaceholderFile(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated
+	agentRun.Spec.Broker = &nvtv1alpha1.AgentRunBroker{Grants: []nvtv1alpha1.AgentRunBrokerGrant{
+		{Provider: "api-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject, EgressHosts: []string{"api.example.test:443"}},
+		{Provider: "codex-main", Materialization: nvtv1alpha1.AgentRunGrantPlaceholderFile},
+	}}
+	config := InjectMediatedEgressConfig(map[string]any{}, agentRun)
+	egress := config["egress"].(map[string]any)
+	grants := egress["grants"].([]any)
+	var placeholder map[string]any
+	for _, raw := range grants {
+		grant := raw.(map[string]any)
+		if grant["provider"] == "codex-main" {
+			placeholder = grant
+		}
+	}
+	if placeholder == nil {
+		t.Fatalf("placeholder-file grant missing from agent egress config: %#v", grants)
+	}
+	if placeholder["materialization"] != "placeholder-file" {
+		t.Fatalf("unexpected materialization: %#v", placeholder)
+	}
+	if _, hasBaseURL := placeholder["base-url"]; hasBaseURL {
+		t.Fatalf("placeholder-file grant must not carry a base-url: %#v", placeholder)
+	}
+}
+
 func TestValidateAgentRunEgressModeRejectsMediatedRuntimeAuth(t *testing.T) {
 	agentRun := testAgentRun()
 	agentRun.Spec.Egress = nvtv1alpha1.AgentRunEgressMediated

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -240,6 +240,10 @@ Rules:
   bindings, and a `placeholder-file` grant is denied on `/v1/token`,
   `/v1/headers`, and `/v1/files` (`materialization-mismatch`) — the real
   secret is unreachable everywhere.
+- **Injection-capable**: a `placeholder-file` grant also authorizes
+  `/v1/injection/headers` for the paired egress identity, so the same grant
+  both materializes the placeholder file and lets the edge inject the real
+  credential (no second `header-inject` grant for the provider is needed).
 - `egress`-role identities are refused; the placeholder file is inert and
   agent-owned.
 - Error shape and status conventions match `/v1/token`.

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -240,10 +240,13 @@ Rules:
   bindings, and a `placeholder-file` grant is denied on `/v1/token`,
   `/v1/headers`, and `/v1/files` (`materialization-mismatch`) — the real
   secret is unreachable everywhere.
-- **Injection-capable**: a `placeholder-file` grant also authorizes
-  `/v1/injection/headers` for the paired egress identity, so the same grant
-  both materializes the placeholder file and lets the edge inject the real
-  credential (no second `header-inject` grant for the provider is needed).
+- **Injection-eligible**: `/v1/injection/headers` accepts a `placeholder-file`
+  grant, so the same grant both materializes the placeholder file and lets the
+  edge inject the real credential (no second `header-inject` grant for the
+  provider is needed). This functions only for providers that also implement
+  injection (an `injection_headers` method plus `injection-hosts`), such as the
+  Codex preset; the generic `placeholder` provider is materialization-only and
+  returns `injection-not-supported`.
 - `egress`-role identities are refused; the placeholder file is inert and
   agent-owned.
 - Error shape and status conventions match `/v1/token`.

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -195,6 +195,55 @@ Unknown providers, missing grants, and provider failures use the same
 `{"ok":false,"error":"...","message":"..."}` error shape and status
 conventions as `/v1/token`.
 
+### POST /v1/placeholder-files
+
+Returns a provider-materialized **placeholder** file: a syntactically valid
+auth/config file whose secret fields carry only inert placeholders. This is
+the `placeholder-file` materialization mode — **distinct from `file-bundle`**.
+`file-bundle` writes usable credential material into the agent (the
+dev/fallback path); `placeholder-file` never does. The real secret values stay
+in broker/provider custody and are injected at the network edge (Phase 6.2),
+so a file-based tool can start against a local auth file it accepts while the
+agent holds no real credential.
+
+Request: `{"provider": "codex-main"}`. Requires an `agent`-role bearer token
+whose identity holds a `placeholder-file` grant for the provider.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "files": [
+    {"path": ".codex/auth.json", "content": "{ ... placeholders ... }\n", "mode": "0600"}
+  ],
+  "hosts": ["chatgpt.com", "api.openai.com", "auth.openai.com"],
+  "expires_at": null
+}
+```
+
+Rules:
+
+- `path` is a **relative** path under the agent home (subdirectories allowed);
+  absolute paths and `.`/`..`/empty segments are refused. `content` is a UTF-8
+  string; `mode` is a four-digit octal string (default `"0600"`).
+- Secret fields are placeholders only, on every path including errors. The two
+  placeholder shapes: `plain` (the zero-entropy `NVT-PLACEHOLDER-NOT-A-KEY`)
+  and `jwt` (a syntactically valid JWT carrying only non-secret identity claims
+  plus a far-future `exp`, with a placeholder signature — for tools that parse
+  local token claims before any network call). Non-secret literal fields are
+  emitted verbatim.
+- `hosts` are the upstream hosts the placeholder's real credential is valid
+  for; consumed by the forward-proxy route/injection map (Phase 6.2). Not a
+  secret.
+- Scoped exactly like every other grant: the agent fetches only its own
+  bindings, and a `placeholder-file` grant is denied on `/v1/token`,
+  `/v1/headers`, and `/v1/files` (`materialization-mismatch`) — the real
+  secret is unreachable everywhere.
+- `egress`-role identities are refused; the placeholder file is inert and
+  agent-owned.
+- Error shape and status conventions match `/v1/token`.
+
 ### POST /v1/identity
 
 Returns commit identity metadata for a broker provider after applying the same

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -79,10 +79,12 @@ Each grant carries a materialization mode:
   real credential stays broker-side and is injected at the edge (Phase 6.2).
   Distinct from `file-bundle`: no path in this mode writes usable credentials.
   The response's `hosts` bindings feed the forward-proxy route/injection map.
-  Like `header-inject`, it is **injection-capable**: the same grant that
-  materializes the placeholder file also authorizes `/v1/injection/headers`,
-  so the edge injects the real credential without a second grant for the
-  provider.
+  A `placeholder-file` grant is **injection-eligible**: `/v1/injection/headers`
+  accepts it, so the same grant that materializes the file can also authorize
+  edge injection without a second grant. This only functions for providers
+  that also implement injection (an `injection_headers` method and
+  `injection-hosts`) — e.g. the Codex preset. The generic `placeholder`
+  provider is materialization-only and returns `injection-not-supported`.
 
 Modes are mutually exclusive per grant, enforced broker-side:
 
@@ -102,6 +104,13 @@ AgentSchedule admission and by compose `agent-init` from plan Phase 3):
 - run `egress: mediated` with any `file-bundle` grant fails admission.
 - There is no downgrade path in either direction. The error names the
   offending grant.
+
+Operator/compose scope (6.1): `placeholder-file` grants are accepted in
+mediated mode and materialized by bootstrap, but they are **not yet routed** —
+a mediated run still requires at least one `header-inject` grant with
+`egressHosts` for its egress route. Standalone `placeholder-file` egress (the
+tool reaching its upstream through the forward proxy) lands in Phase 6.2; until
+then a placeholder file is materialized but inert.
 
 ## Endpoints
 

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -79,6 +79,10 @@ Each grant carries a materialization mode:
   real credential stays broker-side and is injected at the edge (Phase 6.2).
   Distinct from `file-bundle`: no path in this mode writes usable credentials.
   The response's `hosts` bindings feed the forward-proxy route/injection map.
+  Like `header-inject`, it is **injection-capable**: the same grant that
+  materializes the placeholder file also authorizes `/v1/injection/headers`,
+  so the edge injects the real credential without a second grant for the
+  provider.
 
 Modes are mutually exclusive per grant, enforced broker-side:
 
@@ -87,13 +91,14 @@ Modes are mutually exclusive per grant, enforced broker-side:
 - A `placeholder-file` grant is the only mode that may call
   `/v1/placeholder-files`; `file-bundle`/`header-inject` grants are denied
   there.
-- A `file-bundle` grant denies `/v1/injection/headers` for that provider and
-  the paired egress identity.
+- `/v1/injection/headers` accepts `header-inject` and `placeholder-file`
+  grants (both zero-possession); a `file-bundle` grant is denied there.
 
 Run-level admission (normative here, enforced by the operator's
 AgentSchedule admission and by compose `agent-init` from plan Phase 3):
 
-- run `egress: direct` with any `header-inject` grant fails admission.
+- run `egress: direct` with any `header-inject` or `placeholder-file` grant
+  fails admission (both are zero-possession mediated modes).
 - run `egress: mediated` with any `file-bundle` grant fails admission.
 - There is no downgrade path in either direction. The error names the
   offending grant.

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -69,14 +69,24 @@ Rules, all enforced broker-side:
 Each grant carries a materialization mode:
 
 - `file-bundle` (default) — current behavior; the agent identity may call the
-  compatibility endpoints per `protocol/broker.md`.
+  compatibility endpoints per `protocol/broker.md`. Writes usable credential
+  material into the container (the dev/fallback path).
 - `header-inject` — zero-possession; only the paired egress identity may
   obtain the credential, via `/v1/injection/headers`.
+- `placeholder-file` — zero-possession for file-based tools; the agent
+  identity fetches a syntactically valid auth file containing only inert
+  placeholders, via `/v1/placeholder-files` (see `protocol/broker.md`). The
+  real credential stays broker-side and is injected at the edge (Phase 6.2).
+  Distinct from `file-bundle`: no path in this mode writes usable credentials.
+  The response's `hosts` bindings feed the forward-proxy route/injection map.
 
 Modes are mutually exclusive per grant, enforced broker-side:
 
-- A `header-inject` grant denies `/v1/token`, `/v1/headers`, and `/v1/files`
-  for that provider and agent.
+- A `header-inject` or `placeholder-file` grant denies `/v1/token`,
+  `/v1/headers`, and `/v1/files` for that provider and agent.
+- A `placeholder-file` grant is the only mode that may call
+  `/v1/placeholder-files`; `file-bundle`/`header-inject` grants are denied
+  there.
 - A `file-bundle` grant denies `/v1/injection/headers` for that provider and
   the paired egress identity.
 

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -446,8 +446,15 @@ def placeholder_file_target(home, rel):
     return home.joinpath(*segments)
 
 
-def write_placeholder_file(target, content, mode):
+def write_placeholder_file(target, content, mode, home):
     target.parent.mkdir(parents=True, exist_ok=True)
+    # Defense in depth: the relative path had no '..', but a symlinked parent
+    # could still redirect the write outside HOME. Verify the resolved parent
+    # stays under the resolved HOME before writing anything.
+    resolved_home = Path(os.path.realpath(home))
+    resolved_parent = Path(os.path.realpath(target.parent))
+    if resolved_parent != resolved_home and resolved_home not in resolved_parent.parents:
+        raise SystemExit(f"bootstrap: placeholder file target {target} resolves outside HOME")
     fd, temporary = tempfile.mkstemp(dir=str(target.parent), prefix=".nvt-placeholder-", suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
@@ -495,7 +502,7 @@ def apply_placeholder_files(egress):
             if not isinstance(raw_mode, str) or len(raw_mode) != 4 or any(char not in "01234567" for char in raw_mode):
                 raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} has an invalid mode {raw_mode!r}")
             target = placeholder_file_target(home, entry.get("path"))
-            write_placeholder_file(target, content, int(raw_mode, 8))
+            write_placeholder_file(target, content, int(raw_mode, 8), home)
 
 
 def apply_additional_paths(paths):

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -374,7 +374,12 @@ def apply_mediated_egress(egress):
         provider = grant.get("provider")
         if not isinstance(provider, str) or not provider:
             raise SystemExit(f"egress.grants[{index}].provider must be a non-empty string")
-        if grant.get("materialization") != "header-inject":
+        materialization = grant.get("materialization")
+        if materialization == "placeholder-file":
+            # Materialized separately by apply_placeholder_files; not an egress
+            # route.
+            continue
+        if materialization != "header-inject":
             raise SystemExit(f"egress mediated grant {provider} must be materialization header-inject")
         base_url = grant.get("base-url")
         if not isinstance(base_url, str) or not base_url:
@@ -397,6 +402,100 @@ def apply_mediated_egress(egress):
         encoding="utf-8",
     )
     persist_env_var("NVT_EGRESS_PLACEHOLDER", PLACEHOLDER)
+
+
+def broker_placeholder_files(provider, deadline):
+    # Same bounded retry as broker_routing: the broker agents ConfigMap can lag
+    # behind Pod start, so unauthorized/unreachable are retried; everything else
+    # fails immediately.
+    while True:
+        result = subprocess.run(
+            ["brokerctl", "placeholder-files", "--provider", provider],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        payload = None
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            payload = parsed
+        if result.returncode == 0 and payload is not None and payload.get("ok"):
+            return payload
+        error = (payload or {}).get("error")
+        if error in {"unauthorized", "broker-unreachable"} and time.monotonic() < deadline:
+            print(f"bootstrap: broker not ready for placeholder files {provider} ({error}); retrying", flush=True)
+            time.sleep(2)
+            continue
+        if payload is None:
+            raise SystemExit(f"bootstrap: placeholder-files failed for {provider}: {result.stderr.strip() or result.stdout.strip()}")
+        raise SystemExit(f"bootstrap: placeholder-files denied for {provider}: {payload.get('message') or payload.get('error') or payload}")
+
+
+def placeholder_file_target(home, rel):
+    # Defense in depth: the broker already refuses absolute/traversal paths, but
+    # the runtime re-validates before writing anywhere.
+    if not isinstance(rel, str) or not rel or rel.startswith("/") or rel.startswith("\\"):
+        raise SystemExit(f"bootstrap: placeholder file path {rel!r} must be a relative path")
+    segments = rel.replace("\\", "/").split("/")
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise SystemExit(f"bootstrap: placeholder file path {rel!r} must not contain traversal segments")
+    return home.joinpath(*segments)
+
+
+def write_placeholder_file(target, content, mode):
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(dir=str(target.parent), prefix=".nvt-placeholder-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(temporary, mode)
+        os.replace(temporary, str(target))
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def apply_placeholder_files(egress):
+    # Materialize provider-owned placeholder auth files (placeholders only; the
+    # real secret stays broker-side). Runs regardless of egress mode. Never
+    # reads a host auth file as the source of truth.
+    if not isinstance(egress, dict):
+        return
+    grants = egress.get("grants") or []
+    if not isinstance(grants, list):
+        return
+    deadline = None
+    for index, grant in enumerate(grants):
+        if not isinstance(grant, dict) or grant.get("materialization") != "placeholder-file":
+            continue
+        provider = grant.get("provider")
+        if not isinstance(provider, str) or not provider:
+            raise SystemExit(f"egress.grants[{index}].provider must be a non-empty string")
+        if deadline is None:
+            deadline = broker_wait_deadline()
+        response = broker_placeholder_files(provider, deadline)
+        files = response.get("files")
+        if not isinstance(files, list) or not files:
+            raise SystemExit(f"bootstrap: placeholder-files for {provider} returned no files")
+        home = Path.home()
+        for file_index, entry in enumerate(files):
+            if not isinstance(entry, dict):
+                raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} must be an object")
+            content = entry.get("content")
+            if not isinstance(content, str):
+                raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} must include string content")
+            raw_mode = entry.get("mode") or "0600"
+            if not isinstance(raw_mode, str) or len(raw_mode) != 4 or any(char not in "01234567" for char in raw_mode):
+                raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} has an invalid mode {raw_mode!r}")
+            target = placeholder_file_target(home, entry.get("path"))
+            write_placeholder_file(target, content, int(raw_mode, 8))
 
 
 def apply_additional_paths(paths):
@@ -554,6 +653,9 @@ def main():
     setup_tmux_config()
     if mediated_mode(egress):
         apply_mediated_egress(egress)
+    # Placeholder-file materialization is independent of egress mode: it writes
+    # inert placeholder auth files whether or not mediated routing is applied.
+    apply_placeholder_files(egress)
     command = optional_string(runtime.get("command"), "runtime.command")
     if command:
         # Kept for older helper scripts and diagnostics; start-agent-session uses

--- a/runtime/core/brokerctl.py
+++ b/runtime/core/brokerctl.py
@@ -113,6 +113,13 @@ def command_files(args):
     return 0 if response.get("ok") else 1
 
 
+def command_placeholder_files(args):
+    payload = {"provider": args.provider}
+    response, _status = request_json("/v1/placeholder-files", payload)
+    print_json(response)
+    return 0 if response.get("ok") else 1
+
+
 def command_injection_routing(args):
     payload = {"capability": args.capability}
     response, _status = request_json("/v1/injection/routing", payload)
@@ -158,6 +165,10 @@ def main():
     files = subparsers.add_parser("files")
     files.add_argument("--provider", required=True)
     files.set_defaults(func=command_files)
+
+    placeholder_files = subparsers.add_parser("placeholder-files")
+    placeholder_files.add_argument("--provider", required=True)
+    placeholder_files.set_defaults(func=command_placeholder_files)
 
     injection = subparsers.add_parser("injection")
     injection_sub = injection.add_subparsers(dest="injection_command", required=True)

--- a/scripts/agent-grant.sh
+++ b/scripts/agent-grant.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 --name <name> --provider <provider> --repo <owner/repo> [--materialization file-bundle|header-inject] [--egress-host host[:port]] [--git] [--permission <name>=read|write]" >&2
+  echo "usage: $0 --name <name> --provider <provider> --repo <owner/repo> [--materialization file-bundle|header-inject|placeholder-file] [--egress-host host[:port]] [--git] [--permission <name>=read|write]" >&2
 }
 
 name=""
@@ -62,7 +62,7 @@ if [ -z "$name" ] || [ -z "$provider" ] || [ -z "$repo" ]; then
   exit 1
 fi
 case "$materialization" in
-  file-bundle|header-inject) ;;
+  file-bundle|header-inject|placeholder-file) ;;
   *)
     echo "invalid materialization: $materialization" >&2
     usage

--- a/scripts/agent-init.sh
+++ b/scripts/agent-init.sh
@@ -309,8 +309,11 @@ for grant in agent.get("grants", []) or []:
         continue
     provider = grant.get("provider") or "<unknown>"
     materialization = grant.get("materialization") or "file-bundle"
-    if mode == "direct" and materialization == "header-inject":
-        raise SystemExit(f"agent-init: egress direct is incompatible with broker grant {provider} materialization header-inject")
+    if materialization not in ("file-bundle", "header-inject", "placeholder-file"):
+        raise SystemExit(f"agent-init: broker grant {provider} materialization must be file-bundle, header-inject, or placeholder-file, got {materialization}")
+    # header-inject and placeholder-file are zero-possession mediated modes.
+    if mode == "direct" and materialization != "file-bundle":
+        raise SystemExit(f"agent-init: egress direct is incompatible with broker grant {provider} materialization {materialization}")
     if mode == "mediated" and materialization == "file-bundle":
         raise SystemExit(f"agent-init: egress mediated is incompatible with broker grant {provider} materialization file-bundle")
     if mode == "mediated" and materialization == "header-inject":
@@ -431,6 +434,13 @@ if mode == "mediated":
         lines.append("      materialization: header-inject")
         lines.append(f"      base-url: {scheme}://127.0.0.1:{8471 + index}")
         index += 1
+    # placeholder-file grants carry no egressd route (edge injection is Phase
+    # 6.2); bootstrap only needs provider + mode to materialize the file.
+    for grant in (agent or {}).get("grants", []) or []:
+        if not isinstance(grant, dict) or (grant.get("materialization") or "file-bundle") != "placeholder-file":
+            continue
+        lines.append(f"    - provider: {grant.get('provider')}")
+        lines.append("      materialization: placeholder-file")
     lines.append(END)
     text = text.rstrip("\n") + "\n\n" + "\n".join(lines) + "\n"
     changed = True

--- a/scripts/broker-agents.py
+++ b/scripts/broker-agents.py
@@ -154,7 +154,7 @@ def main():
     grant.add_argument("--name", required=True)
     grant.add_argument("--provider", required=True)
     grant.add_argument("--repo", required=True)
-    grant.add_argument("--materialization", choices=["file-bundle", "header-inject"])
+    grant.add_argument("--materialization", choices=["file-bundle", "header-inject", "placeholder-file"])
     grant.add_argument("--egress-host", action="append", default=[])
     grant.add_argument("--git", action="store_true", help="git-over-HTTPS grant: TLS redirect route + git bootstrap wiring")
     grant.add_argument("--permission", action="append", default=[], help="grant-level permission as <name>=read|write")

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -435,6 +435,8 @@ providers:
     config:
       injection-hosts:
         - chatgpt.com
+        - api.openai.com
+        - auth.openai.com
 %[6]s      auth-file: %[7]q
       token-url: %[8]q
       client-id: test-client

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -389,6 +389,29 @@ providers:
     allow:
       repositories:
         - my-user/my-repo
+  - name: fixture-auth
+    plugin: placeholder
+    config:
+      file:
+        path: .fixture/auth.json
+        mode: "0600"
+      hosts:
+        - api.fixture.test
+        - auth.fixture.test
+      fields:
+        access_token:
+          secret-env: TEST_PLACEHOLDER_ACCESS
+          shape: plain
+        id_token:
+          secret-env: TEST_PLACEHOLDER_ID
+          shape: jwt
+          claims:
+            sub: acct-fixture-123
+            plan: pro
+        account_id: acct-fixture-123
+    allow:
+      repositories:
+        - my-user/my-repo
   - name: header-provider
     plugin: headers
     config:
@@ -455,6 +478,8 @@ func (f *brokerFixture) start() {
 		"TEST_EXTRA_HEADER=X-Api-Key: extra-secret",
 		"TEST_ALTINN_API_KEY_HEADER=X-API-Key: altinn-secret",
 		"TEST_ANTHROPIC_KEY=anthropic-secret-key",
+		"TEST_PLACEHOLDER_ACCESS=real-placeholder-access-token-secret",
+		"TEST_PLACEHOLDER_ID=real-placeholder-id-token-secret",
 	)
 	cmd.Stdout = &f.stdout
 	cmd.Stderr = &f.stderr

--- a/tests/broker/placeholder_config_validation_test.go
+++ b/tests/broker/placeholder_config_validation_test.go
@@ -1,0 +1,109 @@
+package broker_test
+
+// Config-load validation for the placeholder-file mode (review findings 2, 6,
+// 7): provider/agents config that is ambiguous or unsafe is rejected at load,
+// not silently accepted. These run the broker's own Python validators directly.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runBrokerPython(t *testing.T, script string) (string, error) {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("python3", "-c", script)
+	// Prepend the repo root so `import broker...` resolves, keeping any existing
+	// PYTHONPATH (e.g. site-packages for PyYAML).
+	cmd.Env = append(os.Environ(), "PYTHONPATH="+root+string(os.PathListSeparator)+os.Getenv("PYTHONPATH"))
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestCodexPlaceholderHostsMustSubsetInjectionHosts pins review finding 2: a
+// Codex placeholder host that is not also an injection host is rejected, so
+// refresh mediation (auth.openai.com) cannot silently drift.
+func TestCodexPlaceholderHostsMustSubsetInjectionHosts(t *testing.T) {
+	out, err := runBrokerPython(t, `
+from broker.plugins.codex_oauth.provider import CodexOAuthProvider
+try:
+    CodexOAuthProvider({"name": "codex-main", "config": {
+        "auth-file": "/tmp/codex-auth.json",
+        "injection-hosts": ["chatgpt.com"],
+        "placeholder-file": {"path": ".codex/auth.json", "hosts": ["chatgpt.com", "auth.openai.com"]},
+    }})
+except Exception as exc:
+    print("REJECTED:", type(exc).__name__, exc)
+    raise SystemExit(0)
+raise SystemExit("expected a config error")
+`)
+	if err != nil {
+		t.Fatalf("expected clean rejection, got err=%v out=%s", err, out)
+	}
+	if !strings.Contains(out, "REJECTED") || !strings.Contains(out, "injection-hosts") {
+		t.Fatalf("expected injection-hosts subset rejection, got %s", out)
+	}
+}
+
+// TestGenericPlaceholderRejectsAmbiguousSecretSpec pins review finding 6: an
+// object field that is not a well-formed secret spec (no secret-env) fails
+// closed instead of degrading into a literal object.
+func TestGenericPlaceholderRejectsAmbiguousSecretSpec(t *testing.T) {
+	out, err := runBrokerPython(t, `
+from broker.plugins.placeholder.provider import PlaceholderProvider
+try:
+    PlaceholderProvider({"name": "p", "config": {
+        "file": {"path": ".x/auth.json"},
+        "fields": {"token": {"secretenv": "TYPO"}},
+    }})
+except Exception as exc:
+    print("REJECTED:", type(exc).__name__, exc)
+    raise SystemExit(0)
+raise SystemExit("expected a config error")
+`)
+	if err != nil {
+		t.Fatalf("expected clean rejection, got err=%v out=%s", err, out)
+	}
+	if !strings.Contains(out, "REJECTED") || !strings.Contains(out, "secret-env") {
+		t.Fatalf("expected secret-env rejection, got %s", out)
+	}
+}
+
+// TestAgentsRejectsConflictingMaterialization pins review finding 7: two grants
+// for one provider with differing materializations are rejected, so grant()
+// selection is never order-dependent.
+func TestAgentsRejectsConflictingMaterialization(t *testing.T) {
+	out, err := runBrokerPython(t, `
+import tempfile
+from broker.core.agents import AgentRegistry
+config = """agents:
+  - id: a
+    token-sha256: sha256:""" + ("a" * 64) + """
+    grants:
+      - provider: codex-main
+        materialization: header-inject
+      - provider: codex-main
+        materialization: placeholder-file
+"""
+handle = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False)
+handle.write(config)
+handle.close()
+registry = AgentRegistry(handle.name)
+if registry.last_error and "conflicting materializations" in registry.last_error:
+    print("REJECTED:", registry.last_error)
+    raise SystemExit(0)
+raise SystemExit("expected rejection, last_error=%r" % registry.last_error)
+`)
+	if err != nil {
+		t.Fatalf("expected clean rejection, got err=%v out=%s", err, out)
+	}
+	if !strings.Contains(out, "REJECTED") {
+		t.Fatalf("expected conflicting-materialization rejection, got %s", out)
+	}
+}

--- a/tests/broker/placeholder_file_conformance_test.go
+++ b/tests/broker/placeholder_file_conformance_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // placeholderIdentities: an agent holding a placeholder-file grant for
@@ -149,5 +150,94 @@ func TestPlaceholderFileEgressRoleDenied(t *testing.T) {
 		map[string]any{"provider": "fixture-auth"})
 	if status == http.StatusOK || body["error"] != "role-not-allowed" {
 		t.Fatalf("egress identity must be refused on placeholder-files: status=%d body=%v", status, body)
+	}
+}
+
+// TestCodexPlaceholderFile pins the Codex preset: .codex/auth.json with
+// placeholder access/refresh tokens, a jwt id_token carrying the real
+// (non-secret) chatgpt account id + far-future exp + placeholder signature,
+// and host bindings including auth.openai.com — with no real token bytes.
+func TestCodexPlaceholderFile(t *testing.T) {
+	f := newBrokerFixtureWithCodexConfig(t, ""+
+		"      placeholder-file:\n"+
+		"        path: .codex/auth.json\n"+
+		"        hosts:\n"+
+		"          - chatgpt.com\n"+
+		"          - api.openai.com\n"+
+		"          - auth.openai.com\n"+
+		"        id-token-claims:\n"+
+		"          - claim: chatgpt_account_id\n"+
+		"            claim-path:\n"+
+		"              - https://api.openai.com/auth\n"+
+		"              - chatgpt_account_id\n")
+
+	realAccessToken := testJWTWithClaims(time.Now().Add(24*time.Hour), map[string]any{
+		"https://api.openai.com/auth": map[string]any{"chatgpt_account_id": "acct-real-123"},
+	})
+	f.writeCodexAuth(realAccessToken, "real-codex-refresh-token-secret")
+
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{{Provider: "codex-main", Materialization: "placeholder-file"}}
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/placeholder-files",
+		map[string]any{"provider": "codex-main"})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("codex placeholder-files must succeed: status=%d body=%v", status, body)
+	}
+
+	raw, _ := json.Marshal(body)
+	for _, needle := range []string{"real-codex-refresh-token-secret", realAccessToken} {
+		if strings.Contains(string(raw), needle) {
+			t.Fatalf("real Codex credential leaked into the placeholder response: %s", raw)
+		}
+	}
+
+	file := body["files"].([]any)[0].(map[string]any)
+	if file["path"] != ".codex/auth.json" || file["mode"] != "0600" {
+		t.Fatalf("unexpected file path/mode: %v", file)
+	}
+	var content map[string]any
+	if err := json.Unmarshal([]byte(file["content"].(string)), &content); err != nil {
+		t.Fatalf("auth.json is not valid JSON: %v", err)
+	}
+	tokens, ok := content["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("auth.json missing tokens object: %v", content)
+	}
+	if tokens["access_token"] != nvtPlaceholder || tokens["refresh_token"] != nvtPlaceholder {
+		t.Fatalf("access/refresh tokens must be placeholders, got %v", tokens)
+	}
+	idToken, _ := tokens["id_token"].(string)
+	segments := strings.Split(idToken, ".")
+	if len(segments) != 3 || segments[2] != "nvt-placeholder-signature" {
+		t.Fatalf("id_token must be a jwt with a placeholder signature: %q", idToken)
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		t.Fatal(err)
+	}
+	if claims["chatgpt_account_id"] != "acct-real-123" {
+		t.Fatalf("id_token must carry the real non-secret account id, got %v", claims)
+	}
+	if exp, ok := claims["exp"].(float64); !ok || exp < 2000000000 {
+		t.Fatalf("id_token exp must be far-future, got %v", claims["exp"])
+	}
+
+	hosts := body["hosts"].([]any)
+	found := false
+	for _, h := range hosts {
+		if h == "auth.openai.com" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("host bindings must include the refresh endpoint auth.openai.com, got %v", hosts)
 	}
 }

--- a/tests/broker/placeholder_file_conformance_test.go
+++ b/tests/broker/placeholder_file_conformance_test.go
@@ -132,11 +132,27 @@ func TestPlaceholderFileRequiresGrant(t *testing.T) {
 		t.Fatalf("expected provider-not-granted, got %v", body["error"])
 	}
 
-	// The placeholder-file grant must not reach secret-bearing endpoints.
-	status, body = f.postJSONWithToken("frontend-token", "/v1/files",
-		map[string]any{"provider": "fixture-auth"})
-	if status == http.StatusOK || body["error"] != "materialization-mismatch" {
-		t.Fatalf("placeholder-file grant must be rejected on /v1/files: status=%d body=%v", status, body)
+	// The placeholder-file grant must not reach ANY secret-bearing endpoint.
+	for _, endpoint := range []string{"/v1/files", "/v1/token", "/v1/headers"} {
+		status, body = f.postJSONWithToken("frontend-token", endpoint,
+			map[string]any{"provider": "fixture-auth", "target": "my-user/my-repo"})
+		if status == http.StatusOK || body["error"] != "materialization-mismatch" {
+			t.Fatalf("placeholder-file grant must be rejected on %s: status=%d body=%v", endpoint, status, body)
+		}
+	}
+}
+
+// TestGenericPlaceholderProviderNotInjectionCapable pins review finding 1: the
+// generic placeholder provider is materialization-only, so injection is
+// refused for it even though placeholder-file is an injection-eligible mode.
+func TestGenericPlaceholderProviderNotInjectionCapable(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(placeholderIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers",
+		map[string]any{"capability": "fixture-auth", "host": "api.fixture.test", "method": "GET", "path": "/x"})
+	if status == http.StatusOK || body["error"] != "injection-not-supported" {
+		t.Fatalf("generic placeholder provider must not support injection: status=%d body=%v", status, body)
 	}
 }
 
@@ -271,5 +287,34 @@ func TestPlaceholderFileGrantIsInjectionCapable(t *testing.T) {
 		map[string]any{"provider": "codex-main"})
 	if status == http.StatusOK || body["error"] != "materialization-mismatch" {
 		t.Fatalf("placeholder-file grant must stay denied on /v1/files: status=%d body=%v", status, body)
+	}
+}
+
+// TestCodexPlaceholderClaimGuard pins review finding 4: a configured
+// id-token-claim whose real value is token-shaped is refused rather than
+// copied into the placeholder file.
+func TestCodexPlaceholderClaimGuard(t *testing.T) {
+	f := newBrokerFixtureWithCodexConfig(t, ""+
+		"      placeholder-file:\n"+
+		"        path: .codex/auth.json\n"+
+		"        hosts:\n"+
+		"          - chatgpt.com\n"+
+		"        id-token-claims:\n"+
+		"          - claim: leaked\n"+
+		"            claim-path: secret_blob\n")
+
+	access := testJWTWithClaims(time.Now().Add(time.Hour), map[string]any{"secret_blob": strings.Repeat("x", 200)})
+	f.writeCodexAuth(access, "codex-refresh")
+
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{{Provider: "codex-main", Materialization: "placeholder-file"}}
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/placeholder-files",
+		map[string]any{"provider": "codex-main"})
+	if status == http.StatusOK || body["error"] != "placeholder-claim-unsafe" {
+		t.Fatalf("token-shaped id-token-claim must be refused: status=%d body=%v", status, body)
 	}
 }

--- a/tests/broker/placeholder_file_conformance_test.go
+++ b/tests/broker/placeholder_file_conformance_test.go
@@ -241,3 +241,35 @@ func TestCodexPlaceholderFile(t *testing.T) {
 		t.Fatalf("host bindings must include the refresh endpoint auth.openai.com, got %v", hosts)
 	}
 }
+
+// TestPlaceholderFileGrantIsInjectionCapable pins the load-bearing 6.1↔6.2
+// contract (review finding 1): a single placeholder-file grant both
+// materializes the placeholder file (agent side) and authorizes edge injection
+// (egress side) — so 6.2's egressd can call /v1/injection/headers for it. No
+// second header-inject grant for the same provider is needed. Secret-bearing
+// endpoints stay denied.
+func TestPlaceholderFileGrantIsInjectionCapable(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeCodexAuth(testJWT(time.Now().Add(time.Hour)), "codex-refresh-token")
+
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{{Provider: "codex-main", Materialization: "placeholder-file"}}
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	// The paired egress identity injects for the placeholder-file grant.
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers",
+		map[string]any{"capability": "codex-main", "host": "chatgpt.com", "method": "GET", "path": "/v1/responses"})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("placeholder-file grant must be injection-capable: status=%d body=%v", status, body)
+	}
+
+	// But the agent still cannot pull the real credential from any
+	// secret-bearing endpoint.
+	status, body = f.postJSONWithToken("frontend-token", "/v1/files",
+		map[string]any{"provider": "codex-main"})
+	if status == http.StatusOK || body["error"] != "materialization-mismatch" {
+		t.Fatalf("placeholder-file grant must stay denied on /v1/files: status=%d body=%v", status, body)
+	}
+}

--- a/tests/broker/placeholder_file_conformance_test.go
+++ b/tests/broker/placeholder_file_conformance_test.go
@@ -1,0 +1,153 @@
+package broker_test
+
+// Conformance for the placeholder-file materialization mode
+// (docs/phase6.1-placeholder-file-materialization-pr-plan.md, protocol/broker.md):
+// the agent fetches a syntactically valid auth file containing only inert
+// placeholders; the real secret values stay broker-side and never appear.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// placeholderIdentities: an agent holding a placeholder-file grant for
+// fixture-auth, its paired egress, plus the standard second agent.
+func placeholderIdentities() map[string]roleIdentity {
+	identities := mediatedIdentities()
+	frontend := identities["frontend"]
+	frontend.Grants = []roleGrant{
+		{Provider: "fixture-auth", Materialization: "placeholder-file", Repositories: []string{"my-user/my-repo"}},
+	}
+	identities["frontend"] = frontend
+	return identities
+}
+
+// TestPlaceholderFileMaterializesWithoutRealSecrets is the load-bearing test:
+// the vended file contains placeholders only, and none of the real broker-side
+// secret strings appear anywhere in the response.
+func TestPlaceholderFileMaterializesWithoutRealSecrets(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(placeholderIdentities())
+
+	status, body := f.postJSONWithToken("frontend-token", "/v1/placeholder-files",
+		map[string]any{"provider": "fixture-auth"})
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("placeholder-files must succeed for a granted agent: status=%d body=%v", status, body)
+	}
+
+	rawResponse, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, needle := range []string{"real-placeholder-access-token-secret", "real-placeholder-id-token-secret"} {
+		if strings.Contains(string(rawResponse), needle) {
+			t.Fatalf("real secret %q leaked into the placeholder response: %s", needle, rawResponse)
+		}
+	}
+
+	files, ok := body["files"].([]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("expected one file, got %v", body["files"])
+	}
+	file := files[0].(map[string]any)
+	if file["path"] != ".fixture/auth.json" || file["mode"] != "0600" {
+		t.Fatalf("unexpected file path/mode: %v", file)
+	}
+	var content map[string]any
+	if err := json.Unmarshal([]byte(file["content"].(string)), &content); err != nil {
+		t.Fatalf("placeholder file content is not valid JSON: %v", err)
+	}
+	if content["access_token"] != nvtPlaceholder {
+		t.Fatalf("access_token must be the zero-entropy placeholder, got %v", content["access_token"])
+	}
+	if content["account_id"] != "acct-fixture-123" {
+		t.Fatalf("non-secret literal must be emitted verbatim, got %v", content["account_id"])
+	}
+
+	// Host bindings are returned for 6.2's route/injection map.
+	hosts, ok := body["hosts"].([]any)
+	if !ok || len(hosts) != 2 || hosts[0] != "api.fixture.test" {
+		t.Fatalf("unexpected host bindings: %v", body["hosts"])
+	}
+}
+
+// TestPlaceholderFileJWTShape pins the jwt placeholder shape: a valid JWT with
+// real non-secret claims and a far-future exp, and a placeholder signature.
+func TestPlaceholderFileJWTShape(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(placeholderIdentities())
+
+	_, body := f.postJSONWithToken("frontend-token", "/v1/placeholder-files",
+		map[string]any{"provider": "fixture-auth"})
+	file := body["files"].([]any)[0].(map[string]any)
+	var content map[string]any
+	if err := json.Unmarshal([]byte(file["content"].(string)), &content); err != nil {
+		t.Fatal(err)
+	}
+	idToken, ok := content["id_token"].(string)
+	if !ok {
+		t.Fatalf("id_token missing: %v", content)
+	}
+	segments := strings.Split(idToken, ".")
+	if len(segments) != 3 {
+		t.Fatalf("id_token is not a three-segment JWT: %q", idToken)
+	}
+	if segments[2] != "nvt-placeholder-signature" {
+		t.Fatalf("id_token signature must be the placeholder, got %q", segments[2])
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		t.Fatalf("id_token payload not base64url: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		t.Fatalf("id_token payload not JSON: %v", err)
+	}
+	if claims["sub"] != "acct-fixture-123" || claims["plan"] != "pro" {
+		t.Fatalf("id_token must carry the non-secret identity claims, got %v", claims)
+	}
+	exp, ok := claims["exp"].(float64)
+	if !ok || exp < 2000000000 { // ~2033; well beyond any session
+		t.Fatalf("id_token exp must be far-future, got %v", claims["exp"])
+	}
+}
+
+// TestPlaceholderFileRequiresGrant pins scoping: an agent without the grant is
+// denied, and the placeholder-file grant is denied on secret-bearing endpoints.
+func TestPlaceholderFileRequiresGrant(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(placeholderIdentities())
+
+	// backend holds no grant for fixture-auth.
+	status, body := f.postJSONWithToken("backend-token", "/v1/placeholder-files",
+		map[string]any{"provider": "fixture-auth"})
+	if status == http.StatusOK || body["ok"] == true {
+		t.Fatalf("ungranted agent must be denied: status=%d body=%v", status, body)
+	}
+	if body["error"] != "provider-not-granted" {
+		t.Fatalf("expected provider-not-granted, got %v", body["error"])
+	}
+
+	// The placeholder-file grant must not reach secret-bearing endpoints.
+	status, body = f.postJSONWithToken("frontend-token", "/v1/files",
+		map[string]any{"provider": "fixture-auth"})
+	if status == http.StatusOK || body["error"] != "materialization-mismatch" {
+		t.Fatalf("placeholder-file grant must be rejected on /v1/files: status=%d body=%v", status, body)
+	}
+}
+
+// TestPlaceholderFileEgressRoleDenied pins that the agent (not egress) is the
+// caller: an egress identity is refused (the file is inert, agent-owned).
+func TestPlaceholderFileEgressRoleDenied(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(placeholderIdentities())
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/placeholder-files",
+		map[string]any{"provider": "fixture-auth"})
+	if status == http.StatusOK || body["error"] != "role-not-allowed" {
+		t.Fatalf("egress identity must be refused on placeholder-files: status=%d body=%v", status, body)
+	}
+}

--- a/tests/runtime/placeholder_file_test.go
+++ b/tests/runtime/placeholder_file_test.go
@@ -1,0 +1,113 @@
+package runtime_test
+
+// Runtime materialization of the placeholder-file mode
+// (docs/phase6.1-placeholder-file-materialization-pr-plan.md work item 3):
+// bootstrap writes the broker's placeholder auth file verbatim (placeholders
+// only) and never reads a host auth file as the source of truth.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newFakePlaceholderBroker(t *testing.T, body map[string]any) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "status": "ready"})
+	})
+	mux.HandleFunc("/v1/placeholder-files", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer broker-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if payload["provider"] != "codex-main" {
+			http.Error(w, "provider", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestBootstrapMaterializesPlaceholderFile pins that bootstrap writes the
+// broker's placeholder auth file (path/mode/content) and that a stray host
+// auth file carrying a real token is overwritten — never read as the source.
+func TestBootstrapMaterializesPlaceholderFile(t *testing.T) {
+	f := newFixture(t)
+	f.installBrokerctl()
+
+	realSecret := "real-provider-access-token-secret-xyz"
+	placeholderContent := "{\n" +
+		"  \"tokens\": {\n" +
+		"    \"access_token\": \"NVT-PLACEHOLDER-NOT-A-KEY\",\n" +
+		"    \"refresh_token\": \"NVT-PLACEHOLDER-NOT-A-KEY\",\n" +
+		"    \"id_token\": \"eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhY2N0LTEyMyJ9.nvt-placeholder-signature\"\n" +
+		"  }\n" +
+		"}\n"
+	broker := newFakePlaceholderBroker(t, map[string]any{
+		"ok": true,
+		"files": []any{map[string]any{
+			"path":    ".codex/auth.json",
+			"mode":    "0600",
+			"content": placeholderContent,
+		}},
+		"hosts":      []any{"chatgpt.com", "auth.openai.com"},
+		"expires_at": nil,
+	})
+
+	// A stray host auth file with a real token: bootstrap must overwrite it.
+	mustWriteFile(t, filepath.Join(f.home, ".codex", "auth.json"),
+		`{"tokens":{"access_token":"`+realSecret+`"}}`)
+
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  grants:
+    - provider: codex-main
+      materialization: placeholder-file
+runtime:
+  command: codex
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+
+	output := f.runWithEnv(bootstrapBin(f.root), true, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_BROKER_URL=" + broker.URL,
+		"NVT_BROKER_TOKEN=broker-token",
+	}, config)
+
+	authPath := filepath.Join(f.home, ".codex", "auth.json")
+	content := mustReadFile(t, authPath)
+	if !strings.Contains(content, mediatedPlaceholder) {
+		t.Fatalf("placeholder auth file missing the placeholder:\n%s", content)
+	}
+	if strings.Contains(content, realSecret) {
+		t.Fatalf("stray host real token survived materialization:\n%s", content)
+	}
+	assertFileMode(t, authPath, 0o600)
+
+	// The real token appears nowhere in the tree or bootstrap output.
+	scanTreeForSecretMaterial(t, f.home, []string{realSecret})
+	scanTextForSecretMaterial(t, "bootstrap output", output, []string{realSecret})
+}

--- a/tests/runtime/placeholder_file_test.go
+++ b/tests/runtime/placeholder_file_test.go
@@ -111,3 +111,59 @@ code-server:
 	scanTreeForSecretMaterial(t, f.home, []string{realSecret})
 	scanTextForSecretMaterial(t, "bootstrap output", output, []string{realSecret})
 }
+
+// TestBootstrapPlaceholderFileRefusesSymlinkEscape pins review finding 8: even
+// with a traversal-free relative path, a symlinked parent that resolves outside
+// HOME is refused rather than written through.
+func TestBootstrapPlaceholderFileRefusesSymlinkEscape(t *testing.T) {
+	f := newFixture(t)
+	f.installBrokerctl()
+
+	// .codex is a symlink to a directory outside HOME.
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(f.home, ".codex")); err != nil {
+		t.Fatal(err)
+	}
+
+	broker := newFakePlaceholderBroker(t, map[string]any{
+		"ok": true,
+		"files": []any{map[string]any{
+			"path":    ".codex/auth.json",
+			"mode":    "0600",
+			"content": "{\"tokens\":{}}\n",
+		}},
+		"hosts":      []any{"chatgpt.com"},
+		"expires_at": nil,
+	})
+
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  grants:
+    - provider: codex-main
+      materialization: placeholder-file
+runtime:
+  command: codex
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_BROKER_URL=" + broker.URL,
+		"NVT_BROKER_TOKEN=broker-token",
+	}, config)
+
+	if !strings.Contains(output, "resolves outside HOME") {
+		t.Fatalf("expected symlink-escape refusal, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "auth.json")); err == nil {
+		t.Fatalf("bootstrap wrote through the escaping symlink")
+	}
+}


### PR DESCRIPTION
## PR 6.1: Generic placeholder-file materialization

Implements `docs/phase6.1-placeholder-file-materialization-pr-plan.md` — the broker/provider/runtime half of Phase 6. A **placeholder file** is a syntactically valid auth/config file that carries only inert placeholders, so a file-based tool (Codex's `~/.codex/auth.json`, any JSON auth file) starts against a file it accepts while the real credential stays in broker/provider custody. This moves such tools off the `file-bundle` fallback (usable credentials written into the container — the thing the zero-secrets invariant exists to eliminate) toward true non-possession.

`placeholder-file` is a **distinct mode from `file-bundle`**: separate endpoint, separate provider method, separate admission, separate tests. No path in this mode writes usable credentials.

**Honest dependency:** a placeholder file is inert on its own — the real tool win only lands once 6.2's edge injection swaps the placeholder for the real credential. This PR ships the contract and its tests, provable end-to-end at the fixture level with fake Codex-shaped fixtures and no real secrets.

### What's in it

- **Broker — generic contract** (`POST /v1/placeholder-files`, agent-role, requires a `placeholder-file` grant). A generic `placeholder` provider is config-driven: literal non-secret fields emitted verbatim; secret fields sourced from the environment (held broker-side, **never emitted**) and rendered as a placeholder in one of two shapes — `plain` (the zero-entropy `NVT-PLACEHOLDER-NOT-A-KEY`) or `jwt` (a valid JWT carrying only non-secret claims + a far-future `exp` + a placeholder signature, for tools that parse local token claims before any network call). Response carries `hosts` bindings for 6.2's route/injection map. The mode is denied on every secret-bearing endpoint (`/v1/token`, `/v1/headers`, `/v1/files`).
- **Codex preset** — `codex_oauth` gains a `placeholder-file` config block emitting `.codex/auth.json` with placeholder access/refresh tokens and a `jwt` id_token carrying the real non-secret chatgpt account id + far-future exp + placeholder signature, plus host bindings including the refresh endpoint `auth.openai.com`. Reads current state without triggering a refresh.
- **Runtime** — `bootstrap` materializes placeholder files (path/mode/content) atomically under the agent home, re-validating the path against traversal, independent of egress mode. Never reads a host auth file as the source of truth: a stray host `.codex/auth.json` is overwritten with the broker's placeholders. `brokerctl` gains a `placeholder-files` subcommand.
- **Docs** — `protocol/broker.md` (the endpoint), `protocol/injection.md` (the mode + gating).

### Tests

- Broker conformance: real broker-side secrets never appear in the response; the `jwt` shape carries the expected non-secret claims + far-future exp + placeholder signature; grant scoping (ungranted agent denied, mode denied on `/v1/files`, egress role refused); the Codex preset emits the expected `.codex/auth.json` with no real token bytes.
- Runtime: bootstrap writes the placeholder file with the right path/mode, and a pre-existing host auth file with a real token does not survive materialization (secret scan clean).

All broker/runtime/operator/egressd suites green.

### Out of scope (→ PR 6.2)

egressd CA-leaf-widening, CONNECT-MITM, `HTTPS_PROXY`/`NO_PROXY`, the real Codex end-to-end proof (needs 6.2's edge injection), and body/query placeholder substitution.
