### PR TITLE
Fix Claude OAuth refresh request shape

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -81,8 +81,6 @@ providers:
     plugin: claude-oauth
     config:
       credentials-file: /broker-secrets/claude/.credentials.json
-      token-url: https://platform.claude.com/v1/oauth/token
-      client-id: <claude-code-oauth-client-id>
       refresh-margin-seconds: 600
 ```
 
@@ -95,8 +93,6 @@ providers:
     plugin: claude-oauth
     config:
       credentials-file: /broker-secrets/claude/.credentials.json
-      token-url: https://platform.claude.com/v1/oauth/token
-      client-id: <claude-code-oauth-client-id>
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
@@ -109,6 +105,14 @@ providers:
           - api.anthropic.com
           - mcp-proxy.anthropic.com
 ```
+
+`claude-oauth` defaults to the Claude Code OAuth request shape observed in
+Claude Code CLI 2.1.202: `https://console.anthropic.com/v1/oauth/token`,
+client id `9d1c250a-e61b-44d9-88ed-5944d1962f5e`,
+`anthropic-beta: oauth-2025-04-20`, and `User-Agent: claude-code/2.1.202`.
+These values are not user/subscription secrets and can be overridden with
+`token-url`, `client-id` / `client-id-env`, `oauth-beta`, and `user-agent` if
+Anthropic changes the CLI OAuth app or endpoint.
 
 Grant file-bundle providers by provider name; repositories are not used:
 
@@ -185,9 +189,10 @@ For `claude-oauth`, mediated placeholder bundles contain no real Claude tokens;
 the broker owns and refreshes the canonical `claudeAiOauth` access/refresh
 tokens when `credentials-file` is used. `credentials-env` is read-only and
 fails loudly if a refresh would be required. The refresh path is implemented
-and conformance-tested against the broker's fake OAuth endpoint; real Claude
-endpoint/client-id proof is still required before treating mediated Claude
-refresh as production-ready.
+and conformance-tested against the broker's fake OAuth endpoint. The default
+endpoint/client-id/header values are observed from Claude Code CLI, but a real
+refresh proof should still be run in the target environment before treating
+mediated Claude refresh as production-ready.
 The broker applies file-bundle TTL caps to returned `expires_at` metadata so
 runtime refreshers can re-materialize bundles on a bounded cadence. For
 `codex-oauth`, this does not reduce the lifetime of an already-issued OpenAI

--- a/broker/plugins/claude_oauth/provider.py
+++ b/broker/plugins/claude_oauth/provider.py
@@ -38,7 +38,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from broker.core.config import env_value, fail, injection_hosts, list_value, string_value
@@ -51,7 +51,13 @@ from broker.plugins.placeholder_file import (
 
 
 DEFAULT_FILE_NAME = ".credentials.json"
-DEFAULT_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+# Observed from Claude Code CLI 2.1.202. This is a public OAuth client
+# identifier for the Claude Code application, not a user/subscription secret.
+# Keep it overrideable because Anthropic does not document it as stable.
+DEFAULT_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+DEFAULT_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+DEFAULT_OAUTH_BETA = "oauth-2025-04-20"
+DEFAULT_USER_AGENT = "claude-code/2.1.202"
 DEFAULT_REFRESH_MARGIN_SECONDS = 600
 DEFAULT_BUNDLE_TTL_SECONDS = 1200
 
@@ -87,7 +93,9 @@ class ClaudeOAuthProvider:
         parsed = urlparse(self.token_url)
         if parsed.scheme not in {"http", "https"} or not parsed.hostname:
             fail(f"provider {self.name} config.token-url must be an http(s) URL")
-        self.client_id = self._provider_value("client-id", required=False)
+        self.client_id = self._provider_value("client-id", DEFAULT_CLIENT_ID, required=False)
+        self.oauth_beta = self._provider_value("oauth-beta", DEFAULT_OAUTH_BETA, required=False)
+        self.user_agent = self._provider_value("user-agent", DEFAULT_USER_AGENT, required=False)
         self.refresh_margin_seconds = self._int_config("refresh-margin-seconds", DEFAULT_REFRESH_MARGIN_SECONDS)
         self.bundle_ttl_seconds = self._int_config("bundle-ttl-seconds", DEFAULT_BUNDLE_TTL_SECONDS)
         self.files_refresh_margin_seconds = max(self.refresh_margin_seconds, self.bundle_ttl_seconds)
@@ -281,7 +289,7 @@ class ClaudeOAuthProvider:
             )
             return refreshed_data, refreshed_oauth, refreshed_access_token, refreshed_exp, True
         except ProviderError as error:
-            if error.reason in {"credentials-source-not-writable", "token-refresh-not-configured"}:
+            if error.reason == "credentials-source-not-writable":
                 raise
             if exp <= now:
                 raise
@@ -289,12 +297,6 @@ class ClaudeOAuthProvider:
             return data, oauth, access_token, exp, False
 
     def _refresh(self, data, oauth):
-        if not self.client_id:
-            raise ProviderError(
-                "token-refresh-not-configured",
-                f"Claude provider {self.name} requires client-id or client-id-env before OAuth refresh",
-                502,
-            )
         if self.credentials_file is None:
             raise ProviderError(
                 "credentials-source-not-writable",
@@ -302,7 +304,7 @@ class ClaudeOAuthProvider:
                 502,
             )
         refresh_token = self._refresh_token(oauth)
-        body = urlencode({
+        body = json.dumps({
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
             "client_id": self.client_id,
@@ -311,7 +313,12 @@ class ClaudeOAuthProvider:
             self.token_url,
             method="POST",
             data=body,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "anthropic-beta": self.oauth_beta,
+                "User-Agent": self.user_agent,
+            },
         )
         try:
             with urlopen(request, timeout=30) as response:

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -66,11 +66,20 @@ Point the provider at the credential with exactly one of:
 - `credentials-env`: the name of an env var holding the JSON (broker sidecar /
   Kubernetes secret). No host path required.
 
-Set `client-id` (or `client-id-env`) for automatic refresh. Existing static
-broker-side credentials can still be read without it, but any refresh attempt
-fails closed with `token-refresh-not-configured` until the Claude OAuth client id
-is configured. The Claude `.credentials.json` file does not carry that client
-id; operators must source it from their Claude Code OAuth client metadata.
+`claude-oauth` defaults to the Claude Code OAuth token URL, public client id,
+OAuth beta header, and user-agent observed in Claude Code CLI 2.1.202:
+
+- `token-url`: `https://console.anthropic.com/v1/oauth/token`
+- `client-id`: `9d1c250a-e61b-44d9-88ed-5944d1962f5e`
+- `oauth-beta`: `oauth-2025-04-20`
+- `user-agent`: `claude-code/2.1.202`
+
+The client id identifies the Claude Code OAuth application, not your
+subscription. It is not a secret, and the Claude `.credentials.json` file does
+not carry it. Anthropic does not document these observed values as a stability
+contract, so production deployments can override them with `token-url`,
+`client-id` / `client-id-env`, `oauth-beta`, and `user-agent` if Claude Code
+changes.
 
 To seed a local dev credential, log in with Claude Code once on a trusted host
 and copy the resulting `~/.claude/.credentials.json` to the broker-side path.
@@ -89,8 +98,6 @@ providers:
     plugin: claude-oauth
     config:
       credentials-file: /broker-secrets/claude/.credentials.json
-      token-url: https://platform.claude.com/v1/oauth/token
-      client-id: <claude-code-oauth-client-id>
       refresh-margin-seconds: 600
 ```
 
@@ -134,8 +141,6 @@ providers:
     plugin: claude-oauth
     config:
       credentials-file: /broker-secrets/claude/.credentials.json
-      token-url: https://platform.claude.com/v1/oauth/token
-      client-id: <claude-code-oauth-client-id>
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
@@ -193,10 +198,11 @@ These are pinned by `tests/broker/claude_auth_conformance_test.go` and
 
 The broker implements Claude OAuth refresh before file-bundle vending,
 placeholder-file vending, and edge injection when `claudeAiOauth.expiresAt` is
-within `refresh-margin-seconds`. Successful refresh uses the configured
-`token-url`, `client-id` (or `client-id-env`), and broker-owned `refreshToken`,
-then persists the new `accessToken`, rotated `refreshToken` when returned,
-`expiresAt`, optional scope metadata, and `last_refresh`.
+within `refresh-margin-seconds`. Successful refresh uses the configured or
+default `token-url`, `client-id` (or `client-id-env`), `oauth-beta`,
+`user-agent`, and broker-owned `refreshToken`, then persists the new
+`accessToken`, rotated `refreshToken` when returned, `expiresAt`, optional scope
+metadata, and `last_refresh`.
 
 This is required for mediated mode: the agent receives only placeholder
 credentials, so it cannot self-refresh. If refresh fails while the current
@@ -209,18 +215,18 @@ a refresh would be required, the provider fails with
 `credentials-source-not-writable` instead of rotating a refresh token into
 nowhere.
 
-### Real endpoint proof gap
+### Real refresh proof gap
 
 The refresh path is conformance-tested against the broker's fake OAuth endpoint:
 request shape, refresh-token rotation, valid-token fallback, expired-token
 failure, injection reuse, and placeholder non-leakage are all covered. This repo
-has not yet committed a manual proof that
-`https://platform.claude.com/v1/oauth/token` accepts the exact request shape for
-a real Claude Code credential, nor a repo-owned way to derive the required
-client id from `.credentials.json` itself.
+has not yet committed a manual proof that the observed Claude Code OAuth
+defaults successfully refresh a real Claude Code credential in a target
+environment.
 
 Before treating mediated Claude refresh as production-ready, run a real
-broker-side refresh proof with a copied Claude credential and configured
-`client-id`/`client-id-env`, and verify that `expiresAt` and token material
-change only in the broker-owned credentials file without appearing in agent
-placeholder files, audit logs, or responses.
+broker-side refresh proof with a copied Claude credential, and verify that
+`expiresAt` and token material change only in the broker-owned credentials file
+without appearing in agent placeholder files, audit logs, or responses. If
+Anthropic changes the Claude Code OAuth app, set `client-id`/`client-id-env`,
+`token-url`, `oauth-beta`, or `user-agent` explicitly.

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -409,14 +409,14 @@ Rules:
   every request (so external rotation is picked up), refreshed when
   `expiresAt` is within `refresh-margin-seconds`, and persisted when the source
   is `credentials-file`.
-- The implemented broker refresh contract uses `grant_type=refresh_token`, the
-  configured `client-id`, `token-url`, and current canonical refresh token. It
-  updates `accessToken`, rotated `refreshToken` when returned, `expiresAt`,
+- The implemented broker refresh contract uses JSON
+  `grant_type=refresh_token`, the configured or default `client-id`,
+  `token-url`, `oauth-beta`, `user-agent`, and current canonical refresh token.
+  It updates `accessToken`, rotated `refreshToken` when returned, `expiresAt`,
   optional scope metadata, and `last_refresh`, then atomically replaces the
   canonical credentials file. This contract is conformance-tested against the
-  broker's fake OAuth endpoint; real Claude Code endpoint/client-id
-  verification is still required before treating mediated Claude refresh as
-  production-ready.
+  broker's fake OAuth endpoint; real Claude Code refresh verification is still
+  required before treating mediated Claude refresh as production-ready.
 - If refresh fails while the current access token is still valid, the provider
   serves the current token and records metadata-only audit. If the token is
   expired, the request fails closed with `token-refresh-failed`.
@@ -447,8 +447,6 @@ providers:
     plugin: claude-oauth
     config:
       credentials-file: /state/claude/.credentials.json
-      token-url: https://platform.claude.com/v1/oauth/token
-      client-id: <claude-code-oauth-client-id>
       refresh-margin-seconds: 600
       injection-hosts:
         - api.anthropic.com
@@ -463,25 +461,27 @@ providers:
 Default Claude OAuth settings:
 
 ```yaml
-token-url: https://platform.claude.com/v1/oauth/token
+token-url: https://console.anthropic.com/v1/oauth/token
+client-id: 9d1c250a-e61b-44d9-88ed-5944d1962f5e
+oauth-beta: oauth-2025-04-20
+user-agent: claude-code/2.1.202
 refresh-margin-seconds: 600
 bundle-ttl-seconds: 1200
 ```
 
-`client-id` (or `client-id-env`) is required before refresh can occur because
-the Claude OAuth client id is deployment/client specific; a refresh attempt
-without it fails with `token-refresh-not-configured`. Mediated Claude requires
-broker-side refresh: the agent receives only placeholder credentials and cannot
-self-refresh.
+The default client id is the public Claude Code OAuth application id observed in
+Claude Code CLI 2.1.202, not a user/subscription secret. Anthropic does not
+document it as a stability contract, so deployments can override it with
+`client-id`/`client-id-env` if the CLI OAuth app changes. Mediated Claude
+requires broker-side refresh: the agent receives only placeholder credentials
+and cannot self-refresh.
 
-**Real endpoint proof gap.** The broker-side refresh implementation is covered
+**Real refresh proof gap.** The broker-side refresh implementation is covered
 by local conformance tests for request shape, rotation persistence, fallback,
 and non-leakage. This repository has not yet committed a manual proof that the
-default Claude token endpoint accepts this exact request shape for a real
-Claude Code credential, nor a repo-owned source for the required client id.
-Operators must configure `client-id`/`client-id-env` from their Claude Code
-OAuth client metadata and verify refresh in their environment before relying on
-production mediated Claude refresh.
+observed Claude Code OAuth defaults refresh a real Claude Code credential in a
+target environment. Operators should verify refresh in their environment before
+relying on production mediated Claude refresh.
 
 ## Static Token And Header Providers
 

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -50,16 +50,30 @@ func (f *fakeOAuth) handleToken(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method", http.StatusMethodNotAllowed)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+	request := map[string]string{}
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		request["grant_type"] = payload["grant_type"]
+		request["client_id"] = payload["client_id"]
+		request["refresh_token"] = payload["refresh_token"]
+		request["content_type"] = "application/json"
+		request["anthropic_beta"] = r.Header.Get("anthropic-beta")
+		request["user_agent"] = r.Header.Get("User-Agent")
+	} else {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		request["grant_type"] = r.Form.Get("grant_type")
+		request["client_id"] = r.Form.Get("client_id")
+		request["refresh_token"] = r.Form.Get("refresh_token")
+		request["content_type"] = "form"
 	}
 	f.mu.Lock()
-	request := map[string]string{
-		"grant_type":    r.Form.Get("grant_type"),
-		"client_id":     r.Form.Get("client_id"),
-		"refresh_token": r.Form.Get("refresh_token"),
-	}
 	f.requests = append(f.requests, request)
 	count := len(f.requests)
 	fail := f.fail

--- a/tests/broker/claude_auth_conformance_test.go
+++ b/tests/broker/claude_auth_conformance_test.go
@@ -311,6 +311,11 @@ func TestClaudeOAuthRefreshPersistsRotatedTokenForFileBundles(t *testing.T) {
 	if request["grant_type"] != "refresh_token" || request["client_id"] != "test-claude-client" || request["refresh_token"] != "real-claude-refresh-token-secret" {
 		t.Fatalf("unexpected Claude refresh request metadata: %#v", request)
 	}
+	if request["content_type"] != "application/json" ||
+		request["anthropic_beta"] != "oauth-2025-04-20" ||
+		request["user_agent"] != "claude-code/2.1.202" {
+		t.Fatalf("Claude refresh must use the Claude Code JSON OAuth shape, got %#v", request)
+	}
 
 	var canonical map[string]any
 	decodeJSONFile(t, f.claudeCreds, &canonical)

--- a/tests/broker/placeholder_config_validation_test.go
+++ b/tests/broker/placeholder_config_validation_test.go
@@ -226,10 +226,11 @@ raise SystemExit("expected credentials-source-not-writable")
 	}
 }
 
-// TestClaudeRefreshRequiresClientID pins the compatibility boundary: a legacy
-// Claude provider can still load without client-id, but refresh fails loudly
-// before any token exchange can be attempted.
-func TestClaudeRefreshRequiresClientID(t *testing.T) {
+// TestClaudeDefaultsMatchObservedClaudeCodeOAuth pins the provider defaults for
+// the observed Claude Code OAuth app. They are overrideable because Anthropic
+// does not document them as stable, but local/dev config can refresh without
+// forcing every operator to duplicate the current public client id.
+func TestClaudeDefaultsMatchObservedClaudeCodeOAuth(t *testing.T) {
 	out, err := runBrokerPython(t, `
 import json, tempfile, time
 from broker.plugins.claude_oauth.provider import ClaudeOAuthProvider
@@ -242,20 +243,20 @@ handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
 json.dump(creds, handle); handle.close()
 provider = ClaudeOAuthProvider({"name": "claude-main", "config": {
     "credentials-file": handle.name,
-    "token-url": "http://127.0.0.1:1/token",
 }})
-try:
-    provider.files("agent", None, "rid")
-except Exception as exc:
-    print("REJECTED:", getattr(exc, "reason", type(exc).__name__), exc)
-    raise SystemExit(0)
-raise SystemExit("expected token-refresh-not-configured")
+print("CLIENT_ID", provider.client_id)
+print("TOKEN_URL", provider.token_url)
+print("OAUTH_BETA", provider.oauth_beta)
+print("USER_AGENT", provider.user_agent)
 `)
 	if err != nil {
-		t.Fatalf("expected clean rejection, got err=%v out=%s", err, out)
+		t.Fatalf("expected clean defaults, got err=%v out=%s", err, out)
 	}
-	if !strings.Contains(out, "REJECTED") || !strings.Contains(out, "token-refresh-not-configured") {
-		t.Fatalf("expected token-refresh-not-configured rejection, got %s", out)
+	if !strings.Contains(out, "CLIENT_ID 9d1c250a-e61b-44d9-88ed-5944d1962f5e") ||
+		!strings.Contains(out, "TOKEN_URL https://console.anthropic.com/v1/oauth/token") ||
+		!strings.Contains(out, "OAUTH_BETA oauth-2025-04-20") ||
+		!strings.Contains(out, "USER_AGENT claude-code/2.1.202") {
+		t.Fatalf("expected observed Claude Code OAuth defaults, got %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- update claude-oauth defaults to the observed Claude Code OAuth token URL, public client id, beta header, and user-agent
- switch Claude OAuth refresh to JSON request shape while keeping all values overrideable
- update docs/protocol and broker conformance coverage for the observed request shape

## Tests
- python3 -m py_compile broker/plugins/claude_oauth/provider.py
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 . (from tests/broker)

## Notes
- Real refresh proof reached Claude OAuth behavior but was rate-limited (HTTP 429), so the docs still require an environment refresh proof before treating mediated Claude refresh as production-ready.