### PR TITLE
Support explicit mediated capability selection

### DIFF
--- a/egressd/internal/egress/config.go
+++ b/egressd/internal/egress/config.go
@@ -274,7 +274,7 @@ func (c *Config) validateForwardProxyRouteOverlap() error {
 			blindHosts[normalized] = true
 		}
 	}
-	injectHosts := map[string]bool{}
+	injectHostCapabilities := map[string]bool{}
 	for index, route := range c.ForwardProxy.InjectRoutes {
 		host, err := normalizeProxyHost(route.Host)
 		if err != nil {
@@ -292,13 +292,14 @@ func (c *Config) validateForwardProxyRouteOverlap() error {
 		if route.MaxRequests < 0 {
 			return fmt.Errorf("forward_proxy.inject_routes[%d].max_requests must be non-negative", index)
 		}
-		if injectHosts[host] {
-			return fmt.Errorf("forward_proxy.inject_routes[%d].host %q is duplicated", index, route.Host)
+		hostCapability := host + "\x00" + route.Capability
+		if injectHostCapabilities[hostCapability] {
+			return fmt.Errorf("forward_proxy.inject_routes[%d].host %q and capability %q are duplicated", index, route.Host, route.Capability)
 		}
 		if blindHosts[host] || routeHosts[host] {
 			return fmt.Errorf("forward_proxy.inject_routes[%d].host %q overlaps a blind-tunnel or mediated route host", index, route.Host)
 		}
-		injectHosts[host] = true
+		injectHostCapabilities[hostCapability] = true
 	}
 	return nil
 }

--- a/egressd/internal/egress/config_forward_proxy_test.go
+++ b/egressd/internal/egress/config_forward_proxy_test.go
@@ -48,3 +48,26 @@ func TestLoadForwardProxyInjectConfig(t *testing.T) {
 		t.Fatal("inject routes without a ca block must be rejected")
 	}
 }
+
+func TestForwardProxyInjectRoutesAllowSameHostWithExplicitCapabilities(t *testing.T) {
+	base := &Config{
+		BrokerURL: "https://broker:7347",
+		Routes:    []Route{},
+		CA:        &CAConfig{ServeAddr: "0.0.0.0:8470"},
+		ForwardProxy: &ForwardProxyConfig{
+			Listen: "0.0.0.0:8473",
+			InjectRoutes: []ForwardProxyInjectRoute{
+				{Host: "api.github.com", Capability: "github-main-app", Upstream: "api.github.com:443"},
+				{Host: "api.github.com", Capability: "github-altinn-app", Upstream: "api.github.com:443"},
+			},
+		},
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("same host with distinct capabilities should be valid: %v", err)
+	}
+
+	base.ForwardProxy.InjectRoutes[1].Capability = "github-main-app"
+	if err := base.Validate(); err == nil {
+		t.Fatal("same host with duplicate capability must be rejected")
+	}
+}

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"bufio"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
@@ -44,7 +45,12 @@ type ForwardProxy struct {
 	allowHosts    map[string]bool
 	allowPorts    map[int]bool
 	tunnelSlots   chan struct{}
-	injectProxies map[string]*Proxy
+	injectProxies map[string][]injectProxy
+}
+
+type injectProxy struct {
+	capability string
+	proxy      *Proxy
 }
 
 func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +67,13 @@ func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// A CONNECT to an inject-route host is TLS-terminated and injected; every
 	// other host falls through to the blind-tunnel allowlist.
-	if proxy := p.injectProxy(target.host); proxy != nil {
+	proxy, found, err := p.injectProxy(target.host, capabilityHintFromConnect(r))
+	if err != nil {
+		p.writeDecision(target.host, target.port, "deny", "capability_not_allowed")
+		http.Error(w, "CONNECT capability not allowed", http.StatusForbidden)
+		return
+	}
+	if found {
 		p.serveMITM(w, target, proxy)
 		return
 	}
@@ -235,32 +247,73 @@ func (p *ForwardProxy) init() {
 			p.allowPorts[port] = true
 		}
 		p.tunnelSlots = make(chan struct{}, p.Config.effectiveMaxConcurrentTunnels())
-		p.injectProxies = map[string]*Proxy{}
+		p.injectProxies = map[string][]injectProxy{}
 		for _, route := range p.Config.InjectRoutes {
 			host, err := normalizeProxyHost(route.Host)
 			if err != nil {
 				p.writeInvalidAllowHost(route.Host)
 				continue
 			}
-			p.injectProxies[host] = &Proxy{
-				Route: Route{
-					Capability:            route.Capability,
-					Upstream:              route.Upstream,
-					AllowInsecureUpstream: route.AllowInsecureUpstream,
-					MaxRequests:           route.MaxRequests,
+			p.injectProxies[host] = append(p.injectProxies[host], injectProxy{
+				capability: route.Capability,
+				proxy: &Proxy{
+					Route: Route{
+						Capability:            route.Capability,
+						Upstream:              route.Upstream,
+						AllowInsecureUpstream: route.AllowInsecureUpstream,
+						MaxRequests:           route.MaxRequests,
+					},
+					Broker:             p.Broker,
+					Transport:          p.Transport,
+					Reporter:           p.Reporter,
+					UpgradeIdleTimeout: p.Config.effectiveTunnelIdleTimeout(),
 				},
-				Broker:             p.Broker,
-				Transport:          p.Transport,
-				Reporter:           p.Reporter,
-				UpgradeIdleTimeout: p.Config.effectiveTunnelIdleTimeout(),
-			}
+			})
 		}
 	})
 }
 
-func (p *ForwardProxy) injectProxy(host string) *Proxy {
+func (p *ForwardProxy) injectProxy(host, capabilityHint string) (*Proxy, bool, error) {
 	p.init()
-	return p.injectProxies[host]
+	routes := p.injectProxies[host]
+	if len(routes) == 0 {
+		return nil, false, nil
+	}
+	if capabilityHint != "" {
+		for _, route := range routes {
+			if route.capability == capabilityHint {
+				return route.proxy, true, nil
+			}
+		}
+		return nil, true, fmt.Errorf("capability %q is not configured for host %s", capabilityHint, host)
+	}
+	if len(routes) == 1 {
+		return routes[0].proxy, true, nil
+	}
+	return nil, true, fmt.Errorf("host %s has multiple injectable capabilities and requires an explicit capability hint", host)
+}
+
+func capabilityHintFromConnect(r *http.Request) string {
+	if value := strings.TrimSpace(r.Header.Get("X-NVT-Capability")); value != "" {
+		return value
+	}
+	value := strings.TrimSpace(r.Header.Get("Proxy-Authorization"))
+	if value == "" {
+		return ""
+	}
+	const prefix = "Basic "
+	if len(value) < len(prefix) || !strings.EqualFold(value[:len(prefix)], prefix) {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value[len(prefix):]))
+	if err != nil {
+		return ""
+	}
+	user, _, ok := strings.Cut(string(decoded), ":")
+	if !ok {
+		return ""
+	}
+	return user
 }
 
 func (p *ForwardProxy) writeInvalidAllowHost(host string) {

--- a/egressd/internal/egress/forward_proxy_mitm_test.go
+++ b/egressd/internal/egress/forward_proxy_mitm_test.go
@@ -8,6 +8,7 @@ package egress
 import (
 	"bufio"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -42,8 +43,18 @@ func newMITMProxy(t *testing.T, broker *fakeBroker, route ForwardProxyInjectRout
 // the tunnel, validating the minted leaf against the given SNI.
 func mitmDial(t *testing.T, proxy *httptest.Server, ca *CA, connectHost, sni string) *tls.Conn {
 	t.Helper()
+	return mitmDialWithCapability(t, proxy, ca, connectHost, sni, "")
+}
+
+func mitmDialWithCapability(t *testing.T, proxy *httptest.Server, ca *CA, connectHost, sni, capability string) *tls.Conn {
+	t.Helper()
+	extra := ""
+	if capability != "" {
+		token := base64.StdEncoding.EncodeToString([]byte(capability + ":"))
+		extra = "Proxy-Authorization: Basic " + token + "\r\n"
+	}
 	conn, status := sendRawProxyRequest(t, proxyAddress(t, proxy), fmt.Sprintf(
-		"CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n\r\n", connectHost, connectHost))
+		"CONNECT %s:443 HTTP/1.1\r\nHost: %s:443\r\n%s\r\n", connectHost, connectHost, extra))
 	if !strings.Contains(status, "200") {
 		_ = conn.Close()
 		t.Fatalf("CONNECT status = %q", status)
@@ -85,6 +96,51 @@ func TestForwardProxyMITMInjectsRealToken(t *testing.T) {
 	}
 	if record.path != "/v1/responses?stream=true" {
 		t.Fatalf("upstream path = %q, want the preserved request path", record.path)
+	}
+}
+
+func TestForwardProxyMITMRequiresCapabilityForAmbiguousHost(t *testing.T) {
+	broker := newFakeBroker(t)
+	upstream := newFakeUpstream(t)
+	ca, err := NewCAWithUpstreams(nil, []string{"api.github.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := &ForwardProxy{
+		Config: ForwardProxyConfig{
+			Listen: "unused",
+			InjectRoutes: []ForwardProxyInjectRoute{
+				{Host: "api.github.com", Capability: "github-main-app", Upstream: proxyAddress(t, upstream.server), AllowInsecureUpstream: true},
+				{Host: "api.github.com", Capability: "github-altinn-app", Upstream: proxyAddress(t, upstream.server), AllowInsecureUpstream: true},
+			},
+		},
+		CA:        ca,
+		Broker:    &BrokerClient{URL: broker.server.URL, Token: "egress-role-token", Client: broker.server.Client()},
+		Transport: http.DefaultTransport,
+	}
+	server := httptest.NewServer(fp)
+	t.Cleanup(server.Close)
+
+	conn, status := sendRawProxyRequest(t, proxyAddress(t, server),
+		"CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n")
+	_ = conn.Close()
+	if !strings.Contains(status, "403") {
+		t.Fatalf("ambiguous CONNECT without capability status = %q, want 403", status)
+	}
+
+	tlsConn := mitmDialWithCapability(t, server, ca, "api.github.com", "api.github.com", "github-altinn-app")
+	fmt.Fprintf(tlsConn, "GET /repos/Altinn/altinn-studio/pulls/1 HTTP/1.1\r\nHost: api.github.com\r\nAuthorization: Bearer %s\r\nConnection: close\r\n\r\n", Placeholder)
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), nil)
+	if err != nil {
+		t.Fatalf("read selected MITM response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("selected MITM request status = %d", resp.StatusCode)
+	}
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if len(broker.requests) != 1 || broker.requests[0]["capability"] != "github-altinn-app" {
+		t.Fatalf("broker requests = %#v, want selected github-altinn-app capability", broker.requests)
 	}
 }
 

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2849,9 +2849,17 @@ func InjectMediatedEgressConfig(config map[string]any, agentRun *nvtv1alpha1.Age
 	routeIndex := 0
 	for _, grant := range AgentRunBrokerGrants(agentRun.Spec.Broker) {
 		// In forward-proxy mode header-inject grants are reached through the
-		// proxy (HTTP(S)_PROXY), not a per-route base URL, so bootstrap renders
-		// no base-url redirect for them.
-		if forwardProxy || AgentRunGrantMaterialization(grant) != nvtv1alpha1.AgentRunGrantHeaderInject {
+		// proxy (HTTP(S)_PROXY), not a per-route base URL. Still render the
+		// grant metadata so runtime.proxy.provider can validate the selected
+		// provider against egress.grants.
+		if forwardProxy && AgentRunGrantMaterialization(grant) == nvtv1alpha1.AgentRunGrantHeaderInject {
+			grants = append(grants, map[string]any{
+				"provider":        grant.Provider,
+				"materialization": string(nvtv1alpha1.AgentRunGrantHeaderInject),
+			})
+			continue
+		}
+		if AgentRunGrantMaterialization(grant) != nvtv1alpha1.AgentRunGrantHeaderInject {
 			continue
 		}
 		baseURL := fmt.Sprintf("http://127.0.0.1:%d", egressRouteBasePort+routeIndex)

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -2463,16 +2463,20 @@ func ValidateAgentRunEgressMode(agentRun *nvtv1alpha1.AgentRun) error {
 		// Mirror egressd's inject-route rules at admission so a config egressd
 		// would reject at boot fails loudly here instead of CrashLooping a
 		// silently-broken run: MITM hosts must be DNS names (SNI/leaf need a
-		// name), and each normalized host maps to exactly one inject route.
-		claimedBy := map[string]string{}
+		// name), and each normalized host/capability pair is unique. A host may
+		// map to more than one capability; egressd then requires an explicit
+		// non-secret capability hint on the CONNECT request and fails closed
+		// without one.
+		claimedBy := map[string]bool{}
 		for _, inject := range injects {
 			if net.ParseIP(inject.Host) != nil {
 				return fmt.Errorf("forward-proxy egressHost %q must be a DNS name, not an IP (TLS-MITM needs a name for SNI/leaf)", inject.Host)
 			}
-			if existing, ok := claimedBy[inject.Host]; ok {
-				return fmt.Errorf("forward-proxy host %q is claimed by more than one grant/egressHost (%s and %s); each host maps to exactly one inject route", inject.Host, existing, inject.Capability)
+			key := inject.Host + "\x00" + inject.Capability
+			if claimedBy[key] {
+				return fmt.Errorf("forward-proxy host %q is duplicated for broker grant %s", inject.Host, inject.Capability)
 			}
-			claimedBy[inject.Host] = inject.Capability
+			claimedBy[key] = true
 		}
 		return nil
 	}

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -4032,6 +4032,27 @@ func TestForwardProxyAgentPodEnv(t *testing.T) {
 	}
 }
 
+func TestForwardProxyHeaderInjectGrantIsRenderedForRuntimeProxyValidation(t *testing.T) {
+	agentRun := forwardProxyAgentRun()
+	agentRun.Spec.Broker.Grants = []nvtv1alpha1.AgentRunBrokerGrant{{
+		Provider: "static-bearer-main", Materialization: nvtv1alpha1.AgentRunGrantHeaderInject,
+		EgressHosts: []string{"api.example.test:443"},
+	}}
+	config := InjectMediatedEgressConfig(map[string]any{}, agentRun)
+	egress, _ := config["egress"].(map[string]any)
+	grants, _ := egress["grants"].([]any)
+	if len(grants) != 1 {
+		t.Fatalf("expected one rendered egress grant, got %#v", grants)
+	}
+	grant, _ := grants[0].(map[string]any)
+	if grant["provider"] != "static-bearer-main" || grant["materialization"] != string(nvtv1alpha1.AgentRunGrantHeaderInject) {
+		t.Fatalf("unexpected rendered grant: %#v", grant)
+	}
+	if _, ok := grant["base-url"]; ok {
+		t.Fatalf("forward-proxy header-inject grant must not render redirect base-url: %#v", grant)
+	}
+}
+
 // TestValidateForwardProxyMirrorsEgressdRules pins that the operator rejects
 // forward-proxy configs that egressd's config.Validate would reject at boot
 // (duplicate host+capability, IP-literal hosts), so a bad spec fails loudly at

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -4032,26 +4032,28 @@ func TestForwardProxyAgentPodEnv(t *testing.T) {
 	}
 }
 
-// TestValidateForwardProxyMirrorsEgressdRules pins review findings 2 & 3: the
-// operator rejects forward-proxy configs that egressd's config.Validate would
-// reject at boot (duplicate normalized inject hosts, IP-literal hosts), so a
-// bad spec fails loudly at admission instead of CrashLooping egressd.
+// TestValidateForwardProxyMirrorsEgressdRules pins that the operator rejects
+// forward-proxy configs that egressd's config.Validate would reject at boot
+// (duplicate host+capability, IP-literal hosts), so a bad spec fails loudly at
+// admission instead of CrashLooping egressd.
 func TestValidateForwardProxyMirrorsEgressdRules(t *testing.T) {
-	// Duplicate normalized host across egressHosts of one grant.
+	// Duplicate normalized host for the same grant/capability.
 	dupWithinGrant := forwardProxyAgentRun()
 	dupWithinGrant.Spec.Broker.Grants[0].EgressHosts = []string{"chatgpt.com:443", "chatgpt.com:8443"}
 	if err := ValidateAgentRunEgressMode(dupWithinGrant); err == nil || !strings.Contains(err.Error(), "chatgpt.com") {
-		t.Fatalf("duplicate inject host must be rejected, got %v", err)
+		t.Fatalf("duplicate inject host for one capability must be rejected, got %v", err)
 	}
 
-	// Same host claimed by two grants (genuinely ambiguous capability).
+	// Same host claimed by two different grants is valid: egressd requires an
+	// explicit non-secret capability hint on CONNECT and fails closed without
+	// one.
 	dupAcrossGrants := forwardProxyAgentRun()
 	dupAcrossGrants.Spec.Broker.Grants = append(dupAcrossGrants.Spec.Broker.Grants, nvtv1alpha1.AgentRunBrokerGrant{
 		Provider: "other-provider", Materialization: nvtv1alpha1.AgentRunGrantPlaceholderFile,
 		EgressHosts: []string{"chatgpt.com:443"},
 	})
-	if err := ValidateAgentRunEgressMode(dupAcrossGrants); err == nil || !strings.Contains(err.Error(), "more than one grant") {
-		t.Fatalf("host claimed by two grants must be rejected, got %v", err)
+	if err := ValidateAgentRunEgressMode(dupAcrossGrants); err != nil {
+		t.Fatalf("host claimed by two grants should be admitted for explicit selection, got %v", err)
 	}
 
 	// IP-literal egressHost is rejected for forward-proxy (MITM needs a name).

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -208,6 +208,42 @@ for grants whose routing carries it. Non-git capabilities omit the field.
 The local base URL the agent's tooling points at (the `egressd` listen
 address) is composed by runtime bootstrap, not returned by the broker.
 
+### Explicit forward-proxy capability selection
+
+Forward-proxy MITM may have several mediated providers for the same upstream
+host, for example multiple GitHub Apps on `api.github.com`, or multiple Codex
+or Claude sessions on their shared service hosts. Host-only selection is
+ambiguous and must not guess.
+
+When more than one inject route is configured for a CONNECT host, `egressd`
+requires an explicit non-secret capability selector on the CONNECT request.
+The supported selector is HTTP proxy Basic auth where the username is the
+broker provider name, e.g. a proxy URL shaped like:
+
+```text
+http://github-altinn-app@egressd:8473
+```
+
+The password is ignored. The selector is consumed by `egressd` and never
+forwarded upstream. It is not authority by itself: `egressd` still calls
+`/v1/injection/headers` with the selected capability, and the broker enforces
+the paired agent grant, materialization mode, host, method, path, and
+provider-specific scope. If the selector names a capability that is not
+configured for that host, or no selector is present for an ambiguous host, the
+CONNECT fails closed.
+
+Runtime bootstrap exports both the plain forward proxy URL and provider-scoped
+variants:
+
+```text
+NVT_EGRESS_FORWARD_PROXY_URL=http://egressd:8473
+NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN=http://codex-main@egressd:8473
+```
+
+Tool wrappers or preseeded runtime profiles that explicitly reference a broker
+provider should use the provider-scoped URL. The plain URL remains valid when a
+CONNECT host maps to a single inject route.
+
 ### POST /v1/injection/report
 
 Egress role only. Reports proxied requests so the broker's audit log covers

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -244,6 +244,20 @@ Tool wrappers or preseeded runtime profiles that explicitly reference a broker
 provider should use the provider-scoped URL. The plain URL remains valid when a
 CONNECT host maps to a single inject route.
 
+When `runtime.command` is used with mediated forward-proxy egress, runtime
+bootstrap requires:
+
+```yaml
+runtime:
+  proxy:
+    provider: codex-main
+```
+
+Bootstrap binds `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, and their lowercase
+variants to that provider-scoped URL. This keeps the runtime's primary agent
+CLI explicit without teaching bootstrap about Codex, Claude, GitHub, or any
+other provider type.
+
 ### POST /v1/injection/report
 
 Egress role only. Reports proxied requests so the broker's audit log covers

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -169,6 +169,40 @@ def proxy_url_for_provider(proxy_url, provider):
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
+def runtime_proxy_provider(runtime):
+    proxy = runtime.get("proxy")
+    if proxy is None:
+        return None
+    if not isinstance(proxy, dict):
+        raise SystemExit("runtime.proxy must be a YAML object")
+    provider = proxy.get("provider")
+    if not isinstance(provider, str) or not provider:
+        raise SystemExit("runtime.proxy.provider must be a non-empty string")
+    return provider
+
+
+def apply_runtime_proxy(runtime, egress, command):
+    provider = runtime_proxy_provider(runtime)
+    forward_proxy = mediated_mode(egress) and bool(egress.get("forward-proxy"))
+    if provider is not None and not forward_proxy:
+        raise SystemExit("runtime.proxy.provider requires mediated forward-proxy egress")
+    if not command:
+        return
+    if forward_proxy and provider is None:
+        raise SystemExit("runtime.proxy.provider is required when runtime.command uses mediated forward-proxy egress")
+    if provider is None:
+        return
+    grants = egress.get("grants") or []
+    if not isinstance(grants, list):
+        raise SystemExit("egress.grants must be a list")
+    if not any(isinstance(grant, dict) and grant.get("provider") == provider for grant in grants):
+        raise SystemExit(f"runtime.proxy.provider {provider} is not present in egress.grants")
+    proxy_url = (egress.get("forward-proxy-url") or DEFAULT_FORWARD_PROXY_URL).rstrip("/")
+    selected = proxy_url_for_provider(proxy_url, provider)
+    for name in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy"):
+        persist_env_var(name, selected)
+
+
 def persist_agent_command(command, args):
     target = Path.home() / ".nvt-agent" / "agent-command.json"
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -726,15 +760,16 @@ def setup_code_server(config):
 def main():
     config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/nvt-agent/agent.yaml")
     runtime, tools, code_server, egress, preseed = load_bootstrap_config(config_path)
+    command = optional_string(runtime.get("command"), "runtime.command")
 
     setup_tmux_config()
     apply_preseed_files(preseed)
     if mediated_mode(egress):
         apply_mediated_egress(egress)
+    apply_runtime_proxy(runtime, egress, command)
     # Placeholder-file materialization is independent of egress mode: it writes
     # inert placeholder auth files whether or not mediated routing is applied.
     apply_placeholder_files(egress)
-    command = optional_string(runtime.get("command"), "runtime.command")
     if command:
         # Kept for older helper scripts and diagnostics; start-agent-session uses
         # agent-command.json so runtime.args are passed without shell parsing.

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -399,6 +399,7 @@ def apply_mediated_egress(egress):
     deadline = broker_wait_deadline()
     https_provider = None
     enforced = bool(egress.get("enforcement"))
+    forward_proxy = bool(egress.get("forward-proxy"))
     for index, grant in enumerate(grants):
         if not isinstance(grant, dict):
             raise SystemExit(f"egress.grants[{index}] must be an object")
@@ -412,6 +413,11 @@ def apply_mediated_egress(egress):
             continue
         if materialization != "header-inject":
             raise SystemExit(f"egress mediated grant {provider} must be materialization header-inject")
+        if forward_proxy:
+            # Forward-proxy header-inject grants are reached through
+            # HTTP(S)_PROXY and selected by runtime.proxy.provider or a tool
+            # wrapper. They intentionally have no redirect base-url.
+            continue
         base_url = grant.get("base-url")
         if not isinstance(base_url, str) or not base_url:
             raise SystemExit(f"egress mediated grant {provider} must include base-url")
@@ -424,7 +430,6 @@ def apply_mediated_egress(egress):
         if base_url.startswith("https://") and https_provider is None:
             https_provider = provider
         apply_redirect_env(provider, grant, placeholder)
-    forward_proxy = bool(egress.get("forward-proxy"))
     if forward_proxy:
         proxy_url = egress.get("forward-proxy-url") or DEFAULT_FORWARD_PROXY_URL
         if not isinstance(proxy_url, str) or not proxy_url.startswith(("http://", "https://")):
@@ -761,12 +766,13 @@ def main():
     config_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/nvt-agent/agent.yaml")
     runtime, tools, code_server, egress, preseed = load_bootstrap_config(config_path)
     command = optional_string(runtime.get("command"), "runtime.command")
+    effective_command = command or "codex"
 
     setup_tmux_config()
     apply_preseed_files(preseed)
     if mediated_mode(egress):
         apply_mediated_egress(egress)
-    apply_runtime_proxy(runtime, egress, command)
+    apply_runtime_proxy(runtime, egress, effective_command)
     # Placeholder-file materialization is independent of egress mode: it writes
     # inert placeholder auth files whether or not mediated routing is applied.
     apply_placeholder_files(egress)

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import yaml
 
@@ -145,6 +146,27 @@ def persist_env_var(name, value):
 
     env_path.parent.mkdir(parents=True, exist_ok=True)
     env_path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+
+def env_suffix(value):
+    suffix = re.sub(r"[^A-Za-z0-9]+", "_", value).strip("_").upper()
+    if not suffix:
+        raise SystemExit(f"cannot derive env suffix from {value!r}")
+    return suffix
+
+
+def proxy_url_for_provider(proxy_url, provider):
+    parts = urlsplit(proxy_url)
+    if not parts.scheme or not parts.hostname:
+        raise SystemExit(f"egress.forward-proxy-url is not a valid proxy URL: {proxy_url!r}")
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    netloc = f"{quote(provider, safe='')}@{netloc}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def persist_agent_command(command, args):
@@ -373,7 +395,18 @@ def apply_mediated_egress(egress):
         proxy_url = egress.get("forward-proxy-url") or DEFAULT_FORWARD_PROXY_URL
         if not isinstance(proxy_url, str) or not proxy_url.startswith(("http://", "https://")):
             raise SystemExit("egress.forward-proxy-url must be an http(s) URL")
-        persist_env_var("NVT_EGRESS_FORWARD_PROXY_URL", proxy_url.rstrip("/"))
+        proxy_url = proxy_url.rstrip("/")
+        persist_env_var("NVT_EGRESS_FORWARD_PROXY_URL", proxy_url)
+        for grant in grants:
+            if not isinstance(grant, dict):
+                continue
+            provider = grant.get("provider")
+            if not isinstance(provider, str) or not provider:
+                continue
+            persist_env_var(
+                "NVT_EGRESS_FORWARD_PROXY_URL_" + env_suffix(provider),
+                proxy_url_for_provider(proxy_url, provider),
+            )
     if enforced and (https_provider is not None or forward_proxy):
         # Forward-proxy mode has no https base-url to trigger the install, but
         # the MITM leaf must be trusted system-wide so proxy-env HTTPS clients

--- a/runtime/plugins/git-host-credentials/README.md
+++ b/runtime/plugins/git-host-credentials/README.md
@@ -113,8 +113,14 @@ When `--provider` is omitted, `gh-auth` resolves from `--repo`, the current
 
 For `credential-kind: mediated`, `gh-auth` sets `GH_TOKEN` to the inert NVT
 placeholder and forces GitHub traffic through `NVT_EGRESS_FORWARD_PROXY_URL`.
-egressd strips the placeholder and injects the broker-owned credential. The
-agent process never receives the real token.
+It also encodes the selected `broker-provider` as the proxy username. That
+username is a non-secret capability selector: egressd consumes it from the
+CONNECT request, strips the placeholder, and injects the broker-owned
+credential for that exact provider. This lets one agent use multiple GitHub App
+providers for the same `github.com` / `api.github.com` hosts without host-based
+guessing. The broker still enforces the paired agent grant, host, method, path,
+and repository scope; naming an ungranted provider fails closed. The agent
+process never receives the real token.
 
 ## Security
 

--- a/runtime/plugins/git-host-credentials/gh-auth.py
+++ b/runtime/plugins/git-host-credentials/gh-auth.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from git_host_credentials import credential_kind, load_config, normalize_repo, resolve_provider, token
 
@@ -70,10 +71,29 @@ def remove_no_proxy_hosts(value, blocked):
     return ",".join(kept)
 
 
+def proxy_url_for_provider(proxy_url, provider_name):
+    parts = urlsplit(proxy_url)
+    if not parts.scheme or not parts.hostname:
+        fail(f"NVT_EGRESS_FORWARD_PROXY_URL is not a valid proxy URL: {proxy_url!r}")
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    # The username is a non-secret capability selector. HTTP clients send it
+    # as Proxy-Authorization on CONNECT; egressd consumes it and never forwards
+    # it upstream. This lets one agent use multiple GitHub App providers for
+    # the same github.com/api.github.com hosts without host-based guessing.
+    netloc = f"{quote(provider_name, safe='')}@{netloc}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
 def mediated_env(provider, repo):
     proxy_url = os.environ.get("NVT_EGRESS_FORWARD_PROXY_URL")
     if not proxy_url:
         fail(f"provider {provider['name']} is mediated but NVT_EGRESS_FORWARD_PROXY_URL is not set")
+    proxy_url = proxy_url_for_provider(proxy_url, provider["broker-provider"])
     placeholder = os.environ.get("NVT_EGRESS_PLACEHOLDER") or PLACEHOLDER
     env = os.environ.copy()
     env["GH_TOKEN"] = placeholder

--- a/tests/operator/kind/cases/forward-proxy-egress.sh
+++ b/tests/operator/kind/cases/forward-proxy-egress.sh
@@ -126,7 +126,11 @@ spec = {
     "broker": {"grants": [grant]},
     "agent": {
         "config": {
-            "runtime": {"command": "bash", "args": ["-lc", 'echo "forward-proxy smoke ready"; sleep infinity']},
+            "runtime": {
+                "command": "bash",
+                "args": ["-lc", 'echo "forward-proxy smoke ready"; sleep infinity'],
+                "proxy": {"provider": "static-bearer-main"},
+            },
             "tools": {"packages": [], "mise": [], "additional-paths": [], "shell": []},
             "code-server": {"extensions": []},
         }

--- a/tests/runtime/git_host_credentials_test.go
+++ b/tests/runtime/git_host_credentials_test.go
@@ -252,7 +252,7 @@ if [ "${GITHUB_ENTERPRISE_TOKEN+x}" = "x" ]; then
   echo "GITHUB_ENTERPRISE_TOKEN must be unset" >&2
   exit 1
 fi
-if [ "${HTTPS_PROXY:-}" != "http://127.0.0.1:8470" ]; then
+if [ "${HTTPS_PROXY:-}" != "http://fork-app@127.0.0.1:8470" ]; then
   echo "unexpected HTTPS_PROXY=${HTTPS_PROXY:-}" >&2
   exit 1
 fi

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -808,6 +808,86 @@ code-server:
 	}
 }
 
+func TestBootstrapForwardProxyRequiresRuntimeProxyProviderForImplicitCommand(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("update-ca-certificates", "#!/usr/bin/env bash\nexit 0\n")
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	mustWriteFile(t, caFile, testCertificatePEM(t))
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  enforcement: true
+  forward-proxy: true
+  placeholder: NVT-PLACEHOLDER-NOT-A-KEY
+  grants:
+    - provider: claude-auth-mirko
+      materialization: placeholder-file
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_EGRESS_MODE=mediated",
+		"NVT_EGRESS_CA_FILE=" + caFile,
+		"NVT_CA_TRUST_DIR=" + t.TempDir(),
+		"NVT_CA_BUNDLE_FILE=" + filepath.Join(t.TempDir(), "bundle.crt"),
+	}, config)
+	if !strings.Contains(output, "runtime.proxy.provider is required") {
+		t.Fatalf("expected missing runtime proxy provider failure for implicit command, got:\n%s", output)
+	}
+}
+
+func TestBootstrapForwardProxyHeaderInjectGrantSupportsRuntimeProxyProvider(t *testing.T) {
+	f := newFixture(t)
+	updateLog := filepath.Join(f.home, "update-ca-certificates.log")
+	f.writeBin("update-ca-certificates", "#!/usr/bin/env bash\necho called >> "+updateLog+"\nexit 0\n")
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	mustWriteFile(t, caFile, testCertificatePEM(t))
+	bundle := filepath.Join(t.TempDir(), "ca-bundle.crt")
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  enforcement: true
+  forward-proxy: true
+  placeholder: NVT-PLACEHOLDER-NOT-A-KEY
+  grants:
+    - provider: static-bearer-main
+      materialization: header-inject
+runtime:
+  command: bash
+  proxy:
+    provider: static-bearer-main
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	output := f.runWithEnv(bootstrapBin(f.root), true, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_EGRESS_MODE=mediated",
+		"NVT_EGRESS_CA_FILE=" + caFile,
+		"NVT_CA_TRUST_DIR=" + t.TempDir(),
+		"NVT_CA_BUNDLE_FILE=" + bundle,
+	}, config)
+	if _, err := os.Stat(updateLog); err != nil {
+		t.Fatalf("forward-proxy header-inject bootstrap did not install CA trust:\n%s", output)
+	}
+	envFile := mustReadFile(t, filepath.Join(f.home, ".nvt-agent", "env"))
+	if !strings.Contains(envFile, `export HTTPS_PROXY="http://static-bearer-main@127.0.0.1:8470"`) {
+		t.Fatalf("runtime proxy env not bound for header-inject grant:\n%s", envFile)
+	}
+}
+
 func TestBootstrapRuntimeProxyProviderRequiresForwardProxy(t *testing.T) {
 	f := newFixture(t)
 	config := f.writeAgentConfig(`

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -726,6 +726,8 @@ egress:
       materialization: placeholder-file
 runtime:
   command: bash
+  proxy:
+    provider: codex-main
 tools:
   packages: []
   mise: []
@@ -759,8 +761,75 @@ code-server:
 	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN="http://codex-main@127.0.0.1:8470"`) {
 		t.Fatalf("provider-selected forward proxy URL not exported for mediated tools:\n%s", envFile)
 	}
+	if !strings.Contains(envFile, `export HTTPS_PROXY="http://codex-main@127.0.0.1:8470"`) ||
+		!strings.Contains(envFile, `export https_proxy="http://codex-main@127.0.0.1:8470"`) {
+		t.Fatalf("runtime proxy env not bound to selected provider:\n%s", envFile)
+	}
 	meta := mustReadFile(t, filepath.Join(f.home, ".nvt-agent", "egress.json"))
 	if !strings.Contains(meta, `"forward_proxy": true`) {
 		t.Fatalf("egress.json missing forward_proxy marker:\n%s", meta)
+	}
+}
+
+func TestBootstrapForwardProxyRequiresRuntimeProxyProvider(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("update-ca-certificates", "#!/usr/bin/env bash\nexit 0\n")
+	caFile := filepath.Join(t.TempDir(), "ca.crt")
+	mustWriteFile(t, caFile, testCertificatePEM(t))
+	config := f.writeAgentConfig(`
+egress:
+  mode: mediated
+  enforcement: true
+  forward-proxy: true
+  placeholder: NVT-PLACEHOLDER-NOT-A-KEY
+  grants:
+    - provider: claude-auth-mirko
+      materialization: placeholder-file
+runtime:
+  command: claude
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"NVT_EGRESS_MODE=mediated",
+		"NVT_EGRESS_CA_FILE=" + caFile,
+		"NVT_CA_TRUST_DIR=" + t.TempDir(),
+		"NVT_CA_BUNDLE_FILE=" + filepath.Join(t.TempDir(), "bundle.crt"),
+	}, config)
+	if !strings.Contains(output, "runtime.proxy.provider is required") {
+		t.Fatalf("expected missing runtime proxy provider failure, got:\n%s", output)
+	}
+}
+
+func TestBootstrapRuntimeProxyProviderRequiresForwardProxy(t *testing.T) {
+	f := newFixture(t)
+	config := f.writeAgentConfig(`
+egress:
+  mode: direct
+runtime:
+  command: claude
+  proxy:
+    provider: claude-auth-mirko
+tools:
+  packages: []
+  mise: []
+  additional-paths: []
+  shell: []
+code-server:
+  extensions: []
+`)
+	output := f.runWithEnv(bootstrapBin(f.root), false, []string{
+		"HOME=" + f.home,
+		"PATH=" + f.pathPrefix + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}, config)
+	if !strings.Contains(output, "runtime.proxy.provider requires mediated forward-proxy egress") {
+		t.Fatalf("expected wrong-mode runtime proxy provider failure, got:\n%s", output)
 	}
 }

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -702,6 +702,14 @@ func TestBootstrapForwardProxyInstallsCATrust(t *testing.T) {
 	f := newFixture(t)
 	updateLog := filepath.Join(f.home, "update-ca-certificates.log")
 	f.writeBin("update-ca-certificates", "#!/usr/bin/env bash\necho called >> "+updateLog+"\nexit 0\n")
+	f.writeBin("brokerctl", `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" != "placeholder-files" ] || [ "$2" != "--provider" ] || [ "$3" != "codex-main" ]; then
+  echo "unexpected brokerctl args: $*" >&2
+  exit 1
+fi
+printf '%s\n' '{"ok":true,"files":[{"path":".codex/auth.json","content":"{\"access_token\":\"NVT-PLACEHOLDER-NOT-A-KEY\"}\n","mode":"0600"}],"hosts":["chatgpt.com"],"expires_at":"2099-01-01T00:00:00Z"}'
+`)
 	caFile := filepath.Join(t.TempDir(), "ca.crt")
 	mustWriteFile(t, caFile, testCertificatePEM(t))
 	trustDir := t.TempDir()
@@ -713,7 +721,9 @@ egress:
   enforcement: true
   forward-proxy: true
   placeholder: NVT-PLACEHOLDER-NOT-A-KEY
-  grants: []
+  grants:
+    - provider: codex-main
+      materialization: placeholder-file
 runtime:
   command: bash
 tools:
@@ -745,6 +755,9 @@ code-server:
 	}
 	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL="http://127.0.0.1:8470"`) {
 		t.Fatalf("forward proxy URL not exported for mediated tools:\n%s", envFile)
+	}
+	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN="http://codex-main@127.0.0.1:8470"`) {
+		t.Fatalf("provider-selected forward proxy URL not exported for mediated tools:\n%s", envFile)
 	}
 	meta := mustReadFile(t, filepath.Join(f.home, ".nvt-agent", "egress.json"))
 	if !strings.Contains(meta, `"forward_proxy": true`) {


### PR DESCRIPTION
## Summary
- allow forward-proxy MITM routes to share a host when capabilities differ, requiring an explicit non-secret capability selector for ambiguous hosts
- consume provider selection from proxy CONNECT credentials and make gh-auth encode the selected broker provider in the proxy URL
- export provider-scoped forward proxy URLs from bootstrap for future explicit Codex/Claude profiles
- document the selector contract and add egressd/operator/runtime tests

## Tests
- python3 -m py_compile runtime/plugins/git-host-credentials/gh-auth.py runtime/core/bootstrap.py
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -run 'TestValidateForwardProxyMirrorsEgressdRules|TestRenderForwardProxyEgressdConfig' . (operator/internal/controller)
- PATH=/private/tmp/nvt-agent-test-venv/bin:/Users/mirkosekulic/.codex/tmp/arg0/codex-arg0E8z0Sq:/Users/mirkosekulic/.local/bin:/Users/mirkosekulic/.nvm/versions/node/v22.16.0/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Users/mirkosekulic/.cargo/bin:/Users/mirkosekulic/.dotnet/tools GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -run 'TestGhAuthWrapsMediatedProviderWithPlaceholderAndProxy|TestGhAuthMediatedProviderRequiresManagedProxyURL|TestBootstrapForwardProxyInstallsCATrust' . (tests/runtime)
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -run 'TestForwardProxyMITMRequiresCapabilityForAmbiguousHost|TestForwardProxyMITMInjectsRealToken|TestForwardProxyInjectRoutesAllowSameHostWithExplicitCapabilities' . (egressd/internal/egress)
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 ./... (egressd/internal/egress)
- GOCACHE=/private/tmp/nvt-go-cache go test -count=1 ./... (tests/broker)