### PR TITLE
Fix local mediated forward-proxy agent init

### DIFF
--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -364,6 +364,7 @@ def install_egress_ca_trust(provider):
     try:
         run(["nvt-as-root", "mkdir", "-p", str(trust_dir)])
         run(["nvt-as-root", "cp", str(tmp_path), str(trust_dir / "nvt-egress-ca.crt")])
+        run(["nvt-as-root", "chmod", "0644", str(trust_dir / "nvt-egress-ca.crt")])
         run(["nvt-as-root", "update-ca-certificates"])
     except FileNotFoundError:
         raise SystemExit("bootstrap: nvt-as-root or update-ca-certificates not found; refusing to continue without egress trust")
@@ -387,7 +388,7 @@ def apply_git_redirect(provider, grant, hosts):
     for host in hosts:
         # Config, not env, so the rewrite survives any shell. scrub_git_state
         # removed pre-existing rewrites before this managed one is installed.
-        run(["git", "config", "--global", f"url.{base_url}/.insteadOf", f"https://{host}/"])
+        run(["git", "config", "--global", "--add", f"url.{base_url}/.insteadOf", f"https://{host}/"])
         # git-SSH stays disallowed in mediated mode; rewriting the SSH remote
         # shape onto the mediated HTTPS route is a convenience, not a bypass.
         run(["git", "config", "--global", "--add", f"url.{base_url}/.insteadOf", f"git@{host}:"])

--- a/scripts/agent-init.sh
+++ b/scripts/agent-init.sh
@@ -399,10 +399,6 @@ PY
 
 mkdir -p "$egress_ca_dir"
 chmod 700 "$egress_ca_dir"
-if [ ! -e "$egress_ca_cert_file" ]; then
-  : >"$egress_ca_cert_file"
-fi
-chmod 644 "$egress_ca_cert_file" 2>/dev/null || true
 
 if [ "$egress_mode" = "mediated" ]; then
   {
@@ -433,31 +429,46 @@ target = Path(sys.argv[3])
 allow_insecure = sys.argv[4] in {"1", "true", "TRUE", "True", "yes", "YES", "Yes"}
 data = yaml.safe_load(agents_file.read_text(encoding="utf-8")) or {}
 agent = next((item for item in data.get("agents", []) if isinstance(item, dict) and item.get("id") == name), None)
-routes = []
-need_ca = False
+inject_routes = []
+seen_inject_routes = set()
 for grant in agent.get("grants", []) or []:
-    if not isinstance(grant, dict) or (grant.get("materialization") or "file-bundle") != "header-inject":
+    if not isinstance(grant, dict):
+        continue
+    materialization = grant.get("materialization") or "file-bundle"
+    if materialization not in {"header-inject", "placeholder-file"}:
         continue
     hosts = grant.get("egress-hosts") or grant.get("egressHosts") or []
-    route = {
-        "listen": f"0.0.0.0:{8471 + len(routes)}",
-        "capability": grant.get("provider"),
-        "upstream": hosts[0],
-        "allow_insecure_upstream": False,
-    }
-    quota = grant.get("quota")
-    if isinstance(quota, dict) and isinstance(quota.get("requests"), int):
-        route["max_requests"] = quota["requests"]
-    if grant.get("git"):
-        route["listen_tls"] = "ca"
-        need_ca = True
-    routes.append(route)
+    for host in hosts:
+        host = str(host).lower()
+        key = (host.split(":", 1)[0], grant.get("provider"))
+        if key in seen_inject_routes:
+            continue
+        seen_inject_routes.add(key)
+        route = {
+            "host": key[0],
+            "capability": grant.get("provider"),
+            "upstream": host,
+        }
+        quota = grant.get("quota")
+        if isinstance(quota, dict) and isinstance(quota.get("requests"), int):
+            route["max_requests"] = quota["requests"]
+        inject_routes.append(route)
 config = {
     "broker_url": "http://broker:7347",
     "allow_insecure_broker": allow_insecure,
-    "routes": routes,
+    "routes": [],
 }
-if need_ca:
+if inject_routes:
+    config["forward_proxy"] = {
+        "listen": "0.0.0.0:8470",
+        # Local compose remains a development backend: agents need normal
+        # internet access for package downloads and tool calls. Inject routes
+        # still mediate configured credential hosts; unmatched hosts are blind
+        # tunnels with no broker credential. Kubernetes enforcement is stricter
+        # and is handled by NetworkPolicy.
+        "allow_unmatched_hosts": True,
+        "inject_routes": inject_routes,
+    }
     config["ca"] = {
         "cert_file": "/etc/nvt-egress-ca/ca.crt",
         "key_file": "/etc/nvt-egress-ca/ca.key",
@@ -496,7 +507,7 @@ PY
       "$NVT_EGRESS_CA_INIT_BIN" \
         --cert-file "$egress_ca_cert_file" \
         --key-file "$egress_ca_key_file" \
-        "${ca_init_args[@]}"
+        ${ca_init_args+"${ca_init_args[@]}"}
     else
       docker run --rm \
         --user 0:0 \
@@ -505,8 +516,10 @@ PY
         "${NVT_EGRESSD_IMAGE:-nvt-egressd:latest}" \
         --cert-file /egress-ca/ca.crt \
         --key-file /egress-ca/ca.key \
-        "${ca_init_args[@]}"
+        ${ca_init_args+"${ca_init_args[@]}"}
     fi
+    chmod 644 "$egress_ca_cert_file" 2>/dev/null || true
+    chmod 600 "$egress_ca_key_file" 2>/dev/null || true
   fi
 else
   rm -f "$egressd_config_file"
@@ -572,6 +585,63 @@ config_file.write_text(text, encoding="utf-8")
 print(f"rendered preseed config into {config_file}")
 PY
 
+# Local compose needs runtime.proxy.provider for mediated forward-proxy mode.
+# The default generated runtime command is tool-specific, so agent-init owns
+# this small preset and keeps bootstrap generic.
+python3 - "$agent_config_file" "$broker_agents_file" "$name" "$egress_mode" "$agent_type" <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+config_file = Path(sys.argv[1])
+agents_file = Path(sys.argv[2])
+name = sys.argv[3]
+mode = sys.argv[4]
+agent_type = sys.argv[5]
+
+if mode != "mediated":
+    raise SystemExit(0)
+
+default_provider = {"codex": "codex-main", "claude": "claude-main"}.get(agent_type)
+if not default_provider:
+    raise SystemExit(0)
+
+text = config_file.read_text(encoding="utf-8")
+parsed = yaml.safe_load(text) or {}
+if not isinstance(parsed, dict):
+    raise SystemExit("agent-init: agent config is not a YAML object before runtime proxy rendering")
+runtime = parsed.get("runtime") or {}
+if not isinstance(runtime, dict):
+    raise SystemExit("agent-init: runtime must be a YAML object")
+proxy = runtime.get("proxy")
+if isinstance(proxy, dict) and proxy.get("provider"):
+    raise SystemExit(0)
+
+data = yaml.safe_load(agents_file.read_text(encoding="utf-8")) or {}
+agent = next((item for item in data.get("agents", []) if isinstance(item, dict) and item.get("id") == name), None)
+providers = {
+    grant.get("provider")
+    for grant in (agent or {}).get("grants", []) or []
+    if isinstance(grant, dict)
+}
+if default_provider not in providers:
+    raise SystemExit(f"agent-init: mediated {agent_type} agent requires broker grant {default_provider} or an explicit runtime.proxy.provider")
+
+lines = text.splitlines()
+runtime_index = next((index for index, line in enumerate(lines) if line == "runtime:"), None)
+if runtime_index is None:
+    raise SystemExit("agent-init: runtime block is required")
+insert_at = len(lines)
+for index in range(runtime_index + 1, len(lines)):
+    if lines[index] and not lines[index].startswith((" ", "\t", "#")):
+        insert_at = index
+        break
+lines[insert_at:insert_at] = ["  proxy:", f"    provider: {default_provider}"]
+config_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+print(f"rendered runtime proxy provider {default_provider} into {config_file}")
+PY
+
 # Manage the egress block in agent.yaml: bootstrap reads egress.grants
 # (base-url per route) from the agent config, so the compose path must render
 # the same grant metadata the operator injects on k8s. The block lives
@@ -600,17 +670,27 @@ if changed:
 if mode == "mediated":
     data = yaml.safe_load(agents_file.read_text(encoding="utf-8")) or {}
     agent = next((item for item in data.get("agents", []) if isinstance(item, dict) and item.get("id") == name), None)
-    lines = [BEGIN, "egress:", "  mode: mediated", "  placeholder: NVT-PLACEHOLDER-NOT-A-KEY", "  grants:"]
-    index = 0
+    lines = [
+        BEGIN,
+        "egress:",
+        "  mode: mediated",
+        "  placeholder: NVT-PLACEHOLDER-NOT-A-KEY",
+        "  forward-proxy: true",
+        "  forward-proxy-url: http://127.0.0.1:8470",
+        "  grants:",
+    ]
     for grant in (agent or {}).get("grants", []) or []:
         if not isinstance(grant, dict) or (grant.get("materialization") or "file-bundle") != "header-inject":
             continue
-        # Route order and ports must match the egressd.json render above.
-        scheme = "https" if grant.get("git") else "http"
         lines.append(f"    - provider: {grant.get('provider')}")
         lines.append("      materialization: header-inject")
-        lines.append(f"      base-url: {scheme}://127.0.0.1:{8471 + index}")
-        index += 1
+        hosts = grant.get("egress-hosts") or grant.get("egressHosts") or []
+        if hosts:
+            lines.append("      egress-hosts:")
+            for host in hosts:
+                lines.append(f"      - {host}")
+        if grant.get("git"):
+            lines.append("      git: true")
     # placeholder-file grants carry no egressd route (edge injection is Phase
     # 6.2); bootstrap only needs provider + mode to materialize the file.
     for grant in (agent or {}).get("grants", []) or []:
@@ -618,6 +698,11 @@ if mode == "mediated":
             continue
         lines.append(f"    - provider: {grant.get('provider')}")
         lines.append("      materialization: placeholder-file")
+        hosts = grant.get("egress-hosts") or grant.get("egressHosts") or []
+        if hosts:
+            lines.append("      egress-hosts:")
+            for host in hosts:
+                lines.append(f"      - {host}")
     lines.append(END)
     text = text.rstrip("\n") + "\n\n" + "\n".join(lines) + "\n"
     changed = True

--- a/tests/runtime/compose_agent_test.go
+++ b/tests/runtime/compose_agent_test.go
@@ -970,6 +970,10 @@ func TestAgentInitMediatedKeepsEgressTokenOutOfAgentEnv(t *testing.T) {
 - id: mediated-env-boundary
   token-sha256: sha256:0000000000000000000000000000000000000000000000000000000000000000
   grants:
+    - provider: codex-main
+      materialization: placeholder-file
+      egress-hosts:
+        - chatgpt.com:443
     - provider: api-main
       materialization: header-inject
       egress-hosts:
@@ -978,7 +982,8 @@ func TestAgentInitMediatedKeepsEgressTokenOutOfAgentEnv(t *testing.T) {
         - example/repo
 `)
 	home := t.TempDir()
-	command := "HOME=" + shellQuote(home) + " MEDIATED=1 NVT_EGRESS_ALLOW_INSECURE_BROKER=1 bash " + shellQuote(filepath.Join(root, "scripts", "agent-init.sh"))
+	caInitBin := buildEgressCAInit(t, root)
+	command := "HOME=" + shellQuote(home) + " NVT_EGRESS_CA_INIT_BIN=" + shellQuote(caInitBin) + " MEDIATED=1 NVT_EGRESS_ALLOW_INSECURE_BROKER=1 bash " + shellQuote(filepath.Join(root, "scripts", "agent-init.sh"))
 	cmd := commandWithEnv(command, nil, "--name", name)
 	cmd.Dir = root
 	output, err := cmd.CombinedOutput()
@@ -1069,6 +1074,9 @@ func TestAgentInitMediatedRendersMultiRouteWithGitCA(t *testing.T) {
 - id: mediated-multi-route
   token-sha256: sha256:0000000000000000000000000000000000000000000000000000000000000000
   grants:
+    - provider: codex-main
+      materialization: placeholder-file
+      egress-hosts: [chatgpt.com:443]
     - provider: api-main
       materialization: header-inject
       egress-hosts: [api.example.test:443]
@@ -1091,19 +1099,33 @@ func TestAgentInitMediatedRendersMultiRouteWithGitCA(t *testing.T) {
 		t.Fatalf("agent-init failed: %v\n%s", err, output)
 	}
 	var config struct {
-		Routes []map[string]any `json:"routes"`
-		CA     map[string]any   `json:"ca"`
+		Routes       []map[string]any `json:"routes"`
+		ForwardProxy struct {
+			Listen              string           `json:"listen"`
+			AllowUnmatchedHosts bool             `json:"allow_unmatched_hosts"`
+			InjectRoutes        []map[string]any `json:"inject_routes"`
+		} `json:"forward_proxy"`
+		CA map[string]any `json:"ca"`
 	}
 	decodeJSONFile(t, filepath.Join(agentDir, "egressd.json"), &config)
-	if len(config.Routes) != 2 {
-		t.Fatalf("expected one route per header-inject grant, got %#v", config.Routes)
+	if len(config.Routes) != 0 {
+		t.Fatalf("compose mediated egress should use forward_proxy routes, got %#v", config.Routes)
 	}
-	api, git := config.Routes[0], config.Routes[1]
-	if api["listen"] != "0.0.0.0:8471" || api["capability"] != "api-main" || api["listen_tls"] != nil {
-		t.Fatalf("unexpected api route: %#v", api)
+	if config.ForwardProxy.Listen != "0.0.0.0:8470" || len(config.ForwardProxy.InjectRoutes) != 3 {
+		t.Fatalf("unexpected forward proxy config: %#v", config.ForwardProxy)
 	}
-	if git["listen"] != "0.0.0.0:8472" || git["capability"] != "git-app" || git["listen_tls"] != "ca" {
-		t.Fatalf("unexpected git route: %#v", git)
+	if !config.ForwardProxy.AllowUnmatchedHosts {
+		t.Fatal("local compose forward proxy should blind-tunnel unmatched hosts for dev egress")
+	}
+	codex, api, git := config.ForwardProxy.InjectRoutes[0], config.ForwardProxy.InjectRoutes[1], config.ForwardProxy.InjectRoutes[2]
+	if codex["host"] != "chatgpt.com" || codex["capability"] != "codex-main" || codex["upstream"] != "chatgpt.com:443" {
+		t.Fatalf("unexpected codex inject route: %#v", codex)
+	}
+	if api["host"] != "api.example.test" || api["capability"] != "api-main" || api["upstream"] != "api.example.test:443" {
+		t.Fatalf("unexpected api inject route: %#v", api)
+	}
+	if git["host"] != "github.com" || git["capability"] != "git-app" || git["upstream"] != "github.com:443" {
+		t.Fatalf("unexpected git inject route: %#v", git)
 	}
 	if config.CA["cert_file"] != "/etc/nvt-egress-ca/ca.crt" || config.CA["key_file"] != "/etc/nvt-egress-ca/ca.key" {
 		t.Fatalf("unexpected durable CA config: %#v", config.CA)
@@ -1119,6 +1141,11 @@ func TestAgentInitMediatedRendersMultiRouteWithGitCA(t *testing.T) {
 	}
 	if !strings.Contains(string(certBytes), "BEGIN CERTIFICATE") {
 		t.Fatalf("durable CA cert is not PEM:\n%s", certBytes)
+	}
+	if info, err := os.Stat(certPath); err != nil {
+		t.Fatalf("stat durable CA cert: %v", err)
+	} else if info.Mode().Perm() != 0o644 {
+		t.Fatalf("durable CA cert mode = %v, want 0644", info.Mode().Perm())
 	}
 	keyBytes, err := os.ReadFile(keyPath)
 	if err != nil {
@@ -1142,20 +1169,28 @@ func TestAgentInitMediatedRendersMultiRouteWithGitCA(t *testing.T) {
 	}
 	firstFingerprint := sha256.Sum256(certBytes)
 
-	// The agent config must carry the same grant metadata the operator
-	// injects on k8s — bootstrap reads egress.grants (base-url per route)
-	// from agent.yaml, so without this block the sidecar starts but git/tool
-	// wiring never happens. agent-init validates the merged YAML parses; the
-	// block is machine-generated, so exact-string assertions are stable.
+	// The agent config must carry the same grant metadata bootstrap needs:
+	// forward-proxy mode plus provider/host metadata. Without this block the
+	// sidecar starts but runtime proxy and tool wiring never happen.
 	agentConfig := mustReadFile(t, filepath.Join(agentDir, "agent.yaml"))
 	for _, fragment := range []string{
+		"runtime:",
+		"  proxy:",
+		"    provider: codex-main",
 		"egress:",
 		"  mode: mediated",
+		"  forward-proxy: true",
+		"  forward-proxy-url: http://127.0.0.1:8470",
+		"    - provider: codex-main",
+		"      materialization: placeholder-file",
+		"      - chatgpt.com:443",
 		"    - provider: api-main",
-		"      base-url: http://127.0.0.1:8471",
+		"      egress-hosts:",
+		"      - api.example.test:443",
 		"    - provider: git-app",
 		"      materialization: header-inject",
-		"      base-url: https://127.0.0.1:8472",
+		"      - github.com:443",
+		"      git: true",
 	} {
 		if !strings.Contains(agentConfig, fragment) {
 			t.Fatalf("agent.yaml missing egress fragment %q:\n%s", fragment, agentConfig)


### PR DESCRIPTION
## Summary
- render local compose mediated agents with the forward-proxy egressd shape instead of stale same-Pod routes
- let egress-ca-init own durable CA creation, keep ca.crt readable and ca.key private, and install the CA with readable permissions in bootstrap
- allow multiple Git insteadOf entries for same-Pod git grants and include sanitized upstream errors in egressd logs

## Tests
- `PATH=/private/tmp/nvt-agent-test-venv/bin:$PATH GOCACHE=/private/tmp/nvt-go-cache go test -count=1 -run 'TestBootstrap|TestMediated|TestCompose|TestAgentInit|TestGitHostCredential|TestGhAuth|TestGitCredentials' -v .` from `tests/runtime`\n- `GOCACHE=/private/tmp/nvt-go-cache go test ./...` from `egressd`\n\n## Live validation\n- Rebuilt runtime and egressd images\n- Regenerated `nvtclaude` with `MEDIATED=1 NVT_EGRESS_ALLOW_INSECURE_BROKER=1 --user non-root`\n- `git ls-remote origin HEAD` succeeds through mediated Git\n- `claude --dangerously-skip-permissions -p "reply with exactly pong"` returns `pong` through mediated Claude auth\n