### PR TITLE
Support mediated GitHub GraphQL injection

### DIFF
--- a/broker/plugins/github_app/README.md
+++ b/broker/plugins/github_app/README.md
@@ -20,9 +20,12 @@ exactly these path shapes:
 - `/{owner}/{repo}[.git]/git-upload-pack` (POST) — fetch/clone
 - `/{owner}/{repo}[.git]/git-receive-pack` (POST) — push
 - `/repos/{owner}/{repo}/...` — REST API paths (methods per `allow.methods`)
+- `/graphql` (POST) — GraphQL API paths, only when the agent grant contains
+  exactly one concrete repository. Multi-repo and wildcard grants are rejected
+  because GraphQL has no repository in the URL for the broker to scope.
 
 git paths are answered with `authorization: Basic base64(x-access-token:<token>)`;
-API paths with `Bearer`. Every shape runs the same two-layer repo check
+API and GraphQL paths with `Bearer`. Every shape runs the same two-layer repo check
 (provider `allow.repositories` ∩ the agent grant's `repositories`) and mints a
 single-repo installation token.
 

--- a/broker/plugins/github_app/provider.py
+++ b/broker/plugins/github_app/provider.py
@@ -317,27 +317,47 @@ class GithubAppProvider:
                 return
         raise ProviderError("repo-not-allowed")
 
+    def _single_concrete_grant_repo(self, effective_repositories):
+        if effective_repositories is None:
+            raise ProviderError("repo-not-allowed", "agent grant scope is required")
+        if len(effective_repositories) != 1:
+            raise ProviderError("repo-not-allowed", "GraphQL injection requires exactly one repository in the agent grant")
+        repo = effective_repositories[0]
+        if any(char in repo for char in "*?["):
+            raise ProviderError("repo-not-allowed", "GraphQL injection requires a concrete repository grant")
+        self._ensure_repo_allowed(repo, effective_repositories)
+        return repo
+
     def injection_headers(self, host, method, path, agent_id, audit, request_id, grant=None):
         method = method.upper()
         effective_repositories = (grant or {}).get("repositories")
-        git = self._git_path(path)
-        if git is not None:
-            repo, service = git
-            if service in GIT_SERVICES:
-                if method != "POST":
-                    raise ProviderError("method-not-allowed")
-            elif method != "GET":
+        if path == "/graphql":
+            if method != "POST":
                 raise ProviderError("method-not-allowed")
-            permissions = self._git_permissions(service, grant)
-            token, expires_at = self.token_for_repo(repo, effective_repositories, permissions)
-            credentials = base64.b64encode(f"x-access-token:{token}".encode("ascii")).decode("ascii")
-            headers = {"authorization": f"Basic {credentials}"}
-        else:
             if method not in self.allowed_methods:
                 raise ProviderError("method-not-allowed")
-            repo = self._repo_from_path(path)
+            repo = self._single_concrete_grant_repo(effective_repositories)
             token, expires_at = self.token_for_repo(repo, effective_repositories)
             headers = {"authorization": f"Bearer {token}"}
+        else:
+            git = self._git_path(path)
+            if git is None:
+                if method not in self.allowed_methods:
+                    raise ProviderError("method-not-allowed")
+                repo = self._repo_from_path(path)
+                token, expires_at = self.token_for_repo(repo, effective_repositories)
+                headers = {"authorization": f"Bearer {token}"}
+            else:
+                repo, service = git
+                if service in GIT_SERVICES:
+                    if method != "POST":
+                        raise ProviderError("method-not-allowed")
+                elif method != "GET":
+                    raise ProviderError("method-not-allowed")
+                permissions = self._git_permissions(service, grant)
+                token, expires_at = self.token_for_repo(repo, effective_repositories, permissions)
+                credentials = base64.b64encode(f"x-access-token:{token}".encode("ascii")).decode("ascii")
+                headers = {"authorization": f"Basic {credentials}"}
         return headers, self._injection_expiry(expires_at), ["authorization"]
 
     def _git_path(self, path):

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -356,6 +356,7 @@ providers:
         contents: write
       methods:
         - GET
+        - POST
   - name: git-app-ro
     plugin: github-app
     config:

--- a/tests/broker/injection_git_conformance_test.go
+++ b/tests/broker/injection_git_conformance_test.go
@@ -208,7 +208,7 @@ func TestGitInjectionRepoScopeDenies(t *testing.T) {
 	f.writeRoleIdentities(gitIdentities(nil))
 
 	for _, path := range []string{
-		"/my-user/other-repo.git/info/refs", // allowed by provider, not by grant
+		"/my-user/other-repo.git/info/refs",  // allowed by provider, not by grant
 		"/evil-user/evil-repo.git/info/refs", // outside the provider allowlist
 	} {
 		status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", gitInjectionRequest("GET", path))
@@ -268,6 +268,88 @@ func TestGitInjectionAPIPathUsesBearerDialect(t *testing.T) {
 	value, _ := headers["authorization"].(string)
 	if !strings.HasPrefix(value, "Bearer token-my-repo-") {
 		t.Fatalf("API path must use Bearer dialect, got %q", value)
+	}
+}
+
+// TestGitInjectionGraphQLUsesSingleRepoGrant pins the only supported GraphQL
+// injection shape: GitHub GraphQL has no repo in the URL, so the provider can
+// mint a token only when the agent grant is a single concrete repository.
+func TestGitInjectionGraphQLUsesSingleRepoGrant(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(gitIdentities(nil))
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", gitInjectionRequest("POST", "/graphql"))
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("GraphQL injection denied: status=%d body=%v", status, body)
+	}
+	headers, _ := body["headers"].(map[string]any)
+	value, _ := headers["authorization"].(string)
+	if !strings.HasPrefix(value, "Bearer token-my-repo-") {
+		t.Fatalf("GraphQL path must use Bearer dialect, got %q", value)
+	}
+	minted := f.lastTokenRequest(t)
+	repos, _ := minted["repositories"].([]any)
+	if len(repos) != 1 || repos[0] != "my-repo" {
+		t.Fatalf("GraphQL token must be minted for the granted repo only, got %v", minted)
+	}
+}
+
+func TestGitInjectionGraphQLRejectsAmbiguousGrants(t *testing.T) {
+	tests := []struct {
+		name         string
+		repositories []string
+		method       string
+		want         string
+	}{
+		{
+			name:         "multi repo",
+			repositories: []string{"my-user/my-repo", "my-user/other-repo"},
+			method:       "POST",
+			want:         "repo-not-allowed",
+		},
+		{
+			name:         "wildcard repo",
+			repositories: []string{"my-user/*"},
+			method:       "POST",
+			want:         "repo-not-allowed",
+		},
+		{
+			name:         "wrong method",
+			repositories: []string{"my-user/my-repo"},
+			method:       "GET",
+			want:         "method-not-allowed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newBrokerFixture(t)
+			identities := gitIdentities(nil)
+			frontend := identities["frontend"]
+			frontend.Grants[0].Repositories = tt.repositories
+			identities["frontend"] = frontend
+			f.writeRoleIdentities(identities)
+
+			status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", gitInjectionRequest(tt.method, "/graphql"))
+			if status == http.StatusOK || body["ok"] == true || body["error"] != tt.want {
+				t.Fatalf("expected %s, got status=%d body=%v", tt.want, status, body)
+			}
+		})
+	}
+}
+
+func TestGitInjectionGraphQLRespectsAllowedMethods(t *testing.T) {
+	f := newBrokerFixture(t)
+	identities := gitIdentities(nil)
+	frontend := identities["frontend"]
+	frontend.Grants[0].Provider = "git-app-ro"
+	identities["frontend"] = frontend
+	f.writeRoleIdentities(identities)
+
+	request := gitInjectionRequest("POST", "/graphql")
+	request["capability"] = "git-app-ro"
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", request)
+	if status == http.StatusOK || body["ok"] == true || body["error"] != "method-not-allowed" {
+		t.Fatalf("GET-only provider must deny GraphQL POST, got status=%d body=%v", status, body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow github-app mediated injection for POST /graphql when the agent grant has exactly one concrete repository
- reject ambiguous, wildcard, and method-disallowed GraphQL grants
- document the GraphQL policy and add broker conformance coverage

## Tests
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -v . (from tests/broker)
- real nvt-dev proof: gh-auth pr view 76 --repo mirkoSekulic/nvt-agent --json number,title,url,state succeeded through mediated egress; audit showed POST /graphql injection status 200