### PR TITLE
Production readiness: broker config rollout checksum + real-Codex proof harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.pyc
 .phase2-out/
 .phase2b-out/
+.phase6-out/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OPERATOR_KIND_EXTRA_IMAGE_TARGETS := gateway-kind-load
 OPERATOR_KIND_GATEWAY_HELM_ARGS := --set gateway.enabled=true --set gateway.image=$(GATEWAY_IMAGE)
 endif
 
-.PHONY: runtime-build broker-build egressd-build echo-build echo-kind-load phase2-codex-gate phase2b-codex-forward-proxy operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-cluster-enforced operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
+.PHONY: runtime-build broker-build egressd-build echo-build echo-kind-load phase2-codex-gate phase2b-codex-forward-proxy operator-build producer-build gateway-build operator-helm-test operator-kind-cluster operator-kind-cluster-enforced operator-kind-images operator-kind-install operator-kind-setup operator-kind-delete operator-kind-smoke operator-kind-smoke-render gateway-kind-load producer-kind-load producer-kind-install producer-kind-setup operator-codex-auth-secret phase6-real-codex-proof github-comments-producer-secret broker-env-secret operator-smoke-schedule infra-up infra-down infra-network-rm agent-init agent-copy agent-cp agent-grant agent-up agent-logs agent-shell agent-doctor agent-ps agent-forward forward agent-down agent-down-all agent-rm agent-rm-all plugin-init down-all clean nuke
 
 runtime-build:
 	bash scripts/runtime-build.sh $(if $(NO_CACHE),--no-cache)
@@ -152,6 +152,11 @@ producer-kind-setup: producer-kind-load producer-kind-install
 
 operator-codex-auth-secret:
 	CODEX_AUTH_SOURCE="$(CODEX_AUTH_SOURCE)" CODEX_AUTH_SECRET="$(CODEX_AUTH_SECRET)" SOURCE="$(SOURCE)" SECRET="$(SECRET)" NAMESPACE="$(NAMESPACE)" CLUSTER="$(CLUSTER)" KUBECTL_CONTEXT="$(KUBECTL_CONTEXT)" bash scripts/operator-codex-auth-secret.sh
+
+# Manual, opt-in real-Codex forward-proxy proof (docs/real-codex-forward-proxy-proof.md).
+# NOT run in CI: needs real host Codex auth. Writes evidence to .phase6-out/.
+phase6-real-codex-proof:
+	CODEX_AUTH_SOURCE="$(CODEX_AUTH_SOURCE)" CODEX_AUTH_SECRET="$(CODEX_AUTH_SECRET)" NAMESPACE="$(NAMESPACE)" CLUSTER="$(CLUSTER)" KUBECTL_CONTEXT="$(KUBECTL_CONTEXT)" ROLLOUT_TIMEOUT="$(ROLLOUT_TIMEOUT)" bash scripts/phase6-real-codex-proof.sh
 
 github-comments-producer-secret:
 	GITHUB_APP_PRIVATE_KEY_FILE="$(GITHUB_APP_PRIVATE_KEY_FILE)" PRODUCER_GITHUB_APP_SECRET="$(PRODUCER_GITHUB_APP_SECRET)" PRODUCER_GITHUB_APP_KEY="$(PRODUCER_GITHUB_APP_KEY)" NAMESPACE="$(NAMESPACE)" CLUSTER="$(CLUSTER)" KUBECTL_CONTEXT="$(KUBECTL_CONTEXT)" bash scripts/github-comments-producer-secret.sh

--- a/charts/nvt/templates/_helpers.tpl
+++ b/charts/nvt/templates/_helpers.tpl
@@ -117,6 +117,17 @@ app.kubernetes.io/component: gateway
   an existingSecret between upgrades still needs a manual
   `kubectl rollout restart deployment/nvt-broker`.
 */ -}}
+{{/*
+nvt.brokerConfigChecksum hashes the broker provider config (broker.yaml). The
+broker loads providers once at startup and does NOT hot-reload them (unlike the
+agents ConfigMap, which reloads by mtime), so a Helm upgrade that changes
+broker.config must roll the Deployment or the running broker keeps the old
+providers — the exact false failure hit in the real Codex proof.
+*/ -}}
+{{- define "nvt.brokerConfigChecksum" -}}
+{{- .Values.broker.config | toYaml | sha256sum -}}
+{{- end -}}
+
 {{- define "nvt.brokerTLSChecksum" -}}
 {{- if .Values.broker.tls.existingSecret -}}
 {{- $existing := lookup "v1" "Secret" (include "nvt.namespace" .) .Values.broker.tls.existingSecret -}}

--- a/charts/nvt/templates/broker-deployment.yaml
+++ b/charts/nvt/templates/broker-deployment.yaml
@@ -19,12 +19,15 @@ spec:
       {{- include "nvt.brokerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- if .Values.broker.tls.enabled }}
       annotations:
+        # The broker loads its provider config once at startup and does not
+        # hot-reload it, so a broker.config change must roll the Deployment.
+        checksum/broker-config: {{ include "nvt.brokerConfigChecksum" . | quote }}
+        {{- if .Values.broker.tls.enabled }}
         # The broker loads its TLS cert/key once at startup; this checksum
         # restarts it when the TLS Secret material (or name) changes.
         checksum/broker-tls: {{ include "nvt.brokerTLSChecksum" . | quote }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "nvt.brokerSelectorLabels" . | nindent 8 }}
     spec:

--- a/docs/real-codex-forward-proxy-proof.md
+++ b/docs/real-codex-forward-proxy-proof.md
@@ -143,6 +143,14 @@ Acceptance:
 - Helm upgrade that changes `broker.config.providers` rolls `deployment/nvt-broker`.
 - A test or helm render assertion pins the checksum annotation.
 
+**Fixed (PR A landed):** the broker Deployment now carries a
+`checksum/broker-config` pod annotation (`nvt.brokerConfigChecksum`) that hashes
+`broker.config`, so a Helm upgrade changing `broker.config.providers` rolls
+`deployment/nvt-broker`. The `nvt-broker-agents` ConfigMap is **not** checksummed
+on purpose — the broker hot-reloads it by mtime (revocation depends on that), so
+a restart there would be counterproductive. A helm-render assertion pins that the
+annotation is present and changes when `broker.config.providers` changes.
+
 ### 2. Codex WebSocket Path Failed, HTTPS Fallback Worked
 
 Codex stderr showed repeated WebSocket failures:
@@ -201,7 +209,7 @@ Acceptance:
 
 ## Recommended PRs
 
-### PR A: Broker Config Rollout Checksum
+### PR A: Broker Config Rollout Checksum — LANDED
 
 Scope:
 
@@ -214,7 +222,10 @@ Why first:
 - This caused a real false failure during the proof.
 - It is small and production-relevant beyond Codex.
 
-### PR B: Manual Real Codex Proof Harness
+Landed as the `checksum/broker-config` pod annotation on the broker Deployment,
+pinned by `tests/operator/helm/test.sh`.
+
+### PR B: Manual Real Codex Proof Harness — LANDED
 
 Scope:
 
@@ -222,11 +233,17 @@ Scope:
 - Do not run in CI by default.
 - Should write evidence under an ignored output directory, for example `.phase6-out/real-codex-proof/`.
 
-Suggested target:
+Target (landed):
 
 ```sh
-make phase6-real-codex-proof
+make phase6-real-codex-proof            # uses ~/.codex
+CODEX_AUTH_SOURCE=/path/to/.codex make phase6-real-codex-proof
 ```
+
+Implemented in `scripts/phase6-real-codex-proof.sh`; writes evidence and a
+summary (normal turn / WebSocket / refresh / secret-scan) under
+`.phase6-out/real-codex-proof/` (git-ignored). Refresh is not forced yet (PR D)
+and the WebSocket path is recorded as fallback-only (PR C).
 
 Suggested behavior:
 

--- a/scripts/phase6-real-codex-proof.sh
+++ b/scripts/phase6-real-codex-proof.sh
@@ -22,7 +22,9 @@ KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${CLUSTER}}"
 CODEX_AUTH_SOURCE="${CODEX_AUTH_SOURCE:-${HOME}/.codex}"
 CODEX_AUTH_SECRET="${CODEX_AUTH_SECRET:-codex-auth}"
 ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-300s}"
-RUN_NAME="${RUN_NAME:-real-codex-proof}"
+# Unique per invocation so a rerun always creates a fresh AgentRun/pod (an
+# apply over the previous run's still-sleeping pod would not start a new turn).
+RUN_NAME="${RUN_NAME:-real-codex-proof-$(date +%s)}"
 OUTPUT_DIR="${OUTPUT_DIR:-${ROOT}/.phase6-out/real-codex-proof}"
 # A fixed-per-run nonce the model must echo back; passed in so the script stays
 # reproducible (no Date/Random at import time in the harness values file).
@@ -132,6 +134,14 @@ doc = {"apiVersion": "nvt.dev/v1alpha1", "kind": "AgentRun",
 print(json.dumps(doc))
 PY
 log "submitting forward-proxy placeholder-file AgentRun ${RUN_NAME}"
+# Defensive even with a unique name: if an explicit RUN_NAME is reused, delete
+# the prior AgentRun and wait for its agent pod to clear so the new run is not
+# racing a stale, still-sleeping pod.
+if "${KUBECTL[@]}" -n "${NAMESPACE}" get agentrun "${RUN_NAME}" >/dev/null 2>&1; then
+  log "deleting pre-existing AgentRun ${RUN_NAME}"
+  "${KUBECTL[@]}" -n "${NAMESPACE}" delete agentrun "${RUN_NAME}" --wait=true --timeout="${ROLLOUT_TIMEOUT}" || true
+  "${KUBECTL[@]}" -n "${NAMESPACE}" wait --for=delete "pod/${RUN_NAME}-agent" --timeout="${ROLLOUT_TIMEOUT}" 2>/dev/null || true
+fi
 "${KUBECTL[@]}" apply -f "${RUN_YAML}"
 
 # 6: wait for the agent Pod and the codex turn to finish.
@@ -163,9 +173,20 @@ collect proxy-env bash -lc 'env | grep -Ei "PROXY" | sort'
 "${KUBECTL[@]}" -n "${NAMESPACE}" cp "${RUN_NAME}-agent:/root/.codex" "${OUTPUT_DIR}/agent-codex" -c agent 2>/dev/null || true
 
 # 8: secret scan — the real host access/refresh tokens must not appear.
-log "scanning copied agent files for host Codex token material"
+log "scanning copied agent files and collected evidence for host Codex token material"
 SCAN_RESULT="clean"
-python3 - "${CODEX_AUTH_SOURCE}/auth.json" "${OUTPUT_DIR}/agent-codex" "${OUTPUT_DIR}/agent-auth.json" >"${OUTPUT_DIR}/secret-scan.txt" 2>&1 <<'PY' || SCAN_RESULT="FAIL"
+# Scan the copied agent Codex dir plus every collected evidence file (codex
+# stdout/stderr, proxy env, egressd + broker logs) for the real host tokens.
+python3 - "${CODEX_AUTH_SOURCE}/auth.json" \
+  "${OUTPUT_DIR}/agent-codex" \
+  "${OUTPUT_DIR}/agent-auth.json" \
+  "${OUTPUT_DIR}/codex.stdout" \
+  "${OUTPUT_DIR}/codex.stderr" \
+  "${OUTPUT_DIR}/last-message" \
+  "${OUTPUT_DIR}/proxy-env" \
+  "${OUTPUT_DIR}/egressd.log" \
+  "${OUTPUT_DIR}/broker.log" \
+  >"${OUTPUT_DIR}/secret-scan.txt" 2>&1 <<'PY' || SCAN_RESULT="FAIL"
 import json
 import os
 import sys

--- a/scripts/phase6-real-codex-proof.sh
+++ b/scripts/phase6-real-codex-proof.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Manual, opt-in real-Codex forward-proxy proof
+# (docs/real-codex-forward-proxy-proof.md). NOT run in CI: it needs real host
+# Codex auth. It stands up a Calico kind cluster, seeds the broker with the
+# host Codex credential, runs `codex exec` inside a mediated + enforced +
+# forward-proxy AgentRun whose codex-main grant is materialization
+# placeholder-file, and records evidence under an ignored output directory.
+#
+# Usage:
+#   make phase6-real-codex-proof            # uses ~/.codex
+#   CODEX_AUTH_SOURCE=/path/to/.codex make phase6-real-codex-proof
+#
+# Requires: kind, kubectl, helm, docker, and a working host Codex login.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+CLUSTER="${CLUSTER:-nvt-codex-proof}"
+NAMESPACE="${NAMESPACE:-nvt}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${CLUSTER}}"
+CODEX_AUTH_SOURCE="${CODEX_AUTH_SOURCE:-${HOME}/.codex}"
+CODEX_AUTH_SECRET="${CODEX_AUTH_SECRET:-codex-auth}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-300s}"
+RUN_NAME="${RUN_NAME:-real-codex-proof}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT}/.phase6-out/real-codex-proof}"
+# A fixed-per-run nonce the model must echo back; passed in so the script stays
+# reproducible (no Date/Random at import time in the harness values file).
+PROOF_NONCE="${PROOF_NONCE:-NVT_CODEX_PROOF_$(date +%s)}"
+
+KUBECTL=(kubectl --context "${KUBECTL_CONTEXT}")
+
+log() { printf '[phase6-real-codex-proof] %s\n' "$*"; }
+die() { printf '[phase6-real-codex-proof] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ -d "${CODEX_AUTH_SOURCE}" ]] || die "CODEX_AUTH_SOURCE must be an existing Codex auth dir: ${CODEX_AUTH_SOURCE}"
+[[ -f "${CODEX_AUTH_SOURCE}/auth.json" ]] || die "missing ${CODEX_AUTH_SOURCE}/auth.json — log into Codex first"
+
+mkdir -p "${OUTPUT_DIR}"
+SUMMARY="${OUTPUT_DIR}/summary.txt"
+: >"${SUMMARY}"
+
+# 1 + 2: Calico cluster + namespace + images.
+log "creating Calico kind cluster ${CLUSTER} and loading images"
+make -C "${ROOT}" CLUSTER="${CLUSTER}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" operator-kind-cluster-enforced
+make -C "${ROOT}" CLUSTER="${CLUSTER}" operator-kind-images
+"${KUBECTL[@]}" create namespace "${NAMESPACE}" --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -
+
+# 3: filtered codex-auth Secret from the host (never printed).
+log "seeding Secret ${NAMESPACE}/${CODEX_AUTH_SECRET} from ${CODEX_AUTH_SOURCE}"
+CODEX_AUTH_SOURCE="${CODEX_AUTH_SOURCE}" CODEX_AUTH_SECRET="${CODEX_AUTH_SECRET}" \
+  NAMESPACE="${NAMESPACE}" CLUSTER="${CLUSTER}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" \
+  bash "${ROOT}/scripts/operator-codex-auth-secret.sh"
+
+# 4: install nvt with broker persistence + codex-main provider config.
+VALUES="${OUTPUT_DIR}/values.yaml"
+cat >"${VALUES}" <<YAML
+broker:
+  persistence:
+    enabled: true
+    seedSecretName: ${CODEX_AUTH_SECRET}
+    seedTargetDir: codex
+  config:
+    providers:
+      - name: codex-main
+        plugin: codex-oauth
+        config:
+          auth-file: /state/codex/auth.json
+          injection-hosts:
+            - chatgpt.com
+            - api.openai.com
+            - auth.openai.com
+          placeholder-file:
+            path: .codex/auth.json
+            hosts:
+              - chatgpt.com
+              - api.openai.com
+              - auth.openai.com
+            id-token-claims:
+              - claim: chatgpt_account_id
+                claim-path:
+                  - https://api.openai.com/auth
+                  - chatgpt_account_id
+          injection-claim-headers:
+            - header: ChatGPT-Account-ID
+              claim-path:
+                - https://api.openai.com/auth
+                - chatgpt_account_id
+        allow:
+          repositories:
+            - example/*
+egress:
+  allowInsecureUpstreams: false
+YAML
+log "installing chart with broker persistence + codex-main provider"
+make -C "${ROOT}" CLUSTER="${CLUSTER}" NAMESPACE="${NAMESPACE}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" \
+  ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT}" OPERATOR_KIND_HELM_ARGS="-f ${VALUES}" operator-kind-setup
+
+# 5: submit a forward-proxy placeholder-file AgentRun that runs codex exec.
+RUN_YAML="${OUTPUT_DIR}/agentrun.yaml"
+python3 - "${RUN_NAME}" "${NAMESPACE}" "${PROOF_NONCE}" >"${RUN_YAML}" <<'PY'
+import json
+import sys
+
+run_name, namespace, nonce = sys.argv[1], sys.argv[2], sys.argv[3]
+prompt = f"Reply with exactly this token and nothing else: {nonce}"
+spec = {
+    "runtime": {"type": "codex", "autonomy": "trusted-local"},
+    "image": "nvt-agent-runtime:latest",
+    "egress": "mediated",
+    "egressEnforcement": True,
+    "egressForwardProxy": True,
+    "workspace": {"mode": "Ephemeral"},
+    "broker": {"grants": [{
+        "provider": "codex-main",
+        "repositories": ["example/repo"],
+        "materialization": "placeholder-file",
+        "egressHosts": ["chatgpt.com:443", "api.openai.com:443", "auth.openai.com:443"],
+    }]},
+    "agent": {"config": {
+        "runtime": {"command": "bash", "args": ["-lc",
+            f'codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check '
+            f'--output-last-message /tmp/last-message {json.dumps(prompt)} '
+            f'>/tmp/codex.stdout 2>/tmp/codex.stderr; echo done; sleep infinity']},
+        "tools": {"packages": [], "mise": [], "additional-paths": [], "shell": []},
+        "code-server": {"extensions": []},
+    }},
+    "ttl": {"activeDeadlineSeconds": 1800},
+}
+doc = {"apiVersion": "nvt.dev/v1alpha1", "kind": "AgentRun",
+       "metadata": {"name": run_name, "namespace": namespace}, "spec": spec}
+print(json.dumps(doc))
+PY
+log "submitting forward-proxy placeholder-file AgentRun ${RUN_NAME}"
+"${KUBECTL[@]}" apply -f "${RUN_YAML}"
+
+# 6: wait for the agent Pod and the codex turn to finish.
+log "waiting for agent Pod ${RUN_NAME}-agent"
+"${KUBECTL[@]}" -n "${NAMESPACE}" wait --for=condition=Ready "pod/${RUN_NAME}-agent" --timeout="${ROLLOUT_TIMEOUT}" || true
+log "waiting for codex exec to complete (up to 10m)"
+deadline=$(( $(date +%s) + 600 ))
+while (( $(date +%s) < deadline )); do
+  if "${KUBECTL[@]}" -n "${NAMESPACE}" exec "${RUN_NAME}-agent" -c agent -- test -f /tmp/last-message 2>/dev/null; then
+    break
+  fi
+  sleep 5
+done
+
+# 7: collect evidence.
+collect() {
+  local label="$1"; shift
+  "${KUBECTL[@]}" -n "${NAMESPACE}" exec "${RUN_NAME}-agent" -c agent -- "$@" >"${OUTPUT_DIR}/${label}" 2>/dev/null || true
+}
+log "collecting evidence into ${OUTPUT_DIR}"
+collect codex.stdout cat /tmp/codex.stdout
+collect codex.stderr cat /tmp/codex.stderr
+collect last-message cat /tmp/last-message
+collect agent-auth.json cat "/root/.codex/auth.json"
+collect proxy-env bash -lc 'env | grep -Ei "PROXY" | sort'
+"${KUBECTL[@]}" -n "${NAMESPACE}" logs "${RUN_NAME}-egressd" >"${OUTPUT_DIR}/egressd.log" 2>/dev/null || true
+"${KUBECTL[@]}" -n "${NAMESPACE}" logs deployment/nvt-broker >"${OUTPUT_DIR}/broker.log" 2>/dev/null || true
+# Copy the agent home Codex/proof files for an offline secret scan.
+"${KUBECTL[@]}" -n "${NAMESPACE}" cp "${RUN_NAME}-agent:/root/.codex" "${OUTPUT_DIR}/agent-codex" -c agent 2>/dev/null || true
+
+# 8: secret scan — the real host access/refresh tokens must not appear.
+log "scanning copied agent files for host Codex token material"
+SCAN_RESULT="clean"
+python3 - "${CODEX_AUTH_SOURCE}/auth.json" "${OUTPUT_DIR}/agent-codex" "${OUTPUT_DIR}/agent-auth.json" >"${OUTPUT_DIR}/secret-scan.txt" 2>&1 <<'PY' || SCAN_RESULT="FAIL"
+import json
+import os
+import sys
+
+auth_path, *scan_targets = sys.argv[1:]
+with open(auth_path, "r", encoding="utf-8") as handle:
+    tokens = json.load(handle).get("tokens", {})
+needles = [v for k, v in tokens.items() if isinstance(v, str) and v and k in ("access_token", "refresh_token", "id_token")]
+placeholder = "NVT-PLACEHOLDER-NOT-A-KEY"
+needles = [n for n in needles if n and n != placeholder]
+
+hits = []
+scanned = 0
+for target in scan_targets:
+    if os.path.isfile(target):
+        files = [target]
+    else:
+        files = [os.path.join(dp, f) for dp, _, fs in os.walk(target) for f in fs]
+    for path in files:
+        scanned += 1
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+                text = handle.read()
+        except OSError:
+            continue
+        for needle in needles:
+            if needle in text:
+                hits.append(os.path.basename(path))
+print("secret_hits", sorted(set(hits)))
+print("files_scanned", scanned)
+if hits:
+    raise SystemExit(1)
+PY
+
+# 9: emit the summary.
+last_message="$(cat "${OUTPUT_DIR}/last-message" 2>/dev/null || true)"
+normal_turn="FAIL"
+[[ "${last_message}" == *"${PROOF_NONCE}"* ]] && normal_turn="PASS"
+websocket="unproven"
+grep -qi "Falling back from WebSockets" "${OUTPUT_DIR}/codex.stderr" 2>/dev/null && websocket="fallback-to-https (WSS unproven)"
+{
+  echo "nonce:          ${PROOF_NONCE}"
+  echo "normal_turn:    ${normal_turn}"
+  echo "websocket:      ${websocket}"
+  echo "refresh:        unproven (not forced this run)"
+  echo "secret_scan:    ${SCAN_RESULT}"
+  echo "evidence_dir:   ${OUTPUT_DIR}"
+} | tee "${SUMMARY}"
+
+[[ "${normal_turn}" == "PASS" && "${SCAN_RESULT}" == "clean" ]] || die "proof did not pass — see ${OUTPUT_DIR}"
+log "real Codex forward-proxy proof PASSED (normal HTTPS turn; WebSocket/refresh remain unproven)"

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -500,6 +500,23 @@ grep -q 'value: "https://nvt-broker:7347"' "${DEFAULT_RENDER}"
 grep -q 'name: NVT_BROKER_CA_SECRET' "${DEFAULT_RENDER}"
 grep -q 'checksum/broker-tls: ' "${DEFAULT_RENDER}"
 
+# checksum/broker-config rolls the broker Deployment when broker.config changes.
+# The broker loads providers once at startup and does not hot-reload them, so a
+# provider change that did not roll the Deployment would leave the old config
+# running (the real Codex proof false failure).
+grep -q 'checksum/broker-config: ' "${DEFAULT_RENDER}"
+broker_config_checksum() {
+  grep 'checksum/broker-config: ' "$1" | head -1 | awk '{print $2}' | tr -d '"'
+}
+BROKER_CONFIG_CHANGED_RENDER="${WORKDIR}/broker-config-changed.yaml"
+helm template nvt "${CHART}" -n custom-ns \
+  --set 'broker.config.providers[0].name=changed-provider' \
+  --set 'broker.config.providers[0].plugin=token' > "${BROKER_CONFIG_CHANGED_RENDER}"
+if [[ "$(broker_config_checksum "${DEFAULT_RENDER}")" == "$(broker_config_checksum "${BROKER_CONFIG_CHANGED_RENDER}")" ]]; then
+  echo "checksum/broker-config must change when broker.config.providers changes" >&2
+  exit 1
+fi
+
 # Revocation depends on the broker hot-reloading the agents ConfigMap on
 # mtime change. A subPath mount freezes the projected file forever and would
 # silently kill revocation, so the broker config volume must never be


### PR DESCRIPTION
## Production readiness fixes (post real-Codex proof)

Addresses the two straightforward, low-risk items surfaced by the manual real-Codex forward-proxy proof (`docs/real-codex-forward-proxy-proof.md`). WebSocket (PR C) and refresh (PR D) are intentionally **not** in this PR.

### 1. Broker Deployment rolls on `broker.config` change

The broker loads its provider config once at startup and does **not** hot-reload it, so a Helm upgrade that changed `broker.config.providers` left the old providers running — the exact false failure in the proof (`injection-claim-missing` until a manual `kubectl rollout restart`).

- New `checksum/broker-config` pod annotation on the broker Deployment (`nvt.brokerConfigChecksum`, hashing `broker.config`) so the Deployment rolls when providers change.
- The `nvt-broker-agents` ConfigMap is deliberately **not** checksummed — the broker hot-reloads it by mtime and revocation depends on that; a restart there would be counterproductive.
- Existing `checksum/broker-tls` behavior preserved (now emitted alongside, still gated on `broker.tls.enabled`).
- `tests/operator/helm/test.sh` pins that the annotation is present and **changes** when `broker.config.providers` changes.

### 2. Manual real-Codex proof harness

`make phase6-real-codex-proof` — opt-in, **not run in CI** (needs real host Codex auth). It stands up a Calico kind cluster, seeds the broker with the host Codex credential, runs `codex exec` inside a mediated + enforced + forward-proxy AgentRun whose `codex-main` grant is `materialization: placeholder-file`, and records evidence + a summary (normal turn / WebSocket / refresh / secret-scan) under `.phase6-out/real-codex-proof/`.

- Scans the copied agent Codex files for the real host `access_token`/`refresh_token`/`id_token` needles **without printing values**; the placeholder is allowed.
- Refresh is not forced (PR D); WebSocket is recorded as fallback-only (PR C) — both surfaced in the summary as `unproven`/`fallback`.

### 3. Evidence output dir

`.phase6-out/` added to `.gitignore` (matching the existing `.phase2-out/`/`.phase2b-out/` convention).

### 4. Docs

`docs/real-codex-forward-proxy-proof.md` updated to mark PR A + PR B landed and point at the `make` target.

### Verification

Helm render suite green (including the new checksum assertion); broker Deployment renders correctly with TLS on and off; the harness values render cleanly through the chart; harness passes `bash -n` and the `make` target resolves. The harness itself is manual and unverified end-to-end here (requires real Codex auth + a cluster).
