### PR TITLE
Support WebSocket upgrades through egressd MITM

### DIFF
--- a/docs/real-codex-forward-proxy-proof.md
+++ b/docs/real-codex-forward-proxy-proof.md
@@ -172,21 +172,35 @@ Interpretation:
 Required investigation:
 
 - Add a focused egressd test for HTTP Upgrade/WebSocket through `serveDecrypted` and `Proxy.ServeHTTP`.
-- Verify whether Go's current handler path preserves `Connection: Upgrade`, `Upgrade: websocket`, and bidirectional streaming when the request comes through the single-connection MITM server.
-- Capture sanitized request metadata for the failed WSS handshake:
+- Preserve `Connection: Upgrade`, `Upgrade: websocket`, and bidirectional streaming when the request comes through the single-connection MITM server.
+- Capture sanitized request metadata for the WSS handshake through the existing broker audit report:
   - method
   - path class
-  - upgrade yes/no
-  - upstream response status
+  - upstream response status (`101` proves the upgrade path)
   - no header values, no bodies, no frame payloads
 
 Acceptance:
 
 - Either Codex WebSocket succeeds through egressd, or docs explicitly state that real Codex currently relies on HTTPS fallback and WebSocket remains unproven.
 
-### 3. Refresh Path Is Still Unproven
+Status:
 
-The proof did not force token expiry or refresh.
+- The generic egressd Upgrade path is implemented and pinned by a fixture-level
+  MITM test: the placeholder `Authorization` on the handshake is stripped,
+  broker-injected auth reaches upstream, the upstream returns
+  `101 Switching Protocols`, and bytes relay bidirectionally after the upgrade.
+- The manual proof harness now collects broker `audit.jsonl` and reports
+  WebSocket as `PASS` only when a `101` status is audited and Codex did not log
+  a WebSocket fallback warning.
+- Real Codex rerun on 2026-07-07 passed:
+  - `normal_turn: PASS`
+  - `websocket: PASS (101 Switching Protocols audited)`
+  - `secret_scan: clean`
+  - `refresh: PASS (broker-side refresh forced in follow-up proof)`
+
+### 3. Broker-Side Refresh Path Is Proven
+
+The original proof did not force token expiry or refresh.
 
 Risk:
 
@@ -206,6 +220,34 @@ Acceptance:
 
 - A real Codex run survives token refresh without any real refresh token in the agent.
 - Or the docs explicitly mark refresh as the remaining blocker for long-lived Codex sessions.
+
+Status:
+
+- **Broker-side refresh is proven.** On 2026-07-07, the proof cluster broker was
+  reconfigured with `refresh-margin-seconds: 500000`, above the real access
+  token's remaining lifetime. The next mediated Codex turn forced the
+  `codex-oauth` provider to refresh before serving injection headers.
+- Broker audit recorded:
+  - `operation: "injection.refresh"`
+  - refreshed `expires_at: "2026-07-17T14:37:16Z"`
+  - subsequent `injection.headers` for `chatgpt.com`
+- The Codex turn completed:
+  - nonce: `NVT_BROKER_REFRESH_PROOF_1783435040`
+  - WebSocket remained active (`status: 101` in broker audit)
+  - the agent still had only placeholder `access_token` and placeholder
+    `refresh_token`
+- The refreshed broker auth was copied back to the host after the proof so the
+  host login stayed in sync with refresh-token rotation.
+
+Important nuance:
+
+- Forcing the agent-side placeholder access token to look expired made Codex try
+  its own local refresh and log expected refresh failures. The turn still
+  succeeded because production mediated Codex does not depend on Codex-local
+  refresh: egressd asks the broker for headers, the broker refreshes its real
+  auth, and the agent remains on placeholder auth.
+- The production-relevant path is therefore broker-side refresh, not exposing a
+  real refresh token to satisfy Codex's local refresh manager.
 
 ## Recommended PRs
 
@@ -242,8 +284,9 @@ CODEX_AUTH_SOURCE=/path/to/.codex make phase6-real-codex-proof
 
 Implemented in `scripts/phase6-real-codex-proof.sh`; writes evidence and a
 summary (normal turn / WebSocket / refresh / secret-scan) under
-`.phase6-out/real-codex-proof/` (git-ignored). Refresh is not forced yet (PR D)
-and the WebSocket path is recorded as fallback-only (PR C).
+`.phase6-out/real-codex-proof/` (git-ignored). Refresh is not forced yet
+(PR D). WebSocket is reported from real evidence: fallback warning means WSS is
+still unproven; an audited `101` without fallback means WSS passed.
 
 Suggested behavior:
 
@@ -275,6 +318,11 @@ Scope:
 
 Do not add provider-specific Codex logic to egressd.
 
+Status: implemented generically in egressd and validated with
+`make phase6-real-codex-proof`. The 2026-07-07 proof run passed normal Codex
+execution and audited a real `101 Switching Protocols` WebSocket upgrade with no
+host token material in the copied agent files or collected evidence.
+
 ### PR D: Refresh Proof
 
 Scope:
@@ -284,12 +332,18 @@ Scope:
 
 Do not widen to body/query substitution unless the proof shows Codex sends required secrets in body/query and header injection cannot satisfy it.
 
+Status: broker-side refresh has been validated manually with real Codex and no
+agent-held real token. A follow-up may turn this into an opt-in harness mode, but
+no body/query substitution was needed for the production path tested here.
+
 ## Operational Recommendation
 
 For a real environment today:
 
 - Forward-proxy mediated Codex is promising and has passed the normal HTTPS turn proof.
-- Do not yet claim full long-lived Codex support until refresh is proven.
-- Do not claim WebSocket support until the `405` is understood or fixed.
-- Broker config rollout checksum should be fixed before staging deployment.
-
+- Broker-side refresh is proven for mediated Codex: the broker refreshed real
+  auth during injection while the agent kept placeholder auth.
+- WebSocket support is proven for the tested Codex version/environment: the
+  manual proof showed an audited `101` without Codex falling back to HTTPS.
+- Broker config rollout checksum is in place so broker provider config changes
+  roll the Deployment.

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -21,8 +21,10 @@ const (
 	forwardProxyMITMReadHeaderTimeout       = 30 * time.Second
 )
 
-// ForwardProxy is a CONNECT-only blind tunnel. It does not inspect or modify
-// TLS, WebSocket frames, headers, cookies, bodies, or credentials.
+// ForwardProxy is a CONNECT-only proxy. Non-inject hosts are blind-tunnelled;
+// inject-route hosts are TLS-terminated under the per-agent CA and dispatched
+// through Proxy, which injects credentials on the decrypted HTTP request. It
+// never inspects WebSocket frames after an HTTP Upgrade is established.
 // forwardProxyCapability labels forward-proxy CONNECT audit reports. The
 // forward proxy is not per-capability; this is a fixed observability label.
 const forwardProxyCapability = "forward-proxy"
@@ -247,9 +249,10 @@ func (p *ForwardProxy) init() {
 					AllowInsecureUpstream: route.AllowInsecureUpstream,
 					MaxRequests:           route.MaxRequests,
 				},
-				Broker:    p.Broker,
-				Transport: p.Transport,
-				Reporter:  p.Reporter,
+				Broker:             p.Broker,
+				Transport:          p.Transport,
+				Reporter:           p.Reporter,
+				UpgradeIdleTimeout: p.Config.effectiveTunnelIdleTimeout(),
 			}
 		}
 	})

--- a/egressd/internal/egress/forward_proxy_mitm_test.go
+++ b/egressd/internal/egress/forward_proxy_mitm_test.go
@@ -9,10 +9,13 @@ import (
 	"bufio"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newMITMProxy(t *testing.T, broker *fakeBroker, route ForwardProxyInjectRoute, upstreamNames ...string) (*httptest.Server, *CA) {
@@ -82,6 +85,106 @@ func TestForwardProxyMITMInjectsRealToken(t *testing.T) {
 	}
 	if record.path != "/v1/responses?stream=true" {
 		t.Fatalf("upstream path = %q, want the preserved request path", record.path)
+	}
+}
+
+func TestForwardProxyMITMInjectsUpgradeHandshakeAndRelays(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	upstream.handler = func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+realToken {
+			t.Errorf("upgrade upstream Authorization = %q, want injected token", r.Header.Get("Authorization"))
+		}
+		if strings.Contains(fmt.Sprint(r.Header), Placeholder) {
+			t.Error("placeholder reached upgrade upstream")
+		}
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			t.Errorf("upgrade header = %q, want websocket", r.Header.Get("Upgrade"))
+		}
+		if !headerHasToken(r.Header, "Connection", "upgrade") {
+			t.Errorf("connection header = %q, want Upgrade token", r.Header.Values("Connection"))
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("upstream response writer cannot hijack")
+			return
+		}
+		conn, buffered, err := hijacker.Hijack()
+		if err != nil {
+			t.Errorf("upstream hijack: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, err := conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")); err != nil {
+			t.Errorf("write upgrade response: %v", err)
+			return
+		}
+		line, err := buffered.ReadString('\n')
+		if err != nil {
+			t.Errorf("read upgraded client bytes: %v", err)
+			return
+		}
+		if line != "ping\n" {
+			t.Errorf("upstream upgraded bytes = %q, want ping", line)
+			return
+		}
+		if _, err := io.WriteString(conn, "pong\n"); err != nil {
+			t.Errorf("write upgraded upstream bytes: %v", err)
+		}
+	}
+	proxy, ca := newMITMProxy(t, broker, ForwardProxyInjectRoute{
+		Host: "chatgpt.com", Capability: "codex-main",
+		Upstream: proxyAddress(t, upstream.server), AllowInsecureUpstream: true,
+	}, "chatgpt.com")
+
+	tlsConn := mitmDial(t, proxy, ca, "chatgpt.com", "chatgpt.com")
+	reader := bufio.NewReader(tlsConn)
+	fmt.Fprintf(tlsConn, "GET /backend-api/codex/responses HTTP/1.1\r\nHost: chatgpt.com\r\nAuthorization: Bearer %s\r\nConnection: keep-alive, Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: fixture\r\nSec-WebSocket-Version: 13\r\n\r\n", Placeholder)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("upgrade response status = %d, want 101", resp.StatusCode)
+	}
+	if !strings.EqualFold(resp.Header.Get("Upgrade"), "websocket") {
+		t.Fatalf("upgrade response header = %q, want websocket", resp.Header.Get("Upgrade"))
+	}
+	if !headerHasToken(resp.Header, "Connection", "upgrade") {
+		t.Fatalf("upgrade response connection = %q, want Upgrade token", resp.Header.Values("Connection"))
+	}
+	if _, err := io.WriteString(tlsConn, "ping\n"); err != nil {
+		t.Fatalf("write upgraded client bytes: %v", err)
+	}
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read upgraded upstream bytes: %v", err)
+	}
+	if line != "pong\n" {
+		t.Fatalf("upgraded relay response = %q, want pong", line)
+	}
+	record := upstream.last(t)
+	if record.path != "/backend-api/codex/responses" {
+		t.Fatalf("upstream path = %q, want codex websocket path", record.path)
+	}
+}
+
+func TestUpgradeRelayIdleTimeoutCleansUpStalledPeers(t *testing.T) {
+	client, proxySide := net.Pipe()
+	upstream, upstreamPeer := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = upstreamPeer.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		relayUpgrade(proxySide, bufio.NewReadWriter(bufio.NewReader(proxySide), bufio.NewWriter(proxySide)), upstream, 20*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("idle upgraded relay did not clean up stalled peers")
 	}
 }
 

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -1,6 +1,7 @@
 package egress
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -55,6 +56,10 @@ type Proxy struct {
 	Transport http.RoundTripper
 	Reporter  *Reporter
 	Now       func() time.Time
+	// UpgradeIdleTimeout bounds upgraded HTTP/WebSocket relays. Zero disables
+	// the relay-specific deadline, which keeps redirect routes compatible; the
+	// forward-proxy MITM path sets this from its tunnel idle timeout.
+	UpgradeIdleTimeout time.Duration
 
 	mu    sync.Mutex
 	cache map[string]*cacheEntry
@@ -163,6 +168,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusTooManyRequests, "egress-quota-exceeded")
 		return
 	}
+	if isUpgradeRequest(r) {
+		p.serveUpgrade(w, r, outbound)
+		return
+	}
 	response, err := p.Transport.RoundTrip(outbound)
 	if err != nil {
 		log.Printf("egressd %s: upstream unreachable", p.Route.Capability)
@@ -202,8 +211,56 @@ func (p *Proxy) buildOutbound(r *http.Request, material *Material) (*http.Reques
 	for name, value := range material.Headers {
 		outbound.Header.Set(name, value)
 	}
+	if isUpgradeRequest(r) {
+		copyUpgradeHeaders(outbound.Header, r.Header)
+	}
 	outbound.Host = p.Route.Upstream
 	return outbound, nil
+}
+
+func (p *Proxy) serveUpgrade(w http.ResponseWriter, r *http.Request, outbound *http.Request) {
+	response, err := p.Transport.RoundTrip(outbound)
+	if err != nil {
+		log.Printf("egressd %s: upstream upgrade unreachable", p.Route.Capability)
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
+		writeError(w, http.StatusBadGateway, "egress-upstream-unreachable")
+		return
+	}
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		defer func() { _ = response.Body.Close() }()
+		p.report(r.Method, r.URL.Path, response.StatusCode)
+		copyResponse(w, response)
+		return
+	}
+	upstream, ok := response.Body.(readWriteCloser)
+	if !ok {
+		_ = response.Body.Close()
+		log.Printf("egressd %s: upstream upgrade body is not bidirectional", p.Route.Capability)
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
+		writeError(w, http.StatusBadGateway, "egress-upgrade-unavailable")
+		return
+	}
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		_ = response.Body.Close()
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
+		writeError(w, http.StatusBadGateway, "egress-upgrade-unavailable")
+		return
+	}
+	client, buffered, err := hijacker.Hijack()
+	if err != nil {
+		_ = response.Body.Close()
+		p.report(r.Method, r.URL.Path, http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = client.Close() }()
+	defer func() { _ = upstream.Close() }()
+
+	p.report(r.Method, r.URL.Path, response.StatusCode)
+	if err := writeUpgradeResponse(client, response); err != nil {
+		return
+	}
+	relayUpgrade(client, buffered, upstream, p.UpgradeIdleTimeout)
 }
 
 // injectionHost is the host presented to the broker for authorization: the
@@ -226,6 +283,117 @@ func containsPlaceholder(values []string) bool {
 		}
 	}
 	return false
+}
+
+func isUpgradeRequest(r *http.Request) bool {
+	return headerHasToken(r.Header, "Connection", "upgrade") && r.Header.Get("Upgrade") != ""
+}
+
+func copyUpgradeHeaders(dst, src http.Header) {
+	dst.Set("Connection", "Upgrade")
+	if upgrade := src.Get("Upgrade"); upgrade != "" {
+		dst.Set("Upgrade", upgrade)
+	}
+}
+
+func headerHasToken(header http.Header, name, token string) bool {
+	for _, value := range header.Values(name) {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type readWriteCloser interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+func writeUpgradeResponse(w io.Writer, response *http.Response) error {
+	reason := response.Status
+	if reason == "" {
+		reason = fmt.Sprintf("%03d %s", response.StatusCode, http.StatusText(response.StatusCode))
+	}
+	if _, err := fmt.Fprintf(w, "HTTP/%d.%d %s\r\n", response.ProtoMajor, response.ProtoMinor, reason); err != nil {
+		return err
+	}
+	for name, values := range response.Header {
+		for _, value := range values {
+			if _, err := fmt.Fprintf(w, "%s: %s\r\n", name, value); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := io.WriteString(w, "\r\n")
+	return err
+}
+
+func relayUpgrade(client net.Conn, buffered *bufio.ReadWriter, upstream readWriteCloser, idleTimeout time.Duration) {
+	setUpgradeDeadline(idleTimeout, client, upstream)
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(upstream, upgradeActivityReader{
+			reader:      buffered,
+			idleTimeout: idleTimeout,
+			values:      []any{client, upstream},
+		})
+		_ = closeWriteAny(upstream)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(client, upgradeActivityReader{
+			reader:      upstream,
+			idleTimeout: idleTimeout,
+			values:      []any{client, upstream},
+		})
+		_ = closeWriteAny(client)
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+type upgradeActivityReader struct {
+	reader      io.Reader
+	idleTimeout time.Duration
+	values      []any
+}
+
+func (r upgradeActivityReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		setUpgradeDeadline(r.idleTimeout, r.values...)
+	}
+	return n, err
+}
+
+func setUpgradeDeadline(idleTimeout time.Duration, values ...any) {
+	if idleTimeout <= 0 {
+		return
+	}
+	deadline := time.Now().Add(idleTimeout)
+	for _, value := range values {
+		if deadliner, ok := value.(interface{ SetDeadline(time.Time) error }); ok {
+			_ = deadliner.SetDeadline(deadline)
+		}
+	}
+}
+
+func closeWriteAny(value any) error {
+	type closeWriter interface {
+		CloseWrite() error
+	}
+	if writer, ok := value.(closeWriter); ok {
+		return writer.CloseWrite()
+	}
+	if closer, ok := value.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 func copyResponse(w http.ResponseWriter, response *http.Response) {

--- a/scripts/phase6-real-codex-proof.sh
+++ b/scripts/phase6-real-codex-proof.sh
@@ -169,6 +169,7 @@ collect agent-auth.json cat "/root/.codex/auth.json"
 collect proxy-env bash -lc 'env | grep -Ei "PROXY" | sort'
 "${KUBECTL[@]}" -n "${NAMESPACE}" logs "${RUN_NAME}-egressd" >"${OUTPUT_DIR}/egressd.log" 2>/dev/null || true
 "${KUBECTL[@]}" -n "${NAMESPACE}" logs deployment/nvt-broker >"${OUTPUT_DIR}/broker.log" 2>/dev/null || true
+"${KUBECTL[@]}" -n "${NAMESPACE}" exec deployment/nvt-broker -- cat /state/audit.jsonl >"${OUTPUT_DIR}/broker-audit.jsonl" 2>/dev/null || true
 # Copy the agent home Codex/proof files for an offline secret scan.
 "${KUBECTL[@]}" -n "${NAMESPACE}" cp "${RUN_NAME}-agent:/root/.codex" "${OUTPUT_DIR}/agent-codex" -c agent 2>/dev/null || true
 
@@ -186,6 +187,7 @@ python3 - "${CODEX_AUTH_SOURCE}/auth.json" \
   "${OUTPUT_DIR}/proxy-env" \
   "${OUTPUT_DIR}/egressd.log" \
   "${OUTPUT_DIR}/broker.log" \
+  "${OUTPUT_DIR}/broker-audit.jsonl" \
   >"${OUTPUT_DIR}/secret-scan.txt" 2>&1 <<'PY' || SCAN_RESULT="FAIL"
 import json
 import os
@@ -226,7 +228,11 @@ last_message="$(cat "${OUTPUT_DIR}/last-message" 2>/dev/null || true)"
 normal_turn="FAIL"
 [[ "${last_message}" == *"${PROOF_NONCE}"* ]] && normal_turn="PASS"
 websocket="unproven"
-grep -qi "Falling back from WebSockets" "${OUTPUT_DIR}/codex.stderr" 2>/dev/null && websocket="fallback-to-https (WSS unproven)"
+if grep -qi "Falling back from WebSockets" "${OUTPUT_DIR}/codex.stderr" 2>/dev/null; then
+  websocket="fallback-to-https (WSS unproven)"
+elif grep -Eq '"status"[[:space:]]*:[[:space:]]*101' "${OUTPUT_DIR}/broker-audit.jsonl" 2>/dev/null; then
+  websocket="PASS (101 Switching Protocols audited)"
+fi
 {
   echo "nonce:          ${PROOF_NONCE}"
   echo "normal_turn:    ${normal_turn}"
@@ -237,4 +243,8 @@ grep -qi "Falling back from WebSockets" "${OUTPUT_DIR}/codex.stderr" 2>/dev/null
 } | tee "${SUMMARY}"
 
 [[ "${normal_turn}" == "PASS" && "${SCAN_RESULT}" == "clean" ]] || die "proof did not pass — see ${OUTPUT_DIR}"
-log "real Codex forward-proxy proof PASSED (normal HTTPS turn; WebSocket/refresh remain unproven)"
+if [[ "${websocket}" == PASS* ]]; then
+  log "real Codex forward-proxy proof PASSED (normal turn + WebSocket; refresh remains unproven)"
+else
+  log "real Codex forward-proxy proof PASSED (normal turn; WebSocket/refresh remain unproven)"
+fi

--- a/tests/runtime/mediated_admission_test.go
+++ b/tests/runtime/mediated_admission_test.go
@@ -134,7 +134,6 @@ func runOperatorAdmissionValidationTest(t *testing.T) {
 	root := repoRoot(t)
 	cmd := exec.Command("go", "test", "./internal/controller", "-run", "Test(ValidateAgentRunEgressModeRejectsMismatches|ReconcileRejectsEgressMismatchBeforePodAndSecrets)", "-count=1")
 	cmd.Dir = filepath.Join(root, "operator")
-	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(t.TempDir(), "go-cache"))
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("operator admission validation test failed: %v\n%s", err, output)


### PR DESCRIPTION
## Summary
- add generic HTTP Upgrade/WebSocket relay support to egressd's TLS-terminating MITM proxy path
- preserve Upgrade handshake headers while still stripping placeholder auth and injecting broker-provided credentials
- extend the real Codex proof harness to collect broker audit and report WebSocket PASS from an audited 101
- record the successful real Codex proof run and the forced broker-side refresh proof in docs
- avoid a cold-cache nested operator compile in the runtime admission test so CI does not appear stuck in runtime conformance

## Tests
- bash -n scripts/phase6-real-codex-proof.sh
- GOCACHE=/private/tmp/nvt-go-cache go test ./... (from egressd/)
- GOCACHE=/private/tmp/nvt-go-cache go test -race ./... (from egressd/)
- git diff --check
- /bin/zsh -lc "PATH=/private/tmp/nvt-agent-test-venv/bin:$PATH go test -run TestAdmissionRejects -count=1 -v ./..." (from tests/runtime/, outside sandbox because it writes .agents)
- make phase6-real-codex-proof
  - normal_turn: PASS
  - websocket: PASS (101 Switching Protocols audited)
  - secret_scan: clean
- forced broker-side refresh proof in kind cluster
  - configured codex-oauth refresh-margin-seconds above the real access token remaining lifetime
  - broker audit recorded operation: injection.refresh
  - refreshed broker access token expiry: 2026-07-17T14:37:16Z
  - subsequent real Codex turn completed with WebSocket status 101 audited
  - agent still held only placeholder access_token and refresh_token
