### PR TITLE
fix: harden mediated fresh-cluster startup

### DIFF
--- a/egressd/internal/egress/destination_policy.go
+++ b/egressd/internal/egress/destination_policy.go
@@ -61,32 +61,49 @@ func (p destinationPolicy) allowed(address netip.Addr) bool {
 	return true
 }
 
-func resolveAllowedAddress(ctx context.Context, resolver IPResolver, policy destinationPolicy, host string) (netip.Addr, error) {
+func resolveAllowedAddresses(ctx context.Context, resolver IPResolver, policy destinationPolicy, host string) ([]netip.Addr, error) {
 	if literal, err := netip.ParseAddr(host); err == nil {
 		literal = literal.Unmap()
 		if !policy.allowed(literal) {
-			return netip.Addr{}, fmt.Errorf("destination address is denied")
+			return nil, fmt.Errorf("destination address is denied")
 		}
-		return literal, nil
+		return []netip.Addr{literal}, nil
 	}
 	addresses, err := resolver.LookupNetIP(ctx, "ip", host)
 	if err != nil {
-		return netip.Addr{}, fmt.Errorf("resolve destination: %w", err)
+		return nil, fmt.Errorf("resolve destination: %w", err)
 	}
 	if len(addresses) == 0 {
-		return netip.Addr{}, fmt.Errorf("resolve destination: no addresses")
+		return nil, fmt.Errorf("resolve destination: no addresses")
 	}
-	var selected netip.Addr
+	validated := make([]netip.Addr, 0, len(addresses))
+	seen := make(map[netip.Addr]struct{}, len(addresses))
 	for _, candidate := range addresses {
 		candidate = candidate.Unmap()
 		if !policy.allowed(candidate) {
-			return netip.Addr{}, fmt.Errorf("destination resolution contains denied address")
+			return nil, fmt.Errorf("destination resolution contains denied address")
 		}
-		if !selected.IsValid() {
-			selected = candidate
+		if _, exists := seen[candidate]; !exists {
+			seen[candidate] = struct{}{}
+			validated = append(validated, candidate)
 		}
 	}
-	return selected, nil
+	// Kubernetes kind and many production clusters are IPv4-only even when
+	// public DNS returns IPv6 first. Preserve resolver order within each family
+	// while preferring IPv4, then let the caller fall back across the complete
+	// validated set without another DNS lookup.
+	ordered := make([]netip.Addr, 0, len(validated))
+	for _, candidate := range validated {
+		if candidate.Is4() {
+			ordered = append(ordered, candidate)
+		}
+	}
+	for _, candidate := range validated {
+		if !candidate.Is4() {
+			ordered = append(ordered, candidate)
+		}
+	}
+	return ordered, nil
 }
 
 var _ IPResolver = (*net.Resolver)(nil)

--- a/egressd/internal/egress/destination_policy_test.go
+++ b/egressd/internal/egress/destination_policy_test.go
@@ -106,6 +106,36 @@ func TestForwardProxyPrefersIPv4AndFallsBackAcrossValidatedAddresses(t *testing.
 	}
 }
 
+func TestForwardProxyRejectsEmptyResolvedAddressSet(t *testing.T) {
+	proxy := &ForwardProxy{}
+	if _, err := proxy.dialResolvedAddresses(context.Background(), nil, "443"); err == nil || !strings.Contains(err.Error(), "no validated addresses") {
+		t.Fatalf("empty address error = %v, want explicit rejection", err)
+	}
+}
+
+func TestForwardProxyStopsFallbackDialingWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	dials := 0
+	proxy := &ForwardProxy{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			dials++
+			cancel()
+			return nil, errors.New("fixture address unavailable")
+		},
+	}
+	addresses := []netip.Addr{
+		netip.MustParseAddr("93.184.216.34"),
+		netip.MustParseAddr("93.184.216.35"),
+	}
+	_, err := proxy.dialResolvedAddresses(ctx, addresses, "443")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("dial error = %v, want context cancellation", err)
+	}
+	if dials != 1 {
+		t.Fatalf("dial attempts = %d, want one", dials)
+	}
+}
+
 func TestForwardProxyResolvesOnceAndDialsValidatedAddress(t *testing.T) {
 	resolver := &staticResolver{addresses: []netip.Addr{netip.MustParseAddr("93.184.216.34")}}
 	var dialed string

--- a/egressd/internal/egress/destination_policy_test.go
+++ b/egressd/internal/egress/destination_policy_test.go
@@ -61,11 +61,48 @@ func TestResolveAllowedAddressRejectsAnyDeniedCandidate(t *testing.T) {
 		netip.MustParseAddr("93.184.216.34"),
 		netip.MustParseAddr("169.254.169.254"),
 	}}
-	if _, err := resolveAllowedAddress(context.Background(), resolver, policy, "mixed.example"); err == nil {
+	if _, err := resolveAllowedAddresses(context.Background(), resolver, policy, "mixed.example"); err == nil {
 		t.Fatal("mixed public/private DNS answer must fail closed")
 	}
 	if resolver.calls != 1 {
 		t.Fatalf("resolver calls = %d, want exactly one", resolver.calls)
+	}
+}
+
+func TestForwardProxyPrefersIPv4AndFallsBackAcrossValidatedAddresses(t *testing.T) {
+	resolver := &staticResolver{addresses: []netip.Addr{
+		netip.MustParseAddr("2606:4700:4700::1111"),
+		netip.MustParseAddr("93.184.216.34"),
+		netip.MustParseAddr("93.184.216.35"),
+	}}
+	dialed := []string{}
+	proxy := &ForwardProxy{
+		Resolver: resolver,
+		DialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			if address == "93.184.216.35:80" {
+				client, peer := net.Pipe()
+				_ = peer.Close()
+				return client, nil
+			}
+			return nil, errors.New("fixture address unavailable")
+		},
+	}
+	policy, err := newDestinationPolicy(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy.destinationPolicy = policy
+	connection, err := proxy.dialResolvedTarget(context.Background(), "packages.example", "80")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = connection.Close()
+	if got, want := strings.Join(dialed, ","), "93.184.216.34:80,93.184.216.35:80"; got != want {
+		t.Fatalf("dial order = %q, want %q", got, want)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want one", resolver.calls)
 	}
 }
 

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -438,8 +438,14 @@ func (p *ForwardProxy) resolveTarget(ctx context.Context, target connectTarget) 
 }
 
 func (p *ForwardProxy) dialResolvedAddresses(ctx context.Context, addresses []netip.Addr, port string) (net.Conn, error) {
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("dial resolved destination: no validated addresses")
+	}
 	var lastErr error
 	for _, address := range addresses {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("dial resolved destination: %w", err)
+		}
 		connection, dialErr := p.dial(ctx, net.JoinHostPort(address.String(), port))
 		if dialErr == nil {
 			return connection, nil

--- a/egressd/internal/egress/forward_proxy.go
+++ b/egressd/internal/egress/forward_proxy.go
@@ -101,13 +101,13 @@ func (p *ForwardProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer releaseTunnel()
 
-	address, err := p.resolveTarget(r.Context(), target)
+	addresses, err := p.resolveTarget(r.Context(), target)
 	if err != nil {
 		p.writeDecision(target.host, target.port, "deny", "destination_denied")
 		http.Error(w, "CONNECT destination denied", http.StatusForbidden)
 		return
 	}
-	upstream, err := p.dial(r.Context(), net.JoinHostPort(address.String(), strconv.Itoa(target.port)))
+	upstream, err := p.dialResolvedAddresses(r.Context(), addresses, strconv.Itoa(target.port))
 	if err != nil {
 		p.writeDecision(target.host, target.port, "deny", "upstream_unreachable")
 		http.Error(w, "CONNECT upstream unreachable", http.StatusBadGateway)
@@ -313,11 +313,7 @@ func (p *ForwardProxy) injectRouteTransport(route ForwardProxyInjectRoute) http.
 		if err != nil {
 			return nil, fmt.Errorf("parse inject route destination: %w", err)
 		}
-		resolved, err := resolveAllowedAddress(ctx, p.resolver(), p.destinationPolicy, host)
-		if err != nil {
-			return nil, err
-		}
-		return p.dial(ctx, net.JoinHostPort(resolved.String(), port))
+		return p.dialResolvedTarget(ctx, host, port)
 	}
 	return clone
 }
@@ -427,9 +423,30 @@ func (p *ForwardProxy) resolver() IPResolver {
 	return net.DefaultResolver
 }
 
-func (p *ForwardProxy) resolveTarget(ctx context.Context, target connectTarget) (netip.Addr, error) {
+func (p *ForwardProxy) dialResolvedTarget(ctx context.Context, host, port string) (net.Conn, error) {
 	p.init()
-	return resolveAllowedAddress(ctx, p.resolver(), p.destinationPolicy, target.host)
+	addresses, err := resolveAllowedAddresses(ctx, p.resolver(), p.destinationPolicy, host)
+	if err != nil {
+		return nil, err
+	}
+	return p.dialResolvedAddresses(ctx, addresses, port)
+}
+
+func (p *ForwardProxy) resolveTarget(ctx context.Context, target connectTarget) ([]netip.Addr, error) {
+	p.init()
+	return resolveAllowedAddresses(ctx, p.resolver(), p.destinationPolicy, target.host)
+}
+
+func (p *ForwardProxy) dialResolvedAddresses(ctx context.Context, addresses []netip.Addr, port string) (net.Conn, error) {
+	var lastErr error
+	for _, address := range addresses {
+		connection, dialErr := p.dial(ctx, net.JoinHostPort(address.String(), port))
+		if dialErr == nil {
+			return connection, nil
+		}
+		lastErr = dialErr
+	}
+	return nil, fmt.Errorf("dial resolved destination: %w", lastErr)
 }
 
 func (p *ForwardProxy) dial(ctx context.Context, address string) (net.Conn, error) {

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -351,8 +351,12 @@ func (in *AgentRunBrokerGrant) DeepCopy() *AgentRunBrokerGrant {
 
 	out := new(AgentRunBrokerGrant)
 	*out = *in
-	out.Repositories = append([]string(nil), in.Repositories...)
-	out.EgressHosts = append([]string(nil), in.EgressHosts...)
+	if in.Repositories != nil {
+		out.Repositories = append([]string{}, in.Repositories...)
+	}
+	if in.EgressHosts != nil {
+		out.EgressHosts = append([]string{}, in.EgressHosts...)
+	}
 	if in.Permissions != nil {
 		out.Permissions = make(map[string]string, len(in.Permissions))
 		for key, value := range in.Permissions {

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -349,7 +349,7 @@ func (r *AgentRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 	var preparedFiles []preparedPlaceholderFile
-	if AgentRunLiteralZeroSecret(&agentRun) && existingPod == nil {
+	if AgentRunLiteralZeroSecret(&agentRun) {
 		preparedFiles, err = r.preparePlaceholderFiles(ctx, &agentRun)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -648,14 +648,16 @@ func (r *AgentRunReconciler) preparePlaceholderFiles(ctx context.Context, agentR
 	configKey := client.ObjectKey{Namespace: agentRun.Namespace, Name: AgentConfigMapName(agentRun.Name)}
 	if err := r.Get(ctx, configKey, existing); err == nil {
 		if metav1.IsControlledBy(existing, agentRun) && existing.Annotations[agentConfigPlaceholderCacheAnnotation] == cacheKey {
-			files, loadErr := loadPreparedPlaceholderFiles(existing.Data[preparedPlaceholderFilesKey])
-			if loadErr != nil {
-				return nil, fmt.Errorf("load cached prepared placeholder files from ConfigMap %s/%s: %w", existing.Namespace, existing.Name, loadErr)
+			if raw := existing.Data[preparedPlaceholderFilesKey]; strings.TrimSpace(raw) != "" {
+				files, loadErr := loadPreparedPlaceholderFiles(raw)
+				if loadErr != nil {
+					return nil, fmt.Errorf("load cached prepared placeholder files from ConfigMap %s/%s: %w", existing.Namespace, existing.Name, loadErr)
+				}
+				if len(files) == 0 {
+					return nil, fmt.Errorf("cached AgentRun config ConfigMap %s/%s contains no prepared placeholder files", existing.Namespace, existing.Name)
+				}
+				return files, nil
 			}
-			if len(files) == 0 {
-				return nil, fmt.Errorf("cached AgentRun config ConfigMap %s/%s is missing prepared placeholder files", existing.Namespace, existing.Name)
-			}
-			return files, nil
 		}
 	} else if !errors.IsNotFound(err) {
 		return nil, fmt.Errorf("get AgentRun config ConfigMap for placeholder cache: %w", err)

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -2499,15 +2499,66 @@ func TestLiteralZeroSecretPlaceholderPreparationIsCachedAcrossReconciles(t *test
 		Build()
 	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme, BrokerHTTPClient: broker.Client()}
 
-	for pass := 0; pass < 2; pass++ {
-		_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)})
-		if err != nil {
-			t.Fatalf("reconcile pass %d: %v", pass+1, err)
-		}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	desiredPod, err := DesiredAgentPod(agentRun, scheme)
+	if err != nil {
+		t.Fatalf("render existing agent Pod: %v", err)
+	}
+	if err := k8sClient.Create(ctx, desiredPod); err != nil {
+		t.Fatalf("create existing agent Pod: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: clientKey(agentRun)}); err != nil {
+		t.Fatalf("reconcile with existing agent Pod: %v", err)
 	}
 
 	if brokerRequests != 1 {
 		t.Fatalf("expected placeholder preparation to be cached across reconciles, got %d broker requests", brokerRequests)
+	}
+	configMap := getAgentConfigMap(ctx, t, k8sClient, agentRun)
+	if configMap.Data[preparedPlaceholderFilesKey] == "" || !strings.Contains(configMap.Data[agentConfigKey], "$HOME/.codex/auth.json") {
+		t.Fatalf("existing agent Pod reconcile removed prepared placeholder files: %#v", configMap.Data)
+	}
+}
+
+func TestLiteralZeroSecretMissingPlaceholderCacheIsRebuilt(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	agentRun := enforcedAgentRun()
+	agentRun.Spec.Broker.Grants = append(agentRun.Spec.Broker.Grants, nvtv1alpha1.AgentRunBrokerGrant{
+		Provider:        "codex-main",
+		Materialization: nvtv1alpha1.AgentRunGrantPlaceholderFile,
+	})
+	brokerSecret := mustDesiredTokenSecret(t, agentRun, scheme, BrokerTokenSecretName(agentRun.Name), brokerTokenKey, []byte("agent-token"))
+	configMap, err := DesiredAgentConfigMap(agentRun, scheme)
+	if err != nil {
+		t.Fatalf("render stale agent config: %v", err)
+	}
+	configMap.Annotations = map[string]string{agentConfigPlaceholderCacheAnnotation: agentConfigPlaceholderCacheKey(agentRun)}
+	brokerRequests := 0
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokerRequests++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"files": []map[string]any{{
+				"path":    ".codex/auth.json",
+				"content": "{\n  \"access_token\": \"NVT-PLACEHOLDER-NOT-A-KEY\"\n}\n",
+				"mode":    "0600",
+			}},
+		})
+	}))
+	t.Cleanup(broker.Close)
+	t.Setenv("NVT_BROKER_URL", broker.URL)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(agentRun, brokerSecret, configMap).Build()
+	reconciler := &AgentRunReconciler{Client: k8sClient, Scheme: scheme, BrokerHTTPClient: broker.Client()}
+
+	files, err := reconciler.preparePlaceholderFiles(ctx, agentRun)
+	if err != nil {
+		t.Fatalf("rebuild missing placeholder cache: %v", err)
+	}
+	if brokerRequests != 1 || len(files) != 1 || files[0].Path != ".codex/auth.json" {
+		t.Fatalf("missing placeholder cache was not rebuilt: requests=%d files=%#v", brokerRequests, files)
 	}
 }
 

--- a/operator/internal/controller/agentschedule_admission.go
+++ b/operator/internal/controller/agentschedule_admission.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nvtv1alpha1 "github.com/mirkoSekulic/nvt-agent/operator/api/v1alpha1"
@@ -255,6 +256,7 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 		URL:        admission.Work.URL,
 		Repository: admission.Work.Repository,
 	}, h.scheme); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "prepare scheduled AgentRun", "schedule", client.ObjectKeyFromObject(schedule))
 		http.Error(response, "prepare AgentRun failed\n", http.StatusInternalServerError)
 		return
 	}
@@ -268,6 +270,7 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 		}
 	}
 	if err := h.client.Create(ctx, &run); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "create scheduled AgentRun", "schedule", client.ObjectKeyFromObject(schedule), "agentrun", client.ObjectKeyFromObject(&run))
 		http.Error(response, "create AgentRun failed\n", http.StatusInternalServerError)
 		return
 	}

--- a/operator/internal/controller/execution_profile_test.go
+++ b/operator/internal/controller/execution_profile_test.go
@@ -459,6 +459,22 @@ func TestExecutionProfileDeepCopyIsolation(t *testing.T) {
 	}
 }
 
+func TestAgentRunBrokerGrantDeepCopyPreservesEmptySlices(t *testing.T) {
+	grant := nvtv1alpha1.AgentRunBrokerGrant{
+		Provider:     "codex-main",
+		Repositories: []string{},
+		EgressHosts:  []string{},
+	}
+
+	copy := grant.DeepCopy()
+	if copy.Repositories == nil {
+		t.Fatal("deep copy changed explicit empty repositories into nil")
+	}
+	if copy.EgressHosts == nil {
+		t.Fatal("deep copy changed explicit empty egress hosts into nil")
+	}
+}
+
 func TestAgentRunProfileProvenanceCRDSchema(t *testing.T) {
 	data, err := os.ReadFile("../../config/crd/bases/nvt.dev_agentruns.yaml")
 	if err != nil {

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -7,7 +7,13 @@ ENV NVT_STATE_DIR=/root/.nvt-agent
 ENV CODE_SERVER_PORT=4090
 ENV PATH=/root/.local/bin:/root/bin:/root/.local/share/mise/shims:$PATH
 
-RUN apt-get update \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec \
+    sed -i \
+      -e 's|http://ports.ubuntu.com|https://ports.ubuntu.com|g' \
+      -e 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' \
+      -e 's|http://security.ubuntu.com|https://security.ubuntu.com|g' \
+      {} + \
+  && apt-get update \
   && apt-get install -y --no-install-recommends \
     python3-yaml \
     ca-certificates \


### PR DESCRIPTION
## Summary

- preserve explicit empty grant slices during profile deep-copy so Kubernetes admission accepts profiled placeholder grants
- keep and rebuild inert placeholder-file caches after the agent Pod exists
- fall back across a single validated DNS answer set in egressd, preferring IPv4 in IPv4 clusters
- use HTTPS for Ubuntu package archives in the runtime image
- add sanitized admission error logging

## Verification

- `go test ./...` in `operator/`
- `go vet ./...` in `operator/`
- `go test -race ./...` in `egressd/`
- `go vet ./...` in `egressd/`
- `go test ./...` in `tests/runtime/`
- rebuilt `nvt-operator:latest`, `nvt-egressd:latest`, and `nvt-agent-runtime:latest`
- fresh Calico kind cluster with profiled GitHub producer, mediated transparent egress, and enforcement
- issue #31 created AgentRun `default-7a329aa316`
- verified placeholder-only Codex auth and no Secret volumes, secret env refs, or service-account token in the agent Pod
- broker audit recorded successful `codex-main` and `github-main-app` injection through the paired egress identity
- Codex created PR #99 through mediated Git and `gh-auth`
- gateway landing page returned 200 and the per-agent session route returned the code-server redirect