### PR TITLE
Allow Claude MCP proxy host in mediated auth

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -100,12 +100,14 @@ providers:
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
+        - mcp-proxy.anthropic.com
       injection-extra-headers:
         anthropic-beta: oauth-2025-04-20
       placeholder-file:
         path: .claude/.credentials.json
         hosts:
           - api.anthropic.com
+          - mcp-proxy.anthropic.com
 ```
 
 Grant file-bundle providers by provider name; repositories are not used:

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -197,7 +197,7 @@ broker:
   grants:
     - provider: anthropic-main
       materialization: header-inject
-      egressHosts: [api.anthropic.com:443]
+      egressHosts: [api.anthropic.com:443, mcp-proxy.anthropic.com:443]
       quota:
         requests: 1000
 ```

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -122,8 +122,9 @@ plugin does not expand `~`).
 The agent receives only an inert placeholder `.credentials.json`
 (`accessToken`/`refreshToken` = `NVT-PLACEHOLDER-NOT-A-KEY`, far-future
 `expiresAt`, real non-secret subscription metadata copied through). `egressd`
-injects the real Bearer token on allowed `api.anthropic.com` requests. No real
-Claude credential is ever present in the agent filesystem, env, or process args.
+injects the real Bearer token on allowed Anthropic hosts such as
+`api.anthropic.com` and `mcp-proxy.anthropic.com`. No real Claude credential is
+ever present in the agent filesystem, env, or process args.
 
 Broker provider:
 
@@ -138,12 +139,14 @@ providers:
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
+        - mcp-proxy.anthropic.com
       injection-extra-headers:
         anthropic-beta: oauth-2025-04-20
       placeholder-file:
         path: .claude/.credentials.json
         hosts:
           - api.anthropic.com
+          - mcp-proxy.anthropic.com
 ```
 
 Agent + paired egress identity:

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -471,12 +471,14 @@ providers:
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
+        - mcp-proxy.anthropic.com
       injection-extra-headers:
         anthropic-beta: oauth-2025-04-20
       placeholder-file:
         path: .claude/.credentials.json
         hosts:
           - api.anthropic.com
+          - mcp-proxy.anthropic.com
 `, f.fake.server.URL, perPage, maxResponseBytes, repoLines.String(), methods, f.codexClaimHeaders, f.auth, f.oauth.server.URL, f.codexExtraConfig, f.extra, f.claudeCreds)
 	path := filepath.Join(f.home, "broker.yaml")
 	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {

--- a/tests/broker/claude_auth_conformance_test.go
+++ b/tests/broker/claude_auth_conformance_test.go
@@ -88,7 +88,7 @@ func TestClaudePlaceholderFileMaterializesWithoutRealSecrets(t *testing.T) {
 	}
 
 	hosts, ok := body["hosts"].([]any)
-	if !ok || len(hosts) != 1 || hosts[0] != "api.anthropic.com" {
+	if !ok || len(hosts) != 2 || hosts[0] != "api.anthropic.com" || hosts[1] != "mcp-proxy.anthropic.com" {
 		t.Fatalf("unexpected host bindings: %v", body["hosts"])
 	}
 }
@@ -181,6 +181,17 @@ func TestClaudeInjectionIsEgressIdentityScoped(t *testing.T) {
 	}
 	if !strip["authorization"] || !strip["anthropic-beta"] {
 		t.Fatalf("every injected header must be stripped, got %v", body["strip_request_headers"])
+	}
+
+	mcpReq := map[string]any{
+		"capability": "claude-main",
+		"host":       "mcp-proxy.anthropic.com",
+		"method":     "POST",
+		"path":       "/v1/mcp",
+	}
+	status, body = f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", mcpReq)
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("paired egress must obtain injection headers for Claude MCP proxy: status=%d body=%v", status, body)
 	}
 
 	// The agent holding the grant may not obtain injectable headers.


### PR DESCRIPTION
## Summary
- include mcp-proxy.anthropic.com in mediated Claude OAuth host examples
- update broker fixtures so Claude placeholder files are bound to both Anthropic hosts
- add conformance coverage that Claude injection works for mcp-proxy.anthropic.com

## Tests
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -v . (from tests/broker)
- local nvtclaude check: proxied curl to https://mcp-proxy.anthropic.com/ through egressd returned upstream 404 and egressd logged decision=allow instead of target_not_allowed