### PR TITLE
Add generic runtime preseed files

### DIFF
--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2779,12 +2779,15 @@ func RenderAgentConfigYAML(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 		rawConfig = []byte("{}")
 	}
 
-	if promptText := AgentRunPromptText(agentRun); promptText != "" || AgentRunEgressMode(agentRun) == nvtv1alpha1.AgentRunEgressMediated {
+	if promptText := AgentRunPromptText(agentRun); promptText != "" ||
+		AgentRunEgressMode(agentRun) == nvtv1alpha1.AgentRunEgressMediated ||
+		AgentRunNeedsRuntimePreseed(agentRun) {
 		config := map[string]any{}
 		if err := yaml.Unmarshal(rawConfig, &config); err != nil {
 			return "", fmt.Errorf("render AgentRun agent config: %w", err)
 		}
 		renderedConfig := config
+		renderedConfig = InjectRuntimePreseed(renderedConfig, agentRun)
 		if promptText != "" {
 			var err error
 			renderedConfig, err = InjectInitialPromptPlugin(renderedConfig, promptText)
@@ -2808,6 +2811,31 @@ func RenderAgentConfigYAML(agentRun *nvtv1alpha1.AgentRun) (string, error) {
 	}
 
 	return string(rendered), nil
+}
+
+func AgentRunNeedsRuntimePreseed(agentRun *nvtv1alpha1.AgentRun) bool {
+	return agentRun.Spec.Runtime.Type == "codex"
+}
+
+func InjectRuntimePreseed(config map[string]any, agentRun *nvtv1alpha1.AgentRun) map[string]any {
+	if !AgentRunNeedsRuntimePreseed(agentRun) {
+		return config
+	}
+	if _, ok := config["preseed"]; ok {
+		return config
+	}
+	updated := cloneStringAnyMap(config)
+	updated["preseed"] = map[string]any{
+		"files": []any{
+			map[string]any{
+				"path":      "$HOME/.codex/config.toml",
+				"mode":      "0600",
+				"overwrite": false,
+				"content":   "check_for_update_on_startup = false\n",
+			},
+		},
+	}
+	return updated
 }
 
 func InjectMediatedEgressConfig(config map[string]any, agentRun *nvtv1alpha1.AgentRun) map[string]any {

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -2587,6 +2587,68 @@ func TestRenderAgentConfigYAMLNoPromptRendersUnchanged(t *testing.T) {
 	}
 }
 
+func TestRenderAgentConfigYAMLInjectsCodexPreseed(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Agent.Config = apiextensionsv1.JSON{Raw: []byte(`{"tools": {"packages": []}}`)}
+	agentRun.Spec.Runtime.Type = "codex"
+
+	rendered, err := RenderAgentConfigYAML(agentRun)
+	if err != nil {
+		t.Fatalf("render AgentRun agent config: %v", err)
+	}
+
+	config := parseAgentConfigYAML(t, rendered)
+	preseed, ok := config["preseed"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected codex preseed block, got %#v\n%s", config["preseed"], rendered)
+	}
+	files, ok := preseed["files"].([]any)
+	if !ok || len(files) != 1 {
+		t.Fatalf("expected one preseed file, got %#v\n%s", preseed["files"], rendered)
+	}
+	file, ok := files[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected preseed file object, got %#v", files[0])
+	}
+	if file["path"] != "$HOME/.codex/config.toml" ||
+		file["mode"] != "0600" ||
+		file["overwrite"] != false ||
+		file["content"] != "check_for_update_on_startup = false\n" {
+		t.Fatalf("unexpected codex preseed file: %#v\n%s", file, rendered)
+	}
+}
+
+func TestRenderAgentConfigYAMLPreservesUserPreseed(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Agent.Config = apiextensionsv1.JSON{Raw: []byte(`{
+		"preseed": {
+			"files": [
+				{
+					"path": "$HOME/.custom/config.json",
+					"json": {"enabled": true}
+				}
+			]
+		}
+	}`)}
+	agentRun.Spec.Runtime.Type = "codex"
+
+	rendered, err := RenderAgentConfigYAML(agentRun)
+	if err != nil {
+		t.Fatalf("render AgentRun agent config: %v", err)
+	}
+
+	if strings.Contains(rendered, "check_for_update_on_startup") {
+		t.Fatalf("operator overwrote user preseed:\n%s", rendered)
+	}
+	config := parseAgentConfigYAML(t, rendered)
+	preseed := config["preseed"].(map[string]any)
+	files := preseed["files"].([]any)
+	file := files[0].(map[string]any)
+	if file["path"] != "$HOME/.custom/config.json" {
+		t.Fatalf("expected user preseed to be preserved, got %#v\n%s", file, rendered)
+	}
+}
+
 func TestRenderAgentConfigYAMLEmptyPromptRendersUnchanged(t *testing.T) {
 	agentRun := testAgentRun()
 	agentRun.Spec.Prompt = &nvtv1alpha1.AgentRunPrompt{Text: ""}

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -2574,7 +2574,7 @@ func TestRenderAgentConfigYAMLInjectsInitialPromptPluginWhenPluginsMissing(t *te
 	}
 }
 
-func TestRenderAgentConfigYAMLNoPromptRendersUnchanged(t *testing.T) {
+func TestRenderAgentConfigYAMLNoPromptDoesNotInjectInitialPrompt(t *testing.T) {
 	agentRun := testAgentRun()
 
 	rendered, err := RenderAgentConfigYAML(agentRun)
@@ -2584,6 +2584,21 @@ func TestRenderAgentConfigYAMLNoPromptRendersUnchanged(t *testing.T) {
 
 	if strings.Contains(rendered, "initial-prompt") {
 		t.Fatalf("expected no injected plugin, got:\n%s", rendered)
+	}
+}
+
+func TestRenderAgentConfigYAMLDoesNotInjectPreseedForNonCodex(t *testing.T) {
+	agentRun := testAgentRun()
+	agentRun.Spec.Agent.Config = apiextensionsv1.JSON{Raw: []byte(`{"tools": {"packages": []}}`)}
+	agentRun.Spec.Runtime.Type = "claude"
+
+	rendered, err := RenderAgentConfigYAML(agentRun)
+	if err != nil {
+		t.Fatalf("render AgentRun agent config: %v", err)
+	}
+
+	if strings.Contains(rendered, "preseed") || strings.Contains(rendered, "check_for_update_on_startup") {
+		t.Fatalf("operator injected runtime preseed for non-codex run:\n%s", rendered)
 	}
 }
 

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -492,7 +492,7 @@ def apply_preseed_files(preseed):
         target = preseed_file_target(home, entry.get("path"))
         content = preseed_file_content(entry, index)
         mode = parse_file_mode(entry.get("mode"), f"preseed.files[{index}]")
-        overwrite = optional_bool(entry.get("overwrite"), f"preseed.files[{index}].overwrite", default=True)
+        overwrite = optional_bool(entry.get("overwrite"), f"preseed.files[{index}].overwrite", default=False)
         if target.exists() and not overwrite:
             print(f"bootstrap: preseed file {target} already exists", flush=True)
             continue

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -59,7 +59,7 @@ DEFAULT_BROKER_WAIT_SECONDS = 180
 def load_bootstrap_config(path):
     if not path.is_file():
         print(f"bootstrap: no agent config at {path}", flush=True)
-        return {}, {}, {}, {}
+        return {}, {}, {}, {}, {}
 
     with path.open("r", encoding="utf-8") as file:
         data = yaml.safe_load(file) or {}
@@ -95,7 +95,13 @@ def load_bootstrap_config(path):
     if not isinstance(egress, dict):
         raise SystemExit("egress must be a YAML object")
 
-    return runtime, tools, code_server, egress
+    preseed = data.get("preseed", {})
+    if preseed is None:
+        preseed = {}
+    if not isinstance(preseed, dict):
+        raise SystemExit("preseed must be a YAML object")
+
+    return runtime, tools, code_server, egress, preseed
 
 
 def expand_path(value):
@@ -144,46 +150,6 @@ def persist_agent_command(command, args):
     target = Path.home() / ".nvt-agent" / "agent-command.json"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(json.dumps({"command": command, "args": args}, separators=(",", ":")) + "\n", encoding="utf-8")
-
-
-def codex_home():
-    return Path(os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
-
-
-def has_root_toml_key(lines, key):
-    for line in lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if stripped.startswith("["):
-            return False
-        if re.match(rf"^{re.escape(key)}\s*=", stripped):
-            return True
-    return False
-
-
-def insert_root_toml_key(lines, key, value):
-    entry = f"{key} = {value}"
-    for index, line in enumerate(lines):
-        if line.strip().startswith("["):
-            return [*lines[:index], entry, *lines[index:]]
-    return [*lines, entry]
-
-
-def ensure_codex_update_check_disabled(command):
-    if Path(command).name != "codex":
-        return
-
-    key = "check_for_update_on_startup"
-    target = codex_home() / "config.toml"
-    lines = target.read_text(encoding="utf-8").splitlines() if target.exists() else []
-    if has_root_toml_key(lines, key):
-        print(f"bootstrap: codex startup update check already configured in {target}", flush=True)
-        return
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text("\n".join(insert_root_toml_key(lines, key, "false")) + "\n", encoding="utf-8")
-    print(f"bootstrap: disabled codex startup update check in {target}", flush=True)
 
 
 def setup_tmux_config():
@@ -484,6 +450,56 @@ def write_placeholder_file(target, content, mode, home):
         raise
 
 
+def parse_file_mode(raw_mode, field):
+    if raw_mode is None:
+        raw_mode = "0600"
+    if not isinstance(raw_mode, str) or len(raw_mode) != 4 or any(char not in "01234567" for char in raw_mode):
+        raise SystemExit(f"{field} has an invalid mode {raw_mode!r}")
+    return int(raw_mode, 8)
+
+
+def preseed_file_target(home, path):
+    if not isinstance(path, str) or not path:
+        raise SystemExit(f"bootstrap: preseed file path {path!r} must be a non-empty string")
+    expanded = expand_path(path)
+    target = Path(expanded)
+    if not target.is_absolute():
+        target = home / expanded
+    return target
+
+
+def preseed_file_content(entry, index):
+    has_content = "content" in entry
+    has_json = "json" in entry
+    if has_content == has_json:
+        raise SystemExit(f"preseed.files[{index}] must set exactly one of content or json")
+    if has_content:
+        content = entry.get("content")
+        if not isinstance(content, str):
+            raise SystemExit(f"preseed.files[{index}].content must be a string")
+        return content
+    return json.dumps(entry.get("json"), indent=2, sort_keys=True) + "\n"
+
+
+def apply_preseed_files(preseed):
+    files = preseed.get("files") or []
+    if not isinstance(files, list):
+        raise SystemExit("preseed.files must be a list")
+    home = Path.home()
+    for index, entry in enumerate(files):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"preseed.files[{index}] must be an object")
+        target = preseed_file_target(home, entry.get("path"))
+        content = preseed_file_content(entry, index)
+        mode = parse_file_mode(entry.get("mode"), f"preseed.files[{index}]")
+        overwrite = optional_bool(entry.get("overwrite"), f"preseed.files[{index}].overwrite", default=True)
+        if target.exists() and not overwrite:
+            print(f"bootstrap: preseed file {target} already exists", flush=True)
+            continue
+        write_placeholder_file(target, content, mode, home)
+        print(f"bootstrap: wrote preseed file {target}", flush=True)
+
+
 def apply_placeholder_files(egress):
     # Materialize provider-owned placeholder auth files (placeholders only; the
     # real secret stays broker-side). Runs regardless of egress mode. Never
@@ -513,11 +529,9 @@ def apply_placeholder_files(egress):
             content = entry.get("content")
             if not isinstance(content, str):
                 raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} must include string content")
-            raw_mode = entry.get("mode") or "0600"
-            if not isinstance(raw_mode, str) or len(raw_mode) != 4 or any(char not in "01234567" for char in raw_mode):
-                raise SystemExit(f"bootstrap: placeholder-files[{file_index}] for {provider} has an invalid mode {raw_mode!r}")
+            mode = parse_file_mode(entry.get("mode"), f"bootstrap: placeholder-files[{file_index}] for {provider}")
             target = placeholder_file_target(home, entry.get("path"))
-            write_placeholder_file(target, content, int(raw_mode, 8), home)
+            write_placeholder_file(target, content, mode, home)
 
 
 def apply_additional_paths(paths):
@@ -672,9 +686,10 @@ def setup_code_server(config):
 
 def main():
     config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/nvt-agent/agent.yaml")
-    runtime, tools, code_server, egress = load_bootstrap_config(config_path)
+    runtime, tools, code_server, egress, preseed = load_bootstrap_config(config_path)
 
     setup_tmux_config()
+    apply_preseed_files(preseed)
     if mediated_mode(egress):
         apply_mediated_egress(egress)
     # Placeholder-file materialization is independent of egress mode: it writes
@@ -687,7 +702,6 @@ def main():
         persist_env_var("AGENT_COMMAND", command)
         args = optional_string_list(runtime.get("args"), "runtime.args")
         persist_agent_command(command, args)
-        ensure_codex_update_check_disabled(command)
     setup_code_server(code_server)
     apply_additional_paths(as_string_list(tools.get("additional-paths"), "additional-paths"))
     install_packages(configured_packages(tools))

--- a/scripts/agent-init.sh
+++ b/scripts/agent-init.sh
@@ -137,6 +137,32 @@ else:
 PY
 )"
 
+agent_preseed="$(python3 - "$agent_type" <<'PY'
+import sys
+
+agent_type = sys.argv[1]
+if agent_type == "codex":
+    print("""preseed:
+  files:
+    - path: "$HOME/.codex/config.toml"
+      mode: "0600"
+      overwrite: false
+      content: |
+        check_for_update_on_startup = false""")
+elif agent_type == "claude":
+    print("""preseed:
+  files:
+    - path: "$HOME/.claude/settings.json"
+      mode: "0600"
+      overwrite: false
+      json:
+        theme: dark-daltonized
+        skipDangerousModePermissionPrompt: true""")
+else:
+    print("preseed:\n  files: []")
+PY
+)"
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd "$script_dir/.." && pwd -P)"
 templates_dir="$repo_root/templates"
@@ -422,7 +448,7 @@ else
 fi
 
 if [ ! -f "$agent_config_file" ]; then
-  AGENT_TYPE="$agent_type" AGENT_ARGS="$runtime_args" AGENT_USER="$runtime_user" render_template "$templates_dir/agent.yaml" "$agent_config_file"
+  AGENT_TYPE="$agent_type" AGENT_ARGS="$runtime_args" AGENT_USER="$runtime_user" AGENT_PRESEED="$agent_preseed" render_template "$templates_dir/agent.yaml" "$agent_config_file"
   echo "created $agent_config_file"
 else
   # Keep the declared runtime.user in sync when re-running with --user, without
@@ -442,6 +468,44 @@ if count:
 PY
   echo "exists  $agent_config_file"
 fi
+
+# Manage the generic preseed block in agent.yaml. bootstrap only knows how to
+# write configured files; the tool presets live here so core stays
+# implementation-swappable. If a user already owns an unmarked preseed block,
+# leave it untouched instead of creating duplicate top-level YAML keys.
+python3 - "$agent_config_file" "$agent_preseed" <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+config_file = Path(sys.argv[1])
+preseed = sys.argv[2].strip()
+
+BEGIN = "# BEGIN nvt-managed preseed (agent-init)"
+END = "# END nvt-managed preseed (agent-init)"
+
+text = config_file.read_text(encoding="utf-8")
+if BEGIN in text:
+    before, _, rest = text.partition(BEGIN)
+    _, _, after = rest.partition(END)
+    text = before.rstrip("\n") + "\n" + after.lstrip("\n")
+else:
+    parsed = yaml.safe_load(text) or {}
+    if isinstance(parsed, dict) and "preseed" in parsed:
+        raise SystemExit(0)
+
+block = "\n".join([BEGIN, preseed, END])
+if "tools:" in text:
+    text = text.replace("tools:", block + "\n\ntools:", 1)
+else:
+    text = text.rstrip("\n") + "\n\n" + block + "\n"
+parsed = yaml.safe_load(text)
+if not isinstance(parsed, dict):
+    raise SystemExit("agent-init: agent config is not a YAML object after preseed rendering")
+config_file.write_text(text, encoding="utf-8")
+print(f"rendered preseed config into {config_file}")
+PY
 
 # Manage the egress block in agent.yaml: bootstrap reads egress.grants
 # (base-url per route) from the agent config, so the compose path must render

--- a/scripts/agent-init.sh
+++ b/scripts/agent-init.sh
@@ -448,7 +448,7 @@ else
 fi
 
 if [ ! -f "$agent_config_file" ]; then
-  AGENT_TYPE="$agent_type" AGENT_ARGS="$runtime_args" AGENT_USER="$runtime_user" AGENT_PRESEED="$agent_preseed" render_template "$templates_dir/agent.yaml" "$agent_config_file"
+  AGENT_TYPE="$agent_type" AGENT_ARGS="$runtime_args" AGENT_USER="$runtime_user" render_template "$templates_dir/agent.yaml" "$agent_config_file"
   echo "created $agent_config_file"
 else
   # Keep the declared runtime.user in sync when re-running with --user, without

--- a/templates/agent.yaml
+++ b/templates/agent.yaml
@@ -3,10 +3,6 @@ runtime:
   args: {{AGENT_ARGS}}
   user: {{AGENT_USER}}
 
-# BEGIN nvt-managed preseed (agent-init)
-{{AGENT_PRESEED}}
-# END nvt-managed preseed (agent-init)
-
 tools:
   packages: []
   mise: []

--- a/templates/agent.yaml
+++ b/templates/agent.yaml
@@ -3,6 +3,10 @@ runtime:
   args: {{AGENT_ARGS}}
   user: {{AGENT_USER}}
 
+# BEGIN nvt-managed preseed (agent-init)
+{{AGENT_PRESEED}}
+# END nvt-managed preseed (agent-init)
+
 tools:
   packages: []
   mise: []

--- a/tests/runtime/broker_auth_files_test.go
+++ b/tests/runtime/broker_auth_files_test.go
@@ -430,7 +430,7 @@ max-loops: 1
 		"NVT_PLUGIN_CONFIG=" + config2,
 		"NVT_BROKER_URL=" + broker2.server.URL,
 		"NVT_BROKER_TOKEN=broker-token",
-		"PATH=" + f2.bin + ":/usr/bin:/bin",
+		"PATH=" + f2.bin + ":" + os.Getenv("PATH"),
 	}, "loop")
 	assertFileContent(t, filepath.Join(target2, "auth.json"), "ok\n")
 }

--- a/tests/runtime/compose_agent_test.go
+++ b/tests/runtime/compose_agent_test.go
@@ -496,7 +496,6 @@ preseed:
       content: |
         check_for_update_on_startup = false
     - path: ".codex/existing.toml"
-      overwrite: false
       content: |
         user-managed = false
 `)

--- a/tests/runtime/compose_agent_test.go
+++ b/tests/runtime/compose_agent_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -473,94 +474,83 @@ runtime:
 	}
 }
 
-func TestBootstrapDisablesCodexStartupUpdateCheck(t *testing.T) {
+func TestBootstrapWritesPreseedFiles(t *testing.T) {
 	f := newFixture(t)
-	config := f.writeAgentConfig(`
-runtime:
-  command: codex
-`)
-
-	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
-	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
-
-	codexConfig := filepath.Join(f.home, ".codex", "config.toml")
-	data, err := os.ReadFile(codexConfig)
-	if err != nil {
+	existingCodexConfig := filepath.Join(f.home, ".codex", "existing.toml")
+	if err := os.MkdirAll(filepath.Dir(existingCodexConfig), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	content := string(data)
-	if strings.Count(content, "check_for_update_on_startup") != 1 {
-		t.Fatalf("expected one codex update-check setting, got:\n%s", content)
-	}
-	if !strings.Contains(content, "check_for_update_on_startup = false") {
-		t.Fatalf("expected codex update check to be disabled, got:\n%s", content)
-	}
-}
-
-func TestBootstrapPreservesExistingCodexUpdateCheckConfig(t *testing.T) {
-	f := newFixture(t)
-	codexConfig := filepath.Join(f.home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	existing := "# user-managed codex config\ncheck_for_update_on_startup = true\n[tui]\nshow_tooltips = false\n"
-	if err := os.WriteFile(codexConfig, []byte(existing), 0o600); err != nil {
+	if err := os.WriteFile(existingCodexConfig, []byte("user-managed = true\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	config := f.writeAgentConfig(`
-runtime:
-  command: codex
+preseed:
+  files:
+    - path: "$HOME/.claude/settings.json"
+      mode: "0600"
+      json:
+        theme: dark-daltonized
+        skipDangerousModePermissionPrompt: true
+    - path: ".codex/config.toml"
+      mode: "0640"
+      content: |
+        check_for_update_on_startup = false
+    - path: ".codex/existing.toml"
+      overwrite: false
+      content: |
+        user-managed = false
 `)
 
 	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
 
-	data, err := os.ReadFile(codexConfig)
+	claudeSettings := filepath.Join(f.home, ".claude", "settings.json")
+	data, err := os.ReadFile(claudeSettings)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != existing {
-		t.Fatalf("bootstrap rewrote user codex config:\n%s", data)
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("preseed JSON is invalid: %v\n%s", err, data)
 	}
-}
-
-func TestBootstrapAddsCodexUpdateCheckConfigAtTomlRoot(t *testing.T) {
-	f := newFixture(t)
+	if settings["theme"] != "dark-daltonized" || settings["skipDangerousModePermissionPrompt"] != true {
+		t.Fatalf("unexpected claude settings: %#v", settings)
+	}
 	codexConfig := filepath.Join(f.home, ".codex", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(codexConfig), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(codexConfig, []byte("[tui]\nshow_tooltips = false\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	config := f.writeAgentConfig(`
-runtime:
-  command: codex
-`)
-
-	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
-
-	data, err := os.ReadFile(codexConfig)
+	data, err = os.ReadFile(codexConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "check_for_update_on_startup = false\n[tui]\nshow_tooltips = false\n"
-	if string(data) != want {
+	if string(data) != "check_for_update_on_startup = false\n" {
 		t.Fatalf("unexpected codex config:\n%s", data)
 	}
+	info, err := os.Stat(codexConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Fatalf("expected codex config mode 0640, got %v", info.Mode().Perm())
+	}
+	data, err = os.ReadFile(existingCodexConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "user-managed = true\n" {
+		t.Fatalf("overwrite=false preseed rewrote existing file:\n%s", data)
+	}
 }
 
-func TestBootstrapDoesNotWriteCodexUpdateCheckForClaude(t *testing.T) {
+func TestBootstrapPreseedRejectsEscapingHome(t *testing.T) {
 	f := newFixture(t)
 	config := f.writeAgentConfig(`
-runtime:
-  command: claude
+preseed:
+  files:
+    - path: /tmp/nvt-escape
+      content: nope
 `)
 
-	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
-
-	codexConfig := filepath.Join(f.home, ".codex", "config.toml")
-	if _, err := os.Stat(codexConfig); !os.IsNotExist(err) {
-		t.Fatalf("expected no codex config for claude runtime, stat err=%v", err)
+	output := f.runWithEnv(bootstrapBin(f.root), false, nil, config)
+	if !strings.Contains(output, "resolves outside HOME") {
+		t.Fatalf("expected outside HOME rejection, got:\n%s", output)
 	}
 }
 
@@ -876,6 +866,58 @@ func TestAgentInitRendersAutonomyArgs(t *testing.T) {
 			}
 			if !strings.Contains(string(localInstructions), "Add workspace-specific agent guidance here.") {
 				t.Fatalf("unexpected AGENTS.local.md:\n%s", localInstructions)
+			}
+		})
+	}
+}
+
+func TestAgentInitRendersToolPreseed(t *testing.T) {
+	root := repoRoot(t)
+	tests := []struct {
+		name string
+		typ  string
+		want []string
+	}{
+		{
+			name: "codex",
+			typ:  "codex",
+			want: []string{
+				"# BEGIN nvt-managed preseed (agent-init)",
+				`path: "$HOME/.codex/config.toml"`,
+				"overwrite: false",
+				"check_for_update_on_startup = false",
+			},
+		},
+		{
+			name: "claude",
+			typ:  "claude",
+			want: []string{
+				"# BEGIN nvt-managed preseed (agent-init)",
+				`path: "$HOME/.claude/settings.json"`,
+				"overwrite: false",
+				"theme: dark-daltonized",
+				"skipDangerousModePermissionPrompt: true",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			agentName := "preseed-" + tt.name
+			agentDir := filepath.Join(root, ".agents", agentName)
+			_ = os.RemoveAll(agentDir)
+			t.Cleanup(func() { _ = os.RemoveAll(agentDir) })
+			command := "HOME=" + shellQuote(home) + " bash " + shellQuote(filepath.Join(root, "scripts", "agent-init.sh"))
+			cmd := commandWithEnv(command, nil, "--name", agentName, "--type", tt.typ)
+			cmd.Dir = root
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("agent-init failed: %v\n%s", err, output)
+			}
+			config := mustReadFile(t, filepath.Join(agentDir, "agent.yaml"))
+			for _, want := range tt.want {
+				if !strings.Contains(config, want) {
+					t.Fatalf("agent.yaml missing %q\n%s", want, config)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add generic bootstrap support for preseeded files under HOME with content/json, mode, and overwrite controls
- move Codex/Claude first-run defaults into agent-init generated preseed blocks instead of bootstrap-specific logic
- preserve existing preseeded files by default for generated Codex/Claude presets
- keep runtime test subprocess PATH compatible with the active Python test environment

## Tests
- git diff --check
- PATH=/private/tmp/nvt-agent-test-venv/bin:$PATH GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -v ./... (from tests/runtime)