### PR TITLE
Route mediated Git credentials through egressd

### DIFF
--- a/runtime/plugins/git-credentials/README.md
+++ b/runtime/plugins/git-credentials/README.md
@@ -11,10 +11,10 @@ Token providers (`github-app` and `token-env`) are exposed through
 `git-credential-nvt`. Header providers configure Git `http.<url>.extraHeader`
 entries directly.
 
-Mediated broker providers (`credential-kind: mediated`) are not exposed through
-the helper and do not write `extraHeader`. They rely on the mediated runtime's
-egressd Git routing (`url.<egressd>.insteadOf` + CA trust) so the real
-credential is injected outside the agent.
+Mediated broker providers (`credential-kind: mediated`) are exposed through the
+helper with an inert placeholder password only. The plugin also writes
+provider-scoped Git proxy config so GitHub traffic flows through egressd, where
+the real credential is injected outside the agent.
 
 ## Configuration
 
@@ -114,9 +114,12 @@ Broker-backed header providers configure `http.<url>.extraHeader` the same way
 local header providers do. The header secret is therefore present in Git config;
 this is a compatibility path, not a zero-trust path.
 
-Broker-backed mediated providers are deliberately skipped by the credential
-helper. In mediated mode, bootstrap/operator wiring configures Git URL rewrites
-and trust for egressd; this plugin may still configure repo-local commit
+Broker-backed mediated providers configure `http.<url>.proxy` to a
+provider-scoped egressd proxy URL, force `proxyAuthMethod=basic` so Git sends
+the non-secret provider selector on `CONNECT`, and use the same credential
+helper. The helper returns only the configured username and
+`NVT-PLACEHOLDER-NOT-A-KEY`; egressd strips that placeholder and asks the broker
+for the real credential. This plugin may still configure repo-local commit
 identity, but it must not ask the provider for a token or header.
 
 ## Relationship To checkout-repos

--- a/runtime/plugins/git-credentials/git-credential-nvt.py
+++ b/runtime/plugins/git-credentials/git-credential-nvt.py
@@ -8,6 +8,7 @@ import yaml
 
 
 CONFIG_FILE = Path.home() / ".nvt-agent" / "git-credentials" / "config.yaml"
+PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 
 
 def fail(message):
@@ -91,6 +92,17 @@ def provider_credentials(rule, target):
     username = rule.get("username") or "x-access-token"
     if not isinstance(username, str):
         fail("credential rule username must be a string")
+    try:
+        kind_command = ["git-host-credential", "credential-kind", "--provider", provider]
+        if target:
+            kind_command.extend(["--target", target])
+        kind = output(kind_command).strip()
+    except FileNotFoundError:
+        fail("git-host-credential is not on PATH")
+    except subprocess.CalledProcessError as error:
+        fail(f"git-host-credential credential-kind failed with exit {error.returncode}")
+    if kind == "mediated":
+        return username, os.environ.get("NVT_EGRESS_PLACEHOLDER") or PLACEHOLDER
     try:
         command = ["git-host-credential", "token", "--provider", provider]
         if target:

--- a/runtime/plugins/git-credentials/run.py
+++ b/runtime/plugins/git-credentials/run.py
@@ -255,21 +255,56 @@ def configure_git_helper():
     run(["git", "config", "--global", "credential.useHttpPath", "true"])
 
 
+def git_config_url_keys(match):
+    value = match if match.endswith("/") else match.rstrip("/")
+    keys = [value]
+    if not match.endswith("/") and not value.endswith(".git"):
+        keys.append(value + ".git")
+    return keys
+
+
 def clear_managed_headers():
     for key in read_managed_header_keys():
         subprocess.run(["git", "config", "--global", "--unset-all", key], check=False)
 
 
 def configure_headers(credentials):
-    clear_managed_headers()
     managed_keys = []
     for rule in credentials:
         match = rule["match"]
-        key = f"http.{match}.extraHeader"
-        for header in provider_headers(rule):
-            run(["git", "config", "--global", "--add", key, header])
-        managed_keys.append(key)
-    write_managed_header_keys(managed_keys)
+        for key_match in git_config_url_keys(match):
+            key = f"http.{key_match}.extraHeader"
+            for header in provider_headers(rule):
+                run(["git", "config", "--global", "--add", key, header])
+            managed_keys.append(key)
+    return managed_keys
+
+
+def provider_mediated_proxy(rule):
+    provider = string_value(rule.get("provider"), "provider", required=True)
+    try:
+        return output(["git-host-credential", "mediated-proxy", "--provider", provider]).strip()
+    except FileNotFoundError:
+        fail("git-host-credential is not on PATH")
+    except subprocess.CalledProcessError as error:
+        fail(f"git-host-credential mediated-proxy failed with exit {error.returncode}")
+
+
+def configure_mediated_proxies(credentials):
+    managed_keys = []
+    for rule in credentials:
+        match = rule["match"]
+        proxy = provider_mediated_proxy(rule)
+        if not proxy:
+            fail(f"provider {rule['provider']} returned an empty mediated proxy URL")
+        for key_match in git_config_url_keys(match):
+            key = f"http.{key_match}.proxy"
+            auth_key = f"http.{key_match}.proxyAuthMethod"
+            run(["git", "config", "--global", key, proxy])
+            run(["git", "config", "--global", auth_key, "basic"])
+            managed_keys.append(key)
+            managed_keys.append(auth_key)
+    return managed_keys
 
 
 def main():
@@ -286,7 +321,8 @@ def main():
     credentials = list_value(config.get("credentials"), "credentials")
     if not credentials:
         write_helper_config([])
-        configure_headers([])
+        clear_managed_headers()
+        write_managed_header_keys([])
         print("git-credentials: no credentials configured", flush=True)
         return
 
@@ -306,13 +342,17 @@ def main():
         else:
             token_credentials.append(rule)
 
-    write_helper_config(token_credentials)
-    configure_headers(header_credentials)
-    if token_credentials:
+    write_helper_config([*token_credentials, *mediated_credentials])
+    clear_managed_headers()
+    managed_keys = []
+    managed_keys.extend(configure_headers(header_credentials))
+    managed_keys.extend(configure_mediated_proxies(mediated_credentials))
+    write_managed_header_keys(managed_keys)
+    if token_credentials or mediated_credentials:
         configure_git_helper()
     if mediated_credentials:
         names = ", ".join(rule["provider"] for rule in mediated_credentials)
-        print(f"git-credentials: {len(mediated_credentials)} mediated credential rule(s) use egressd routing only: {names}", flush=True)
+        print(f"git-credentials: configured {len(mediated_credentials)} mediated credential rule(s) through egressd: {names}", flush=True)
 
 
 def doctor():

--- a/runtime/plugins/git-host-credentials/README.md
+++ b/runtime/plugins/git-host-credentials/README.md
@@ -66,6 +66,7 @@ git-host-credential token --provider fork-app
 git-host-credential token --provider brokered-fork-app --target github.com/my-user/project
 git-host-credential identity --provider brokered-fork-app --target github.com/my-user/project
 git-host-credential headers --provider brokered-company-headers --target altinn.studio/repos/digdir/oed
+git-host-credential mediated-proxy --provider brokered-fork-mediated
 git-host-credential doctor --provider fork-app
 ```
 
@@ -84,9 +85,9 @@ credential-kind: headers
 
 Use `credential-kind: mediated` when Git traffic for the provider is routed
 through egressd by the mediated runtime. In this mode the plugin refuses token
-and header export; it is only a provider resolver and identity source. The real
-credential is injected by egressd after broker authorization, outside the agent
-container.
+and header export; it is a provider resolver, identity source, and source of the
+provider-scoped egress proxy URL used by Git. The real credential is injected by
+egressd after broker authorization, outside the agent container.
 
 ```yaml
 type: broker
@@ -113,14 +114,15 @@ When `--provider` is omitted, `gh-auth` resolves from `--repo`, the current
 
 For `credential-kind: mediated`, `gh-auth` sets `GH_TOKEN` to the inert NVT
 placeholder and forces GitHub traffic through `NVT_EGRESS_FORWARD_PROXY_URL`.
-It also encodes the selected `broker-provider` as the proxy username. That
-username is a non-secret capability selector: egressd consumes it from the
-CONNECT request, strips the placeholder, and injects the broker-owned
-credential for that exact provider. This lets one agent use multiple GitHub App
-providers for the same `github.com` / `api.github.com` hosts without host-based
-guessing. The broker still enforces the paired agent grant, host, method, path,
-and repository scope; naming an ungranted provider fails closed. The agent
-process never receives the real token.
+It also encodes the selected `broker-provider` as the proxy username, with a
+fixed dummy proxy password so HTTP clients reliably send `Proxy-Authorization`
+on `CONNECT`. The username is a non-secret capability selector: egressd consumes
+it from the CONNECT request, strips the placeholder, and injects the
+broker-owned credential for that exact provider. This lets one agent use
+multiple GitHub App providers for the same `github.com` / `api.github.com`
+hosts without host-based guessing. The broker still enforces the paired agent
+grant, host, method, path, and repository scope; naming an ungranted provider
+fails closed. The agent process never receives the real token.
 
 ## Security
 

--- a/runtime/plugins/git-host-credentials/gh-auth.py
+++ b/runtime/plugins/git-host-credentials/gh-auth.py
@@ -81,11 +81,12 @@ def proxy_url_for_provider(proxy_url, provider_name):
     netloc = host
     if parts.port is not None:
         netloc = f"{netloc}:{parts.port}"
-    # The username is a non-secret capability selector. HTTP clients send it
-    # as Proxy-Authorization on CONNECT; egressd consumes it and never forwards
-    # it upstream. This lets one agent use multiple GitHub App providers for
-    # the same github.com/api.github.com hosts without host-based guessing.
-    netloc = f"{quote(provider_name, safe='')}@{netloc}"
+    # The username is a non-secret capability selector; the password is a fixed
+    # dummy value so clients reliably send Proxy-Authorization on CONNECT.
+    # egressd consumes it and never forwards it upstream. This lets one agent
+    # use multiple GitHub App providers for the same github.com/api.github.com
+    # hosts without host-based guessing.
+    netloc = f"{quote(provider_name, safe='')}:x@{netloc}"
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 

--- a/runtime/plugins/git-host-credentials/git-host-credential.py
+++ b/runtime/plugins/git-host-credentials/git-host-credential.py
@@ -2,7 +2,7 @@
 import argparse
 import json
 
-from git_host_credentials import credential_kind, headers, identity, load_config, providers, resolve_provider, token, validate_provider
+from git_host_credentials import credential_kind, headers, identity, load_config, mediated_proxy_url, providers, resolve_provider, token, validate_provider
 
 
 def command_token(args):
@@ -34,6 +34,11 @@ def command_type(args):
 def command_credential_kind(args):
     provider = resolve_provider(load_config(), args.provider, args.target)
     print(credential_kind(provider))
+
+
+def command_mediated_proxy(args):
+    provider = resolve_provider(load_config(), args.provider, args.target)
+    print(mediated_proxy_url(provider))
 
 
 def command_doctor(args):
@@ -79,6 +84,11 @@ def main():
     credential_kind_parser.add_argument("--provider")
     credential_kind_parser.add_argument("--target")
     credential_kind_parser.set_defaults(func=command_credential_kind)
+
+    mediated_proxy_parser = subparsers.add_parser("mediated-proxy")
+    mediated_proxy_parser.add_argument("--provider")
+    mediated_proxy_parser.add_argument("--target")
+    mediated_proxy_parser.set_defaults(func=command_mediated_proxy)
 
     doctor = subparsers.add_parser("doctor")
     doctor.add_argument("--provider")

--- a/runtime/plugins/git-host-credentials/git_host_credentials.py
+++ b/runtime/plugins/git-host-credentials/git_host_credentials.py
@@ -2,6 +2,7 @@ import base64
 import fnmatch
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -9,7 +10,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from re import fullmatch
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlparse, urlsplit, urlunsplit
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -17,6 +18,7 @@ import yaml
 
 
 CACHE_FILE = Path.home() / ".nvt-agent" / "git-host-credentials" / "cache.json"
+RUNTIME_ENV_FILE = Path.home() / ".nvt-agent" / "env"
 
 
 def fail(message):
@@ -28,6 +30,37 @@ def env_value(name):
     if value is None:
         fail(f"environment variable {name} is not set")
     return value
+
+
+def runtime_env_value(name):
+    value = os.environ.get(name)
+    if value is not None:
+        return value
+    if not RUNTIME_ENV_FILE.is_file():
+        return None
+    try:
+        lines = RUNTIME_ENV_FILE.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    prefix = f"{name}="
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("export "):
+            candidate = stripped[len("export "):]
+        else:
+            candidate = stripped
+        if not candidate.startswith(prefix):
+            continue
+        try:
+            parts = shlex.split(candidate, posix=True)
+        except ValueError:
+            return candidate[len(prefix):]
+        if not parts:
+            return ""
+        key, separator, parsed = parts[0].partition("=")
+        if key == name and separator:
+            return parsed
+    return None
 
 
 def load_config():
@@ -321,7 +354,7 @@ def github_app_identity(provider):
 
 
 def broker_token(provider, target):
-    broker_provider = string_value(provider.get("broker-provider") or provider.get("provider"), f"provider {provider_name(provider)} broker-provider", required=True)
+    broker_provider = broker_provider_name(provider)
     if not target:
         fail(f"provider {provider_name(provider)} broker token requires --target")
     command = ["brokerctl", "token", "--provider", broker_provider, "--target", target, "--raw"]
@@ -337,7 +370,7 @@ def broker_token(provider, target):
 
 
 def broker_identity(provider, target):
-    broker_provider = string_value(provider.get("broker-provider") or provider.get("provider"), f"provider {provider_name(provider)} broker-provider", required=True)
+    broker_provider = broker_provider_name(provider)
     if not target:
         fail(f"provider {provider_name(provider)} broker identity requires --target")
     command = ["brokerctl", "identity", "--provider", broker_provider, "--target", target]
@@ -360,7 +393,7 @@ def broker_identity(provider, target):
 
 
 def broker_headers(provider, target):
-    broker_provider = string_value(provider.get("broker-provider") or provider.get("provider"), f"provider {provider_name(provider)} broker-provider", required=True)
+    broker_provider = broker_provider_name(provider)
     if not target:
         fail(f"provider {provider_name(provider)} broker headers require --target")
     command = ["brokerctl", "headers", "--provider", broker_provider, "--target", target, "--raw"]
@@ -387,6 +420,33 @@ def credential_kind(provider):
     if kind in {"github-app", "token-env"}:
         return "token"
     fail(f"provider {provider_name(provider)} does not provide Git credentials")
+
+
+def broker_provider_name(provider):
+    return string_value(provider.get("broker-provider") or provider.get("provider"), f"provider {provider_name(provider)} broker-provider", required=True)
+
+
+def proxy_url_for_provider(proxy_url, provider_name_value):
+    parts = urlsplit(proxy_url)
+    if not parts.scheme or not parts.hostname:
+        fail(f"NVT_EGRESS_FORWARD_PROXY_URL is not a valid proxy URL: {proxy_url!r}")
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    netloc = f"{quote(provider_name_value, safe='')}:x@{netloc}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def mediated_proxy_url(provider):
+    if credential_kind(provider) != "mediated":
+        fail(f"provider {provider_name(provider)} is not mediated")
+    proxy_url = runtime_env_value("NVT_EGRESS_FORWARD_PROXY_URL")
+    if not proxy_url:
+        fail(f"provider {provider_name(provider)} is mediated but NVT_EGRESS_FORWARD_PROXY_URL is not set")
+    return proxy_url_for_provider(proxy_url, broker_provider_name(provider))
 
 
 def token(provider, target=None):

--- a/tests/runtime/git_host_credentials_test.go
+++ b/tests/runtime/git_host_credentials_test.go
@@ -231,6 +231,32 @@ providers:
 	}
 }
 
+func TestGitHostCredentialMediatedProxyReadsRuntimeEnvFile(t *testing.T) {
+	f := newFixture(t)
+	config := f.writePluginConfig("git-host-credentials.yaml", `
+providers:
+  - name: fork-app-mediated
+    type: broker
+    broker-provider: github-main-app
+    credential-kind: mediated
+    match:
+      - github.com/my-user/*
+`)
+	envDir := filepath.Join(f.home, ".nvt-agent")
+	if err := os.MkdirAll(envDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "env"), []byte(`export NVT_EGRESS_FORWARD_PROXY_URL="http://127.0.0.1:8470"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	output := f.runWithEnv(gitHostCredentialBin(f.root), true, []string{"NVT_PLUGIN_CONFIG=" + config}, "mediated-proxy", "--provider", "fork-app-mediated")
+	if strings.TrimSpace(output) != "http://github-main-app:x@127.0.0.1:8470" {
+		t.Fatalf("unexpected mediated proxy URL: %q", output)
+	}
+}
+
 func TestGhAuthWrapsMediatedProviderWithPlaceholderAndProxy(t *testing.T) {
 	f := newFixture(t)
 	f.writeBin("brokerctl", "#!/usr/bin/env bash\necho should-not-run >&2\nexit 1\n")
@@ -252,7 +278,7 @@ if [ "${GITHUB_ENTERPRISE_TOKEN+x}" = "x" ]; then
   echo "GITHUB_ENTERPRISE_TOKEN must be unset" >&2
   exit 1
 fi
-if [ "${HTTPS_PROXY:-}" != "http://fork-app@127.0.0.1:8470" ]; then
+if [ "${HTTPS_PROXY:-}" != "http://fork-app:x@127.0.0.1:8470" ]; then
   echo "unexpected HTTPS_PROXY=${HTTPS_PROXY:-}" >&2
   exit 1
 fi
@@ -322,6 +348,11 @@ if [ "$1" = "token" ] && [ "$2" = "--provider" ] && [ "$3" = "fork-app" ] &&
   echo delegated-token
   exit 0
 fi
+if [ "$1" = "credential-kind" ] && [ "$2" = "--provider" ] && [ "$3" = "fork-app" ] &&
+   [ "$4" = "--target" ] && [ "$5" = "github.com/my-user/project" ]; then
+  echo token
+  exit 0
+fi
 echo "unexpected git-host-credential args: $*" >&2
 exit 1
 `)
@@ -346,7 +377,7 @@ credentials:
 	}
 }
 
-func TestGitCredentialsSkipsHelperForMediatedProvider(t *testing.T) {
+func TestGitCredentialsConfiguresMediatedProviderWithPlaceholderAndProxy(t *testing.T) {
 	f := newFixture(t)
 	logPath := filepath.Join(f.home, "git.log")
 	f.writeBin("git", `#!/usr/bin/env bash
@@ -358,6 +389,9 @@ set -euo pipefail
 case "$1:$3" in
   credential-kind:fork-app-mediated)
     echo mediated
+    ;;
+  mediated-proxy:fork-app-mediated)
+    echo http://fork-app:x@127.0.0.1:8470
     ;;
   doctor:fork-app-mediated)
     exit 0
@@ -385,16 +419,31 @@ credentials:
 		t.Fatal(err)
 	}
 	log := string(logData)
-	if strings.Contains(log, "credential.helper") ||
-		strings.Contains(log, "extraHeader") {
-		t.Fatalf("mediated git credentials must not configure helper or headers:\n%s", log)
+	if !strings.Contains(log, "config --global http.https://github.com/my-user/project.proxy http://fork-app:x@127.0.0.1:8470") {
+		t.Fatalf("mediated git credentials must configure provider-scoped proxy:\n%s", log)
+	}
+	if !strings.Contains(log, "config --global http.https://github.com/my-user/project.proxyAuthMethod basic") {
+		t.Fatalf("mediated git credentials must force basic proxy auth for capability hinting:\n%s", log)
+	}
+	if !strings.Contains(log, "config --global credential.helper nvt") {
+		t.Fatalf("mediated git credentials must configure helper:\n%s", log)
+	}
+	if strings.Contains(log, "extraHeader") {
+		t.Fatalf("mediated git credentials must not configure headers:\n%s", log)
 	}
 	configData, err := os.ReadFile(filepath.Join(f.home, ".nvt-agent", "git-credentials", "config.yaml"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(configData), "fork-app-mediated") {
-		t.Fatalf("mediated provider leaked into token helper config:\n%s", configData)
+	if !strings.Contains(string(configData), "fork-app-mediated") {
+		t.Fatalf("mediated provider must be present in placeholder helper config:\n%s", configData)
+	}
+
+	input := "protocol=https\nhost=github.com\npath=my-user/project.git\n\n"
+	helperOutput := f.runWithInput(gitCredentialNvtBin(f.root), input, true, "get")
+	if !strings.Contains(helperOutput, "username=x-access-token") ||
+		!strings.Contains(helperOutput, "password=NVT-PLACEHOLDER-NOT-A-KEY") {
+		t.Fatalf("unexpected mediated helper output:\n%s", helperOutput)
 	}
 }
 
@@ -681,5 +730,60 @@ credentials:
 	}
 	if !strings.Contains(log, "config --global --unset-all http.https://git.company.com/team/.extraHeader") {
 		t.Fatalf("expected stale header unset command, got:\n%s", log)
+	}
+}
+
+func TestGitCredentialsClearsRemovedMediatedProxy(t *testing.T) {
+	f := newFixture(t)
+	logPath := filepath.Join(f.home, "git.log")
+	f.writeBin("git", `#!/usr/bin/env bash
+set -euo pipefail
+printf "%s\n" "$*" >> "$GIT_LOG"
+`)
+	f.writeBin("git-host-credential", `#!/usr/bin/env bash
+set -euo pipefail
+case "$1:$3" in
+  credential-kind:fork-app-mediated)
+    echo mediated
+    ;;
+  mediated-proxy:fork-app-mediated)
+    echo http://fork-app:x@127.0.0.1:8470
+    ;;
+  *)
+    echo "unexpected git-host-credential args: $*" >&2
+    exit 1
+    ;;
+esac
+`)
+
+	firstConfig := f.writePluginConfig("git-credentials-first.yaml", `
+credentials:
+  - match: https://github.com/my-user/project
+    provider: fork-app-mediated
+`)
+	env := []string{
+		"NVT_PLUGIN_CONFIG=" + firstConfig,
+		"GIT_LOG=" + logPath,
+	}
+	f.runWithEnv(gitCredentialsRunBin(f.root), true, env)
+
+	secondConfig := f.writePluginConfig("git-credentials-second.yaml", "credentials: []\n")
+	env[0] = "NVT_PLUGIN_CONFIG=" + secondConfig
+	f.runWithEnv(gitCredentialsRunBin(f.root), true, env)
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "config --global http.https://github.com/my-user/project.proxy http://fork-app:x@127.0.0.1:8470") ||
+		!strings.Contains(log, "config --global http.https://github.com/my-user/project.git.proxy http://fork-app:x@127.0.0.1:8470") {
+		t.Fatalf("expected mediated proxy config commands, got:\n%s", log)
+	}
+	if !strings.Contains(log, "config --global --unset-all http.https://github.com/my-user/project.proxy") ||
+		!strings.Contains(log, "config --global --unset-all http.https://github.com/my-user/project.proxyAuthMethod") ||
+		!strings.Contains(log, "config --global --unset-all http.https://github.com/my-user/project.git.proxy") ||
+		!strings.Contains(log, "config --global --unset-all http.https://github.com/my-user/project.git.proxyAuthMethod") {
+		t.Fatalf("expected stale mediated proxy unset commands, got:\n%s", log)
 	}
 }


### PR DESCRIPTION
## Summary
- keep mediated Git helpers credential-less by returning an inert placeholder from the credential helper
- add a provider-scoped `git-host-credential mediated-proxy` command and configure Git remotes to use egressd with Basic proxy auth
- cover exact and `.git` URL config keys so Git/libcurl routes the actual remote through egressd

## Tests
- `PATH=/private/tmp/nvt-agent-test-venv/bin:$PATH GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -run 'TestGitHostCredential|TestGhAuth|TestGitCredentials|TestCheckoutRepos' -v .` from `tests/runtime`\n- Full `tests/runtime` was attempted; it still fails on unrelated `TestAfterAgentPluginsStartConcurrently` when run alone\n- Live validation in `nvtclaude`: `git ls-remote origin HEAD` and branch push succeeded through mediated Git after granting `contents: write`; PR #82 was created from that branch\n