### PR TITLE
Harden Claude OAuth refresh state

### DIFF
--- a/broker/plugins/claude_oauth/provider.py
+++ b/broker/plugins/claude_oauth/provider.py
@@ -27,9 +27,11 @@ headers with no Claude-specific logic.
 Refresh: the broker keeps the broker-side access token fresh over the network
 (an OAuth ``refresh_token`` exchange against ``token-url``, analogous to the
 Codex flow). Claude credentials only expose ``expiresAt`` for the *access*
-token; refresh-token expiry is unknown, so the broker refreshes the access
-token proactively (before ``expiresAt`` minus a safety margin) rather than
-waiting for a 401. Refresh is serialized: single-flight *within* the broker
+token. Newer Claude credentials may also carry ``refreshTokenExpiresAt``; the
+broker preserves it and advances it when the token endpoint returns
+``refresh_token_expires_in``. Access-token refresh remains proactive (before
+``expiresAt`` minus a safety margin) rather than waiting for a 401. Refresh is
+serialized: single-flight *within* the broker
 process (a thread lock) and *across* processes (an advisory ``flock`` on a lock
 file beside ``credentials-file``) so a second broker or the manual probe cannot
 run a competing refresh-token exchange and invalidate the rotation. It is
@@ -87,10 +89,11 @@ DEFAULT_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 DEFAULT_REFRESH_SCOPE = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 DEFAULT_USER_AGENT = "axios/1.15.2"
 # Refresh the access token this many seconds before its expiresAt. Claude
-# credentials do not expose refresh-token expiry, so we cannot key off it; a
-# generous access-token margin keeps a usable token in hand well before Claude
-# Code would notice a 401 and start retrying.
+# Refresh is driven by access-token expiry. A refresh-token expiry, when known,
+# is retained for operator visibility but cannot replace proactive access-token
+# refresh: no token exchange can extend a refresh token after it has expired.
 DEFAULT_REFRESH_MARGIN_SECONDS = 900
+DEFAULT_REFRESH_EXPIRY_WARNING_SECONDS = 5 * 24 * 60 * 60
 # After a transient refresh failure, cache the sanitized failure for a cooldown
 # (with light jitter and exponential backoff up to the max) so concurrent Claude
 # CLI retries do not hammer the OAuth endpoint. Fail fast (or serve a still-valid
@@ -156,6 +159,9 @@ class ClaudeOAuthProvider:
         self.refresh_scope = self._provider_value("refresh-scope", DEFAULT_REFRESH_SCOPE)
         self.user_agent = self._provider_value("user-agent", DEFAULT_USER_AGENT)
         self.refresh_margin_seconds = self._int_config("refresh-margin-seconds", DEFAULT_REFRESH_MARGIN_SECONDS)
+        self.refresh_expiry_warning_seconds = self._int_config(
+            "refresh-expiry-warning-seconds", DEFAULT_REFRESH_EXPIRY_WARNING_SECONDS
+        )
         self.refresh_cooldown_seconds = self._int_config("refresh-cooldown-seconds", DEFAULT_REFRESH_COOLDOWN_SECONDS)
         self.refresh_cooldown_max_seconds = self._int_config(
             "refresh-cooldown-max-seconds", DEFAULT_REFRESH_COOLDOWN_MAX_SECONDS
@@ -176,6 +182,7 @@ class ClaudeOAuthProvider:
         self._cooldown_until = 0.0
         self._cooldown_error = None
         self._backoff_seconds = self.refresh_cooldown_seconds
+        self._refresh_expiry_warned = False
 
     def _source(self):
         # Exactly one broker-side source of the Claude credentials. A host path
@@ -332,6 +339,26 @@ class ClaudeOAuthProvider:
             return None
         return int(exp_ms // 1000)
 
+    def _refresh_expiry_seconds(self, oauth):
+        exp_ms = oauth.get("refreshTokenExpiresAt")
+        if not isinstance(exp_ms, (int, float)) or isinstance(exp_ms, bool):
+            return None
+        return int(exp_ms // 1000)
+
+    def _warn_refresh_expiry(self, oauth):
+        exp = self._refresh_expiry_seconds(oauth)
+        if exp is None:
+            return
+        if exp - int(time.time()) > self.refresh_expiry_warning_seconds:
+            self._refresh_expiry_warned = False
+            return
+        if not self._refresh_expiry_warned:
+            self._log(
+                f"refresh authorization expires at {rfc3339(exp)}; "
+                "replace the broker credential from a trusted login before then"
+            )
+            self._refresh_expiry_warned = True
+
     # --- proactive, single-flight refresh -----------------------------------
 
     def _can_refresh(self):
@@ -358,6 +385,7 @@ class ClaudeOAuthProvider:
         if margin is None:
             margin = self.refresh_margin_seconds
         data, oauth = self._read_credentials()
+        self._warn_refresh_expiry(oauth)
         access_token = self._access_token(oauth)
         exp = self._expiry_seconds(oauth)
         now = int(time.time())
@@ -411,7 +439,12 @@ class ClaudeOAuthProvider:
                     return data, oauth, access_token, exp, False
                 # Expired and refresh failed on the mediated path: fail closed.
                 raise
-            self._persist(refreshed)
+            try:
+                self._persist(refreshed)
+            except ProviderError as error:
+                self._enter_cooldown(error)
+                self._audit_refresh(audit, request_id, agent_id, operation_prefix, False, None, error.reason)
+                raise
             self._reset_cooldown()
             data = refreshed
             oauth = data["claudeAiOauth"]
@@ -543,7 +576,19 @@ class ClaudeOAuthProvider:
         rotated = payload.get("refresh_token")
         if isinstance(rotated, str) and rotated:
             updated_oauth["refreshToken"] = rotated
-        updated_oauth["expiresAt"] = (int(time.time()) + int(expires_in)) * 1000
+        now = time.time()
+        updated_oauth["expiresAt"] = int((now + float(expires_in)) * 1000)
+        refresh_expires_in = payload.get("refresh_token_expires_in")
+        if (
+            isinstance(refresh_expires_in, (int, float))
+            and not isinstance(refresh_expires_in, bool)
+            and refresh_expires_in > 0
+        ):
+            updated_oauth["refreshTokenExpiresAt"] = int((now + float(refresh_expires_in)) * 1000)
+        scope = payload.get("scope")
+        if isinstance(scope, str):
+            updated_oauth["scopes"] = scope.split()
+        updated_oauth["clientId"] = self.client_id
         return updated
 
     def _classify_http_error(self, error):
@@ -599,24 +644,46 @@ class ClaudeOAuthProvider:
                 "credentials-env source cannot persist a rotated Claude credential",
                 502,
             )
-        self._write_credentials(data)
+        try:
+            self._write_credentials(data)
+        except OSError as error:
+            raise ProviderError(
+                "token-refresh-persist-failed",
+                "Claude token refresh succeeded but the rotated credential could not be persisted",
+                502,
+            ) from error
 
     def _write_credentials(self, data):
         path = self.credentials_file
         path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            mode = path.stat().st_mode & 0o777
-        except FileNotFoundError:
-            mode = 0o600
         temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+        retain_recovery = False
         try:
-            with temporary.open("w", encoding="utf-8") as file:
+            # Create secret-bearing temporary state as 0600 from its first byte;
+            # writing with the process umask and chmodding afterward creates a
+            # brief world/group-readable exposure window on permissive umasks.
+            fd = os.open(str(temporary), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as file:
                 json.dump(data, file, indent=2)
                 file.write("\n")
-            temporary.chmod(mode)
-            os.replace(temporary, path)
+                file.flush()
+                os.fsync(file.fileno())
+            try:
+                os.replace(temporary, path)
+            except OSError:
+                # The upstream may already have invalidated the old refresh
+                # token. Retain the fully-written 0600 file as the only possible
+                # recovery copy instead of deleting the rotated credential.
+                retain_recovery = True
+                raise
+            directory_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
         finally:
-            temporary.unlink(missing_ok=True)
+            if not retain_recovery:
+                temporary.unlink(missing_ok=True)
 
     def _log(self, message):
         # Provider diagnostics only — callers must never pass token material.
@@ -726,18 +793,22 @@ class ClaudeOAuthProvider:
             data, oauth = self._read_credentials()
             self._access_token(oauth)
             old_exp = self._expiry_seconds(oauth)
+            old_refresh_exp = self._refresh_expiry_seconds(oauth)
             old_refresh = oauth.get("refreshToken")
             refreshed = self._refresh(data, oauth)
             self._persist(refreshed)
             self._reset_cooldown()
             new_oauth = refreshed["claudeAiOauth"]
             new_exp = self._expiry_seconds(new_oauth)
+            new_refresh_exp = self._refresh_expiry_seconds(new_oauth)
             return {
                 "status": "ok",
                 "source": "credentials-file",
                 "keys": sorted(new_oauth.keys()),
                 "old_expires_at": rfc3339(old_exp) if old_exp is not None else None,
                 "new_expires_at": rfc3339(new_exp) if new_exp is not None else None,
+                "old_refresh_expires_at": rfc3339(old_refresh_exp) if old_refresh_exp is not None else None,
+                "new_refresh_expires_at": rfc3339(new_refresh_exp) if new_refresh_exp is not None else None,
                 "refresh_token_rotated": bool(new_oauth.get("refreshToken") != old_refresh),
             }
 

--- a/broker/plugins/claude_oauth/provider.py
+++ b/broker/plugins/claude_oauth/provider.py
@@ -58,6 +58,7 @@ import json
 import os
 import random
 import re
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -88,7 +89,6 @@ DEFAULT_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 # not a stable API contract documented by Anthropic.
 DEFAULT_REFRESH_SCOPE = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
 DEFAULT_USER_AGENT = "axios/1.15.2"
-# Refresh the access token this many seconds before its expiresAt. Claude
 # Refresh is driven by access-token expiry. A refresh-token expiry, when known,
 # is retained for operator visibility but cannot replace proactive access-token
 # refresh: no token exchange can extend a refresh token after it has expired.
@@ -420,7 +420,10 @@ class ClaudeOAuthProvider:
                 if exp is not None and exp > now:
                     self._log("refresh in cooldown; serving current valid access token")
                     return data, oauth, access_token, exp, False
-                if serve_expired:
+                if serve_expired and not (
+                    self._cooldown_error is not None
+                    and self._cooldown_error.reason == "token-refresh-persist-failed"
+                ):
                     return data, oauth, access_token, exp, False
                 raise self._cooldown_failure()
             try:
@@ -444,6 +447,9 @@ class ClaudeOAuthProvider:
             except ProviderError as error:
                 self._enter_cooldown(error)
                 self._audit_refresh(audit, request_id, agent_id, operation_prefix, False, None, error.reason)
+                if exp is not None and exp > now:
+                    self._log(f"refresh persistence failed ({error.reason}); serving current valid access token")
+                    return data, oauth, access_token, exp, False
                 raise
             self._reset_cooldown()
             data = refreshed
@@ -586,8 +592,9 @@ class ClaudeOAuthProvider:
         ):
             updated_oauth["refreshTokenExpiresAt"] = int((now + float(refresh_expires_in)) * 1000)
         scope = payload.get("scope")
-        if isinstance(scope, str):
-            updated_oauth["scopes"] = scope.split()
+        granted_scopes = scope.split() if isinstance(scope, str) else []
+        if granted_scopes:
+            updated_oauth["scopes"] = granted_scopes
         updated_oauth["clientId"] = self.client_id
         return updated
 
@@ -656,14 +663,20 @@ class ClaudeOAuthProvider:
     def _write_credentials(self, data):
         path = self.credentials_file
         path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+        recovery_prefix = path.name if path.name.startswith(".") else f".{path.name}"
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=f"{recovery_prefix}.recovery.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        temporary = Path(temporary_name)
         retain_recovery = False
         try:
             # Create secret-bearing temporary state as 0600 from its first byte;
             # writing with the process umask and chmodding afterward creates a
             # brief world/group-readable exposure window on permissive umasks.
-            fd = os.open(str(temporary), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as file:
+                os.fchmod(file.fileno(), 0o600)
                 json.dump(data, file, indent=2)
                 file.write("\n")
                 file.flush()
@@ -676,11 +689,18 @@ class ClaudeOAuthProvider:
                 # recovery copy instead of deleting the rotated credential.
                 retain_recovery = True
                 raise
-            directory_fd = os.open(str(path.parent), os.O_RDONLY)
             try:
-                os.fsync(directory_fd)
-            finally:
-                os.close(directory_fd)
+                directory_fd = os.open(str(path.parent), os.O_RDONLY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+            except OSError:
+                # Replacement already succeeded and the canonical content is
+                # complete. Some filesystems do not support opening/fsyncing a
+                # directory; report reduced crash durability without turning a
+                # successful credential replacement into a failed refresh.
+                self._log("credential replaced but directory fsync failed; crash durability is uncertain")
         finally:
             if not retain_recovery:
                 temporary.unlink(missing_ok=True)

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -147,11 +147,16 @@ backoff. If refresh fails:
   or refresh-failed;
 - token values and response bodies never enter logs or audit events.
 
-Credential replacement is written and `fsync`ed before atomic rename, then the
-parent directory is `fsync`ed. If rename fails after Anthropic has rotated the
-token, the completed mode-`0600` temporary file is retained beside the
-canonical credential as the recovery copy and the mediated request fails
-closed with `token-refresh-persist-failed`.
+Credential replacement is written and `fsync`ed before atomic rename. The
+canonical file is intentionally forced to mode `0600`; deployments must not
+depend on group-readable broker credentials. The parent directory is then
+`fsync`ed when the filesystem supports it; a post-rename directory-`fsync`
+failure is logged as reduced crash durability without misreporting the completed
+replacement as a content failure. If rename itself fails after Anthropic has
+rotated the token, a uniquely named mode-`0600` temporary file is retained
+beside the canonical credential as the recovery copy. A still-valid canonical
+access token may continue during cooldown; expired use fails closed with
+`token-refresh-persist-failed`.
 
 Placeholder-file vending does not itself refresh because the file contains no
 usable token.

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -43,6 +43,7 @@ providers:
     config:
       credentials-file: /broker-secrets/claude/.credentials.json
       refresh-margin-seconds: 600
+      refresh-expiry-warning-seconds: 432000
       injection-hosts:
         - api.anthropic.com
         - mcp-proxy.anthropic.com
@@ -123,8 +124,18 @@ non-injection traffic as policy-approved blind tunnels.
 ## Refresh
 
 Before injection or direct file vending, the broker refreshes when `expiresAt`
-enters `refresh-margin-seconds` (default 900). A successful exchange persists
-the new access token, rotated refresh token, and expiry atomically.
+enters `refresh-margin-seconds` (default 900). A successful exchange durably
+persists the new access token, any rotated refresh token, access expiry,
+returned refresh-token expiry, granted scopes, and OAuth client ID. Older
+credentials or responses may omit refresh-token expiry; in that case the
+existing value is preserved.
+
+Rotation and lifetime extension are separate: a new refresh token can retain
+the old token's absolute expiry. Monitor the persisted
+`refreshTokenExpiresAt` and replace the broker credential from a trusted login
+before it lapses; once it expires, interactive login is required. The provider
+logs one sanitized warning when the authorization enters
+`refresh-expiry-warning-seconds` (default five days).
 
 Refresh is single-flight in-process and protected across processes by a lock
 beside the credential file. Transient failures use bounded cooldown and
@@ -135,6 +146,12 @@ backoff. If refresh fails:
 - errors expose only a sanitized class such as rate-limited, login-required,
   or refresh-failed;
 - token values and response bodies never enter logs or audit events.
+
+Credential replacement is written and `fsync`ed before atomic rename, then the
+parent directory is `fsync`ed. If rename fails after Anthropic has rotated the
+token, the completed mode-`0600` temporary file is retained beside the
+canonical credential as the recovery copy and the mediated request fails
+closed with `token-refresh-persist-failed`.
 
 Placeholder-file vending does not itself refresh because the file contains no
 usable token.
@@ -150,7 +167,8 @@ python3 scripts/claude-refresh-probe.py \
 ```
 
 The probe uses the same cross-process lock as the broker, persists rotation,
-and prints only metadata such as expiry and whether the refresh token rotated.
+and prints only metadata such as old/new access and refresh expiry and whether
+the refresh token rotated.
 It refuses `credentials-env` because rotation cannot be persisted there.
 
 Never run competing native and broker refreshes against the same refresh token.

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -491,11 +491,16 @@ Refresh is hardened against retry storms:
   event, so cooldowns cannot manufacture noisy or misleading duplicate
   upstream-refresh events. A successful refresh audits `allowed: true` with the
   new expiry.
-- **Durable rotation.** The refreshed credential is file- and directory-`fsync`ed
-  around atomic replacement. If replacement fails after upstream rotation, the
-  completed mode-`0600` temporary credential is retained beside the canonical
-  file as a recovery copy, the failure is audited as
-  `token-refresh-persist-failed`, and mediated use fails closed.
+- **Durable rotation.** The refreshed credential is created as mode `0600`,
+  file-`fsync`ed, and atomically replaces the canonical file (also intentionally
+  mode `0600`; group-readable sharing is unsupported). Directory `fsync` is
+  attempted after replacement; an unsupported/failed directory `fsync` logs
+  reduced crash durability but does not misreport the completed replacement as
+  a content failure. If replacement itself fails after upstream rotation, the
+  uniquely named completed temporary credential is retained beside the
+  canonical file as a recovery copy and the failure is audited as
+  `token-refresh-persist-failed`. A still-valid canonical access token may be
+  served during cooldown; expired use fails closed.
 
 **Sanitized diagnostics.** A refresh failure surfaces only the upstream HTTP
 status and a safe OAuth error class (e.g. `HTTP 429 (rate_limit_error)`) in the

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -443,15 +443,24 @@ providers:
 **Refresh.** The broker keeps the broker-side Claude access token fresh over the
 network with an OAuth `refresh_token` exchange (`token-url`/`client-id`,
 analogous to the Codex flow; both default to Claude Code's public values and are
-overridable). Claude credentials expose `expiresAt` for the **access token
-only** — refresh-token expiry is unknown from the credential — so the broker
-cannot wait for a signal that the refresh token is about to lapse. Instead it
+overridable). Claude credentials expose `expiresAt` for the access token and
+newer versions may also expose `refreshTokenExpiresAt`. The latter is useful
+status metadata, but the broker cannot wait until it lapses because an expired
+refresh token cannot renew itself. Instead it
 refreshes **proactively**: on any `/v1/files` or `/v1/injection/headers` request
 where the access token is within `refresh-margin-seconds` (default 900) of
 `expiresAt`, it exchanges the refresh token, persists the rotated credential
-(new `accessToken`, any rotated `refreshToken`, recomputed `expiresAt`) back to
-`credentials-file`, and serves the fresh token. This front-runs Claude Code's
+(new `accessToken`, any rotated `refreshToken`, recomputed `expiresAt`, returned
+`refreshTokenExpiresAt`, granted scopes, and client ID) back to
+`credentials-file`, and serves the fresh token. If the response omits refresh
+expiry or scope metadata, the existing value is preserved. This front-runs Claude Code's
 own 401-driven retries, which would otherwise storm the OAuth endpoint.
+
+Anthropic's returned `refresh_token_expires_in` is authoritative and is
+persisted as `refreshTokenExpiresAt`; rotation alone does not imply lifetime
+extension. Operators must replace the broker credential from a trusted login
+before that absolute expiry. The provider emits one sanitized warning when the
+credential enters `refresh-expiry-warning-seconds` (default 432000, five days).
 
 Refresh is hardened against retry storms:
 
@@ -482,6 +491,11 @@ Refresh is hardened against retry storms:
   event, so cooldowns cannot manufacture noisy or misleading duplicate
   upstream-refresh events. A successful refresh audits `allowed: true` with the
   new expiry.
+- **Durable rotation.** The refreshed credential is file- and directory-`fsync`ed
+  around atomic replacement. If replacement fails after upstream rotation, the
+  completed mode-`0600` temporary credential is retained beside the canonical
+  file as a recovery copy, the failure is audited as
+  `token-refresh-persist-failed`, and mediated use fails closed.
 
 **Sanitized diagnostics.** A refresh failure surfaces only the upstream HTTP
 status and a safe OAuth error class (e.g. `HTTP 429 (rate_limit_error)`) in the
@@ -509,7 +523,7 @@ not reintroduce in-memory env refresh without a genuinely durable sink.
 **Manual probe.** `scripts/claude-refresh-probe.py --provider <name>` runs a
 single one-shot refresh against the configured `token-url`, persists the rotated
 credential on success, and prints only redacted metadata (status, credential
-field names, old/new `expiresAt`, whether the refresh token rotated). It refuses
+field names, old/new access and refresh expiry, whether the refresh token rotated). It refuses
 a `credentials-env` source (rotation cannot be persisted there). It is safe to
 run against a live broker: it takes the same cross-process refresh `flock` as
 the broker's own refresh, so the two serialize instead of racing two rotating

--- a/scripts/claude-refresh-probe.py
+++ b/scripts/claude-refresh-probe.py
@@ -5,8 +5,8 @@ Loads the broker config, instantiates the named ``claude-oauth`` provider, and
 performs a single refresh-token exchange against its configured ``token-url``.
 On success the rotated credential is persisted (to ``credentials-file``) and
 only redacted metadata is printed — status, credential field names, old/new
-``expiresAt``, and whether the refresh token rotated. Token values are never
-printed.
+access/refresh expiry, and whether the refresh token rotated. Token values are
+never printed.
 
 This replaces ad-hoc Python run inside a live agent/broker container. It refuses
 a ``credentials-env`` source, because a rotated credential cannot be written

--- a/tests/broker/broker_conformance_test.go
+++ b/tests/broker/broker_conformance_test.go
@@ -128,16 +128,18 @@ func (f *fakeOAuth) lastRequest() map[string]string {
 // flow. It is independently controllable so tests can exercise rotation,
 // rate-limit (429), re-login (invalid_grant), and slow/concurrent refreshes.
 type fakeClaudeOAuth struct {
-	server    *httptest.Server
-	mu        sync.Mutex
-	requests  []map[string]any
-	status    int           // non-2xx status to return instead of a token, 0 for success
-	errorType string        // OAuth/API error code echoed in the error body
-	rotate    bool          // include a rotated refresh_token in the response
-	expiresIn int           // access token lifetime in seconds (default 3600)
-	delay     time.Duration // artificial latency, to widen the concurrency window
-	inFlight  int           // upstream refreshes currently being served
-	maxFlight int           // high-water mark of concurrent upstream refreshes
+	server           *httptest.Server
+	mu               sync.Mutex
+	requests         []map[string]any
+	status           int           // non-2xx status to return instead of a token, 0 for success
+	errorType        string        // OAuth/API error code echoed in the error body
+	rotate           bool          // include a rotated refresh_token in the response
+	expiresIn        int           // access token lifetime in seconds (default 3600)
+	refreshExpiresIn int           // refresh token lifetime in seconds (omitted when zero)
+	scope            string        // granted scope string (omitted when empty)
+	delay            time.Duration // artificial latency, to widen the concurrency window
+	inFlight         int           // upstream refreshes currently being served
+	maxFlight        int           // high-water mark of concurrent upstream refreshes
 }
 
 func newFakeClaudeOAuth(t *testing.T) *fakeClaudeOAuth {
@@ -170,6 +172,8 @@ func (f *fakeClaudeOAuth) handleToken(w http.ResponseWriter, r *http.Request) {
 	errorType := f.errorType
 	rotate := f.rotate
 	expiresIn := f.expiresIn
+	refreshExpiresIn := f.refreshExpiresIn
+	scope := f.scope
 	delay := f.delay
 	// Track concurrent in-flight upstream refreshes so a test can assert the
 	// broker/probe cross-process lock actually serializes them.
@@ -206,6 +210,12 @@ func (f *fakeClaudeOAuth) handleToken(w http.ResponseWriter, r *http.Request) {
 	}
 	if rotate {
 		response["refresh_token"] = fmt.Sprintf("rotated-claude-refresh-%d", count)
+	}
+	if refreshExpiresIn > 0 {
+		response["refresh_token_expires_in"] = refreshExpiresIn
+	}
+	if scope != "" {
+		response["scope"] = scope
 	}
 	writeJSON(w, response)
 }

--- a/tests/broker/claude_refresh_conformance_test.go
+++ b/tests/broker/claude_refresh_conformance_test.go
@@ -178,7 +178,10 @@ func TestClaudeRefreshPersistsRotatedToken(t *testing.T) {
 func TestClaudeRefreshPreservesOptionalMetadataWhenResponseOmitsIt(t *testing.T) {
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(claudePlaceholderIdentities())
-	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) { c.rotate = true })
+	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) {
+		c.rotate = true
+		c.scope = "   "
+	})
 	refreshExpiresAt := time.Now().Add(20 * 24 * time.Hour).UnixMilli()
 	writeJSONFile(t, f.claudeCreds, map[string]any{
 		"claudeAiOauth": map[string]any{
@@ -200,6 +203,118 @@ func TestClaudeRefreshPreservesOptionalMetadataWhenResponseOmitsIt(t *testing.T)
 	}
 	if got := oauth["scopes"]; !reflect.DeepEqual(got, []any{"user:inference", "user:profile"}) {
 		t.Fatalf("scopes changed when the response omitted them: %#v", got)
+	}
+}
+
+// TestClaudeRefreshRecoverySurvivesNextPersist pins the recovery contract: a
+// failed canonical replacement leaves a unique 0600 copy, and the next persist
+// uses another temporary name without deleting or overwriting that recovery.
+func TestClaudeRefreshRecoverySurvivesNextPersist(t *testing.T) {
+	out, err := runBrokerPython(t, `
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+from broker.plugins.claude_oauth.provider import ClaudeOAuthProvider
+
+with tempfile.TemporaryDirectory() as directory:
+    path = Path(directory) / ".credentials.json"
+    path.write_text('{"claudeAiOauth":{"accessToken":"old","refreshToken":"old"}}')
+    path.chmod(0o600)
+    provider = ClaudeOAuthProvider({"name": "claude-main", "config": {
+        "credentials-file": str(path),
+        "injection-hosts": ["api.anthropic.com"],
+    }})
+    first = {"claudeAiOauth": {"accessToken": "first", "refreshToken": "first"}}
+    second = {"claudeAiOauth": {"accessToken": "second", "refreshToken": "second"}}
+    real_replace = os.replace
+    def fail_canonical(source, target):
+        if Path(target) == path:
+            raise OSError("injected replace failure")
+        return real_replace(source, target)
+    try:
+        with patch("broker.plugins.claude_oauth.provider.os.replace", side_effect=fail_canonical):
+            provider._write_credentials(first)
+    except OSError:
+        pass
+    else:
+        raise SystemExit("expected replacement failure")
+    recoveries = list(path.parent.glob(".credentials.json.recovery.*.tmp"))
+    if len(recoveries) != 1:
+        raise SystemExit(f"expected one recovery, got {recoveries}")
+    recovery = recoveries[0]
+    if json.loads(recovery.read_text()) != first or recovery.stat().st_mode & 0o777 != 0o600:
+        raise SystemExit("recovery content or mode is wrong")
+    provider._write_credentials(second)
+    if not recovery.exists() or json.loads(recovery.read_text()) != first:
+        raise SystemExit("next persist deleted or changed recovery")
+    if json.loads(path.read_text()) != second:
+        raise SystemExit("next canonical persist failed")
+    third = {"claudeAiOauth": {"accessToken": "third", "refreshToken": "third"}}
+    real_fsync = os.fsync
+    def fail_directory_fsync(fd):
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("directory fsync unsupported")
+        return real_fsync(fd)
+    with patch("broker.plugins.claude_oauth.provider.os.fsync", side_effect=fail_directory_fsync):
+        provider._write_credentials(third)
+    if json.loads(path.read_text()) != third:
+        raise SystemExit("directory fsync failure misreported successful replacement")
+print("OK")
+`)
+	if err != nil || !strings.Contains(out, "OK") {
+		t.Fatalf("recovery persistence test failed: err=%v out=%s", err, out)
+	}
+}
+
+func TestClaudePersistFailureServesOnlyValidCanonicalAccess(t *testing.T) {
+	out, err := runBrokerPython(t, `
+import json
+import tempfile
+import time
+from pathlib import Path
+from broker.plugins.claude_oauth.provider import ClaudeOAuthProvider
+from broker.plugins.github_app.provider import ProviderError
+
+with tempfile.TemporaryDirectory() as directory:
+    path = Path(directory) / ".credentials.json"
+    def write(exp):
+        path.write_text(json.dumps({"claudeAiOauth": {
+            "accessToken": "canonical-access",
+            "refreshToken": "canonical-refresh",
+            "expiresAt": exp,
+        }}))
+        path.chmod(0o600)
+    provider = ClaudeOAuthProvider({"name": "claude-main", "config": {
+        "credentials-file": str(path),
+        "injection-hosts": ["api.anthropic.com"],
+    }})
+    provider._refresh = lambda data, oauth: {"claudeAiOauth": {
+        "accessToken": "unpersisted-access",
+        "refreshToken": "unpersisted-refresh",
+        "expiresAt": int((time.time() + 3600) * 1000),
+    }}
+    def fail_persist(data):
+        raise ProviderError("token-refresh-persist-failed", "injected", 502)
+    provider._persist = fail_persist
+    write(int((time.time() + 300) * 1000))
+    _, _, token, _, refreshed = provider._fresh_credentials("agent", None, "request", "injection")
+    if token != "canonical-access" or refreshed:
+        raise SystemExit("valid canonical token was not served")
+    write(int((time.time() - 60) * 1000))
+    try:
+        provider._fresh_credentials("agent", None, "request", "files", serve_expired=True)
+    except ProviderError as error:
+        if error.reason != "token-refresh-persist-failed":
+            raise
+    else:
+        raise SystemExit("expired canonical token was served after persist failure")
+print("OK")
+`)
+	if err != nil || !strings.Contains(out, "OK") {
+		t.Fatalf("persist failure behavior test failed: err=%v out=%s", err, out)
 	}
 }
 

--- a/tests/broker/claude_refresh_conformance_test.go
+++ b/tests/broker/claude_refresh_conformance_test.go
@@ -1,11 +1,11 @@
 package broker_test
 
 // Conformance for the hardened Claude Code OAuth refresh path (protocol/broker.md
-// "Claude OAuth Provider Rules"). Claude credentials expose an access-token
-// expiresAt only (refresh-token expiry is unknown), so the broker refreshes the
-// access token proactively, serializes refresh to a single upstream call, and
-// backs off on transient failure so Claude Code retries cannot storm the OAuth
-// endpoint. Token values must never appear in responses, audit, or broker logs.
+// "Claude OAuth Provider Rules"). The broker refreshes the access token
+// proactively, persists the returned access/refresh lifetime metadata,
+// serializes refresh to a single upstream call, and backs off on transient
+// failure so Claude Code retries cannot storm the OAuth endpoint. Token values
+// must never appear in responses, audit, or broker logs.
 
 import (
 	"bytes"
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -141,7 +142,11 @@ func TestClaudeRefreshSendsLiteralScopeOverride(t *testing.T) {
 func TestClaudeRefreshPersistsRotatedToken(t *testing.T) {
 	f := newBrokerFixture(t)
 	f.writeRoleIdentities(claudePlaceholderIdentities())
-	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) { c.rotate = true })
+	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) {
+		c.rotate = true
+		c.refreshExpiresIn = 30 * 24 * 60 * 60
+		c.scope = "user:inference user:profile user:mcp_servers"
+	})
 	f.writeClaudeCredentialsExpiring("claude-access-near-expiry", "claude-refresh-real", time.Now().Add(5*time.Minute))
 
 	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", claudeInjectionRequest())
@@ -157,6 +162,44 @@ func TestClaudeRefreshPersistsRotatedToken(t *testing.T) {
 	}
 	if oauth["accessToken"] != "refreshed-claude-access-1" {
 		t.Fatalf("access token was not refreshed alongside rotation: %#v", oauth["accessToken"])
+	}
+	refreshExpiresAt, ok := oauth["refreshTokenExpiresAt"].(float64)
+	if !ok || int64(refreshExpiresAt) < time.Now().Add(29*24*time.Hour).UnixMilli() {
+		t.Fatalf("refreshTokenExpiresAt was not advanced from refresh_token_expires_in: %#v", oauth["refreshTokenExpiresAt"])
+	}
+	if got := oauth["scopes"]; !reflect.DeepEqual(got, []any{"user:inference", "user:profile", "user:mcp_servers"}) {
+		t.Fatalf("granted scopes were not persisted: %#v", got)
+	}
+	if oauth["clientId"] != "claude-test-client" {
+		t.Fatalf("refresh client id was not persisted: %#v", oauth["clientId"])
+	}
+}
+
+func TestClaudeRefreshPreservesOptionalMetadataWhenResponseOmitsIt(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.writeRoleIdentities(claudePlaceholderIdentities())
+	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) { c.rotate = true })
+	refreshExpiresAt := time.Now().Add(20 * 24 * time.Hour).UnixMilli()
+	writeJSONFile(t, f.claudeCreds, map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken":           "claude-access-near-expiry",
+			"refreshToken":          "claude-refresh-real",
+			"expiresAt":             time.Now().Add(5 * time.Minute).UnixMilli(),
+			"refreshTokenExpiresAt": refreshExpiresAt,
+			"scopes":                []string{"user:inference", "user:profile"},
+		},
+	})
+
+	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", claudeInjectionRequest())
+	if status != http.StatusOK || body["ok"] != true {
+		t.Fatalf("refresh failed: status=%d body=%v", status, body)
+	}
+	oauth := decodeClaudeCanonical(t, f)
+	if int64(oauth["refreshTokenExpiresAt"].(float64)) != refreshExpiresAt {
+		t.Fatalf("refresh expiry changed when the response omitted it: %#v", oauth["refreshTokenExpiresAt"])
+	}
+	if got := oauth["scopes"]; !reflect.DeepEqual(got, []any{"user:inference", "user:profile"}) {
+		t.Fatalf("scopes changed when the response omitted them: %#v", got)
 	}
 }
 
@@ -533,7 +576,10 @@ func runClaudeProbe(t *testing.T, root, configPath, provider string) (map[string
 // (status, field names, old/new expiresAt, rotation flag) — never token values.
 func TestClaudeRefreshProbePersistsAndRedacts(t *testing.T) {
 	f := newBrokerFixture(t)
-	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) { c.rotate = true })
+	f.claudeOAuth.configure(func(c *fakeClaudeOAuth) {
+		c.rotate = true
+		c.refreshExpiresIn = 30 * 24 * 60 * 60
+	})
 	f.writeClaudeCredentialsExpiring("claude-access-secret-value", "claude-refresh-secret-value", time.Now().Add(time.Hour))
 
 	payload, output, status := runClaudeProbe(t, f.root, f.config, "claude-main")
@@ -542,6 +588,9 @@ func TestClaudeRefreshProbePersistsAndRedacts(t *testing.T) {
 	}
 	if payload["status"] != "ok" || payload["refresh_token_rotated"] != true {
 		t.Fatalf("unexpected probe summary: %#v", payload)
+	}
+	if payload["new_refresh_expires_at"] == nil {
+		t.Fatalf("probe summary must report the refreshed credential lifetime: %#v", payload)
 	}
 	keys, ok := payload["keys"].([]any)
 	if !ok || len(keys) == 0 {
@@ -556,6 +605,13 @@ func TestClaudeRefreshProbePersistsAndRedacts(t *testing.T) {
 	oauth := decodeClaudeCanonical(t, f)
 	if oauth["refreshToken"] != "rotated-claude-refresh-1" || oauth["accessToken"] != "refreshed-claude-access-1" {
 		t.Fatalf("probe did not persist the rotated credential: %#v", oauth)
+	}
+	info, err := os.Stat(f.claudeCreds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("persisted Claude credential mode = %o, want 600", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist Claude refresh-token expiry, granted scopes, and client ID from the OAuth response
- warn before the fixed refresh authorization expires and expose both expiries in the sanitized probe
- make rotated credential persistence crash-durable and retain a mode-0600 recovery copy if replacement fails
- document that refresh-token rotation does not necessarily extend the authorization lifetime

## Verification
- `GOCACHE=/private/tmp/nvt-go-cache go test -count=1 ./...` in `tests/broker`
- `python3 -m py_compile broker/plugins/claude_oauth/provider.py scripts/claude-refresh-probe.py`
- two sanitized real Claude OAuth refresh probes; access and refresh tokens rotated, access expiry advanced, fixed refresh expiry was preserved
- mediated Claude turn returned exactly `refresh-state-ok` after rotation