### PR TITLE
Support mediated gh auth

### DIFF
--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2890,6 +2890,7 @@ func InjectMediatedEgressConfig(config map[string]any, agentRun *nvtv1alpha1.Age
 		// Signals bootstrap to install the CA trust store for proxy-env HTTPS
 		// clients (the MITM leaf must be trusted system-wide).
 		egress["forward-proxy"] = true
+		egress["forward-proxy-url"] = fmt.Sprintf("http://%s:%d", EgressdServiceName(agentRun.Name), egressForwardProxyPort)
 	}
 	updated["egress"] = egress
 	return updated

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -4018,6 +4018,12 @@ func TestForwardProxyAgentPodEnv(t *testing.T) {
 	if !strings.Contains(proxy, EgressdServiceName(forwardProxyAgentRun().Name)) || !strings.Contains(proxy, "8473") {
 		t.Fatalf("HTTPS_PROXY = %q, want the egressd forward-proxy Service", proxy)
 	}
+	config := InjectMediatedEgressConfig(map[string]any{}, forwardProxyAgentRun())
+	egress, _ := config["egress"].(map[string]any)
+	proxyURL, _ := egress["forward-proxy-url"].(string)
+	if proxyURL != proxy {
+		t.Fatalf("forward-proxy-url = %q, want %q", proxyURL, proxy)
+	}
 	noProxy := envValue(agent, "NO_PROXY")
 	for _, want := range []string{"localhost", ".svc.cluster.local", "nvt-operator"} {
 		if !strings.Contains(noProxy, want) {

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -53,6 +53,7 @@ PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 DEFAULT_EGRESS_CA_FILE = "/nvt-egress-ca/ca.crt"
 DEFAULT_EGRESS_CA_WAIT_SECONDS = 60
+DEFAULT_FORWARD_PROXY_URL = "http://127.0.0.1:8470"
 DEFAULT_BROKER_WAIT_SECONDS = 180
 
 
@@ -368,6 +369,11 @@ def apply_mediated_egress(egress):
             https_provider = provider
         apply_redirect_env(provider, grant, placeholder)
     forward_proxy = bool(egress.get("forward-proxy"))
+    if forward_proxy:
+        proxy_url = egress.get("forward-proxy-url") or DEFAULT_FORWARD_PROXY_URL
+        if not isinstance(proxy_url, str) or not proxy_url.startswith(("http://", "https://")):
+            raise SystemExit("egress.forward-proxy-url must be an http(s) URL")
+        persist_env_var("NVT_EGRESS_FORWARD_PROXY_URL", proxy_url.rstrip("/"))
     if enforced and (https_provider is not None or forward_proxy):
         # Forward-proxy mode has no https base-url to trigger the install, but
         # the MITM leaf must be trusted system-wide so proxy-env HTTPS clients

--- a/runtime/plugins/README.md
+++ b/runtime/plugins/README.md
@@ -167,10 +167,18 @@ git-host-credential doctor --provider fork-app
 gh-auth pr view 123 --repo example/project
 ```
 
+`credential-kind: mediated` is available for broker providers whose Git traffic
+is routed through egressd. In that mode `git-host-credential` refuses token and
+header export; the real credential is injected outside the agent container.
+
 `gh-auth` runs `gh` with a per-command token through `GH_TOKEN`. It
 does not call `gh auth login` and does not persist credentials in the GitHub CLI
 config. If `--provider` is omitted, it resolves a provider from `--repo`, the
 current git remote, or `default-provider`.
+For mediated providers, `GH_TOKEN` is only the inert NVT placeholder and
+`gh-auth` forces GitHub traffic through egressd using
+`NVT_EGRESS_FORWARD_PROXY_URL`; the real credential is injected outside the
+agent.
 
 Security note: `git-host-credentials` currently supports local/dev operation
 where raw provider secrets, including GitHub App private keys, are provided to

--- a/runtime/plugins/git-credentials/README.md
+++ b/runtime/plugins/git-credentials/README.md
@@ -11,6 +11,11 @@ Token providers (`github-app` and `token-env`) are exposed through
 `git-credential-nvt`. Header providers configure Git `http.<url>.extraHeader`
 entries directly.
 
+Mediated broker providers (`credential-kind: mediated`) are not exposed through
+the helper and do not write `extraHeader`. They rely on the mediated runtime's
+egressd Git routing (`url.<egressd>.insteadOf` + CA trust) so the real
+credential is injected outside the agent.
+
 ## Configuration
 
 ```yaml
@@ -108,6 +113,11 @@ It does not set global `user.name` or `user.email`.
 Broker-backed header providers configure `http.<url>.extraHeader` the same way
 local header providers do. The header secret is therefore present in Git config;
 this is a compatibility path, not a zero-trust path.
+
+Broker-backed mediated providers are deliberately skipped by the credential
+helper. In mediated mode, bootstrap/operator wiring configures Git URL rewrites
+and trust for egressd; this plugin may still configure repo-local commit
+identity, but it must not ask the provider for a token or header.
 
 ## Relationship To checkout-repos
 

--- a/runtime/plugins/git-credentials/run.py
+++ b/runtime/plugins/git-credentials/run.py
@@ -296,9 +296,12 @@ def main():
 
     token_credentials = []
     header_credentials = []
+    mediated_credentials = []
     for rule in credentials:
         kind = provider_credential_kind(rule)
-        if kind == "headers":
+        if kind == "mediated":
+            mediated_credentials.append(rule)
+        elif kind == "headers":
             header_credentials.append(rule)
         else:
             token_credentials.append(rule)
@@ -307,6 +310,9 @@ def main():
     configure_headers(header_credentials)
     if token_credentials:
         configure_git_helper()
+    if mediated_credentials:
+        names = ", ".join(rule["provider"] for rule in mediated_credentials)
+        print(f"git-credentials: {len(mediated_credentials)} mediated credential rule(s) use egressd routing only: {names}", flush=True)
 
 
 def doctor():

--- a/runtime/plugins/git-host-credentials/README.md
+++ b/runtime/plugins/git-host-credentials/README.md
@@ -44,6 +44,13 @@ plugins:
           credential-kind: headers
           match:
             - altinn.studio/repos/digdir/oed
+
+        - name: brokered-fork-mediated
+          type: broker
+          broker-provider: fork-app
+          credential-kind: mediated
+          match:
+            - github.com/my-user/*
 ```
 
 `match` entries are glob patterns matched against normalized repo targets such
@@ -75,6 +82,18 @@ broker-provider: company-headers
 credential-kind: headers
 ```
 
+Use `credential-kind: mediated` when Git traffic for the provider is routed
+through egressd by the mediated runtime. In this mode the plugin refuses token
+and header export; it is only a provider resolver and identity source. The real
+credential is injected by egressd after broker authorization, outside the agent
+container.
+
+```yaml
+type: broker
+broker-provider: fork-app
+credential-kind: mediated
+```
+
 Broker-backed header providers need a concrete repo target so the broker can
 apply agent grants. Prefer repo-level `match` entries for them. For self-hosted
 Git, configure the broker provider with `target-mode: literal` and match the
@@ -92,6 +111,11 @@ gh-auth pr checks 123 --repo my-user/project
 When `--provider` is omitted, `gh-auth` resolves from `--repo`, the current
 `origin` remote, or `default-provider`.
 
+For `credential-kind: mediated`, `gh-auth` sets `GH_TOKEN` to the inert NVT
+placeholder and forces GitHub traffic through `NVT_EGRESS_FORWARD_PROXY_URL`.
+egressd strips the placeholder and injects the broker-owned credential. The
+agent process never receives the real token.
+
 ## Security
 
 Prefer `type: broker` for secret-bearing providers. Local `token-env` and
@@ -106,3 +130,7 @@ Broker-backed static PAT/header providers are still compatibility paths for
 Git. Token mode returns a token to the agent, and header mode writes headers into
 Git config. GitHub App providers are stronger because broker-minted Git tokens
 are short-lived and repo-scoped.
+
+`credential-kind: mediated` is the zero-secret Git mode: Git is configured by
+the runtime to reach the provider through egressd, and this plugin never returns
+the credential to Git, `gh`, or the agent process.

--- a/runtime/plugins/git-host-credentials/gh-auth.py
+++ b/runtime/plugins/git-host-credentials/gh-auth.py
@@ -4,7 +4,9 @@ import shutil
 import subprocess
 import sys
 
-from git_host_credentials import load_config, normalize_repo, resolve_provider, token
+from git_host_credentials import credential_kind, load_config, normalize_repo, resolve_provider, token
+
+PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 
 
 def fail(message):
@@ -51,6 +53,53 @@ def repo_from_args(args):
         return None
 
 
+def remove_no_proxy_hosts(value, blocked):
+    kept = []
+    blocked = {item.lower() for item in blocked}
+    for part in value.split(","):
+        item = part.strip()
+        if not item:
+            continue
+        lowered = item.lower()
+        if lowered == "*":
+            continue
+        bare = lowered[1:] if lowered.startswith(".") else lowered
+        if lowered in blocked or bare in blocked:
+            continue
+        kept.append(item)
+    return ",".join(kept)
+
+
+def mediated_env(provider, repo):
+    proxy_url = os.environ.get("NVT_EGRESS_FORWARD_PROXY_URL")
+    if not proxy_url:
+        fail(f"provider {provider['name']} is mediated but NVT_EGRESS_FORWARD_PROXY_URL is not set")
+    placeholder = os.environ.get("NVT_EGRESS_PLACEHOLDER") or PLACEHOLDER
+    env = os.environ.copy()
+    env["GH_TOKEN"] = placeholder
+    for key in ("GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):
+        env.pop(key, None)
+    env["HTTPS_PROXY"] = proxy_url
+    env["HTTP_PROXY"] = proxy_url
+    env["ALL_PROXY"] = proxy_url
+    env["https_proxy"] = proxy_url
+    env["http_proxy"] = proxy_url
+    env["all_proxy"] = proxy_url
+    # gh reaches both api.github.com and github.com. Remove those from broad
+    # NO_PROXY lists so egressd can inject the credential instead of the CLI
+    # bypassing mediation with the inert placeholder.
+    host = None
+    normalized = normalize_repo(repo) if repo else None
+    if normalized and "/" in normalized:
+        host = normalized.split("/", 1)[0]
+    blocked = {"github.com", "api.github.com"}
+    if host:
+        blocked.add(host)
+    for key in ("NO_PROXY", "no_proxy"):
+        env[key] = remove_no_proxy_hosts(env.get(key, ""), blocked)
+    return env
+
+
 def main():
     provider_name, gh_args = split_args(sys.argv[1:])
     if not gh_args or gh_args in (["-h"], ["--help"]):
@@ -76,9 +125,12 @@ def main():
             print(f"installation id: {installation_id}")
         return
 
-    env = os.environ.copy()
-    env["GH_TOKEN"] = token(provider, repo)
-    env.pop("GITHUB_TOKEN", None)
+    if credential_kind(provider) == "mediated":
+        env = mediated_env(provider, repo)
+    else:
+        env = os.environ.copy()
+        env["GH_TOKEN"] = token(provider, repo)
+        env.pop("GITHUB_TOKEN", None)
     os.execvpe("gh", ["gh", *gh_args], env)
 
 

--- a/runtime/plugins/git-host-credentials/git_host_credentials.py
+++ b/runtime/plugins/git-host-credentials/git_host_credentials.py
@@ -379,8 +379,8 @@ def credential_kind(provider):
     kind = provider.get("type")
     if kind == "broker":
         value = string_value(provider.get("credential-kind"), f"provider {provider_name(provider)} credential-kind") or "token"
-        if value not in {"token", "headers"}:
-            fail(f"provider {provider_name(provider)} credential-kind must be token or headers")
+        if value not in {"token", "headers", "mediated"}:
+            fail(f"provider {provider_name(provider)} credential-kind must be token, headers, or mediated")
         return value
     if kind == "headers":
         return "headers"
@@ -391,6 +391,8 @@ def credential_kind(provider):
 
 def token(provider, target=None):
     kind = provider.get("type")
+    if credential_kind(provider) == "mediated":
+        fail(f"provider {provider_name(provider)} is mediated; token credentials are not available in the agent")
     if kind == "github-app":
         return installation_token(provider)
     if kind == "token-env":
@@ -410,6 +412,8 @@ def identity(provider, target=None):
 
 
 def headers(provider, target=None):
+    if credential_kind(provider) == "mediated":
+        fail(f"provider {provider_name(provider)} is mediated; header credentials are injected by egressd")
     if provider.get("type") == "broker":
         return broker_headers(provider, target)
     if provider.get("type") != "headers":

--- a/tests/runtime/git_host_credentials_test.go
+++ b/tests/runtime/git_host_credentials_test.go
@@ -201,6 +201,118 @@ providers:
 	}
 }
 
+func TestGitHostCredentialMediatedBrokerProviderRefusesTokenAndHeaders(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("brokerctl", "#!/usr/bin/env bash\necho should-not-run >&2\nexit 1\n")
+	config := f.writePluginConfig("git-host-credentials.yaml", `
+providers:
+  - name: fork-app-mediated
+    type: broker
+    broker-provider: fork-app
+    credential-kind: mediated
+    match:
+      - github.com/my-user/*
+`)
+	env := []string{"NVT_PLUGIN_CONFIG=" + config}
+
+	kind := strings.TrimSpace(f.runWithEnv(gitHostCredentialBin(f.root), true, env, "credential-kind", "--provider", "fork-app-mediated"))
+	if kind != "mediated" {
+		t.Fatalf("unexpected credential kind: %q", kind)
+	}
+
+	tokenOutput := f.runWithEnv(gitHostCredentialBin(f.root), false, env, "token", "--provider", "fork-app-mediated", "--target", "github.com/my-user/project")
+	if !strings.Contains(tokenOutput, "is mediated") || !strings.Contains(tokenOutput, "token credentials are not available") {
+		t.Fatalf("unexpected token failure:\n%s", tokenOutput)
+	}
+
+	headersOutput := f.runWithEnv(gitHostCredentialBin(f.root), false, env, "headers", "--provider", "fork-app-mediated", "--target", "github.com/my-user/project")
+	if !strings.Contains(headersOutput, "is mediated") || !strings.Contains(headersOutput, "injected by egressd") {
+		t.Fatalf("unexpected headers failure:\n%s", headersOutput)
+	}
+}
+
+func TestGhAuthWrapsMediatedProviderWithPlaceholderAndProxy(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("brokerctl", "#!/usr/bin/env bash\necho should-not-run >&2\nexit 1\n")
+	f.writeBin("gh", `#!/usr/bin/env bash
+set -euo pipefail
+if [ "${GH_TOKEN:-}" != "NVT-PLACEHOLDER-NOT-A-KEY" ]; then
+  echo "unexpected GH_TOKEN=${GH_TOKEN:-}" >&2
+  exit 1
+fi
+if [ "${GITHUB_TOKEN+x}" = "x" ]; then
+  echo "GITHUB_TOKEN must be unset" >&2
+  exit 1
+fi
+if [ "${GH_ENTERPRISE_TOKEN+x}" = "x" ]; then
+  echo "GH_ENTERPRISE_TOKEN must be unset" >&2
+  exit 1
+fi
+if [ "${GITHUB_ENTERPRISE_TOKEN+x}" = "x" ]; then
+  echo "GITHUB_ENTERPRISE_TOKEN must be unset" >&2
+  exit 1
+fi
+if [ "${HTTPS_PROXY:-}" != "http://127.0.0.1:8470" ]; then
+  echo "unexpected HTTPS_PROXY=${HTTPS_PROXY:-}" >&2
+  exit 1
+fi
+case ",${NO_PROXY:-}," in
+  *,github.com,*|*,.github.com,*|*,api.github.com,*)
+    echo "NO_PROXY still bypasses github: ${NO_PROXY:-}" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$*"
+`)
+	config := f.writePluginConfig("git-host-credentials.yaml", `
+providers:
+  - name: fork-app-mediated
+    type: broker
+    broker-provider: fork-app
+    credential-kind: mediated
+    match:
+      - github.com/my-user/*
+`)
+	env := []string{
+		"NVT_PLUGIN_CONFIG=" + config,
+		"NVT_EGRESS_FORWARD_PROXY_URL=http://127.0.0.1:8470",
+		"NVT_EGRESS_PLACEHOLDER=NVT-PLACEHOLDER-NOT-A-KEY",
+		"NO_PROXY=localhost,*,github.com,.github.com,api.github.com,example.test",
+		"GITHUB_TOKEN=must-not-survive",
+		"GH_ENTERPRISE_TOKEN=must-not-survive",
+		"GITHUB_ENTERPRISE_TOKEN=must-not-survive",
+	}
+
+	output := f.runWithEnv(ghAuthBin(f.root), true, env, "pr", "view", "--repo", "my-user/project")
+	if strings.TrimSpace(output) != "pr view --repo my-user/project" {
+		t.Fatalf("unexpected gh output:\n%s", output)
+	}
+}
+
+func TestGhAuthMediatedProviderRequiresManagedProxyURL(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("gh", "#!/usr/bin/env bash\necho should-not-run >&2\nexit 1\n")
+	config := f.writePluginConfig("git-host-credentials.yaml", `
+providers:
+  - name: fork-app-mediated
+    type: broker
+    broker-provider: fork-app
+    credential-kind: mediated
+    match:
+      - github.com/my-user/*
+`)
+	env := []string{
+		"NVT_PLUGIN_CONFIG=" + config,
+		"HTTPS_PROXY=http://ambient-proxy.invalid:8080",
+		"https_proxy=http://ambient-proxy.invalid:8080",
+	}
+
+	output := f.runWithEnv(ghAuthBin(f.root), false, env, "pr", "view", "--repo", "my-user/project")
+	if !strings.Contains(output, "NVT_EGRESS_FORWARD_PROXY_URL is not set") {
+		t.Fatalf("unexpected missing proxy failure:\n%s", output)
+	}
+}
+
 func TestGitCredentialsDelegatesToGitHostCredential(t *testing.T) {
 	f := newFixture(t)
 	f.writeBin("git-host-credential", `#!/usr/bin/env bash
@@ -231,6 +343,58 @@ credentials:
 	if !strings.Contains(output, "username=x-access-token") ||
 		!strings.Contains(output, "password=delegated-token") {
 		t.Fatalf("unexpected credential output:\n%s", output)
+	}
+}
+
+func TestGitCredentialsSkipsHelperForMediatedProvider(t *testing.T) {
+	f := newFixture(t)
+	logPath := filepath.Join(f.home, "git.log")
+	f.writeBin("git", `#!/usr/bin/env bash
+set -euo pipefail
+printf "%s\n" "$*" >> "$GIT_LOG"
+`)
+	f.writeBin("git-host-credential", `#!/usr/bin/env bash
+set -euo pipefail
+case "$1:$3" in
+  credential-kind:fork-app-mediated)
+    echo mediated
+    ;;
+  doctor:fork-app-mediated)
+    exit 0
+    ;;
+  *)
+    echo "unexpected git-host-credential args: $*" >&2
+    exit 1
+    ;;
+esac
+`)
+	config := f.writePluginConfig("git-credentials.yaml", `
+credentials:
+  - match: https://github.com/my-user/project
+    provider: fork-app-mediated
+`)
+	env := []string{"NVT_PLUGIN_CONFIG=" + config, "GIT_LOG=" + logPath}
+
+	output := f.runWithEnv(gitCredentialsRunBin(f.root), true, env)
+	if !strings.Contains(output, "mediated credential rule") ||
+		!strings.Contains(output, "fork-app-mediated") {
+		t.Fatalf("expected mediated rule summary, got:\n%s", output)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	log := string(logData)
+	if strings.Contains(log, "credential.helper") ||
+		strings.Contains(log, "extraHeader") {
+		t.Fatalf("mediated git credentials must not configure helper or headers:\n%s", log)
+	}
+	configData, err := os.ReadFile(filepath.Join(f.home, ".nvt-agent", "git-credentials", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(configData), "fork-app-mediated") {
+		t.Fatalf("mediated provider leaked into token helper config:\n%s", configData)
 	}
 }
 

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -743,6 +743,9 @@ code-server:
 	if !strings.Contains(envFile, `export SSL_CERT_FILE="`+bundle+`"`) {
 		t.Fatalf("SSL_CERT_FILE not pointed at the bundle:\n%s", envFile)
 	}
+	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL="http://127.0.0.1:8470"`) {
+		t.Fatalf("forward proxy URL not exported for mediated tools:\n%s", envFile)
+	}
 	meta := mustReadFile(t, filepath.Join(f.home, ".nvt-agent", "egress.json"))
 	if !strings.Contains(meta, `"forward_proxy": true`) {
 		t.Fatalf("egress.json missing forward_proxy marker:\n%s", meta)


### PR DESCRIPTION
## Summary
- add broker provider credential-kind: mediated so token/header export is refused inside the agent
- make git-credentials skip mediated providers instead of configuring a credential helper or extraHeader
- make gh-auth run mediated providers with the inert placeholder token and force GitHub traffic through NVT_EGRESS_FORWARD_PROXY_URL
- persist NVT_EGRESS_FORWARD_PROXY_URL from bootstrap and inject the k8s Service URL from the operator

## Tests
- cd tests/runtime && PATH=/private/tmp/nvt-agent-test-venv/bin:/Users/mirkosekulic/.codex/tmp/arg0/codex-arg0E8z0Sq:/Users/mirkosekulic/.local/bin:/Users/mirkosekulic/.nvm/versions/node/v22.16.0/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Users/mirkosekulic/.cargo/bin:/Users/mirkosekulic/.dotnet/tools env GOCACHE=/private/tmp/nvt-go-cache go test -run 'TestGitHostCredential|TestGitCredentials|TestGhAuth|TestBootstrapForwardProxy' .
- cd operator && env GOCACHE=/private/tmp/nvt-go-cache go test ./internal/controller -run 'TestForwardProxyAgentPodEnv|TestRenderForwardProxyEgressdConfig|TestValidateForwardProxyAdmission'
- cd tests/runtime && PATH=/private/tmp/nvt-agent-test-venv/bin:/Users/mirkosekulic/.codex/tmp/arg0/codex-arg0E8z0Sq:/Users/mirkosekulic/.local/bin:/Users/mirkosekulic/.nvm/versions/node/v22.16.0/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Users/mirkosekulic/.cargo/bin:/Users/mirkosekulic/.dotnet/tools env GOCACHE=/private/tmp/nvt-go-cache go test . (first run hit unrelated TestAfterAgentPluginsStartConcurrently timing flake; rerun passed)

## Notes
- This PR keeps direct/dev credential helper behavior unchanged.
- Local compose agents need an egress.forward-proxy block already rendered for gh-auth mediated mode; current manually migrated agents have that block. A follow-up can teach agent-init to generate forward-proxy routes automatically for local compose.