### PR TITLE
fix: mediate GitHub watcher requests

### DIFF
--- a/runtime/plugins/git-host-credentials/gh-auth.py
+++ b/runtime/plugins/git-host-credentials/gh-auth.py
@@ -5,7 +5,14 @@ import subprocess
 import sys
 from urllib.parse import quote, urlsplit, urlunsplit
 
-from git_host_credentials import credential_kind, load_config, normalize_repo, resolve_provider, token
+from git_host_credentials import (
+    credential_kind,
+    load_config,
+    normalize_repo,
+    resolve_provider,
+    runtime_env_value,
+    token,
+)
 
 PLACEHOLDER = "NVT-PLACEHOLDER-NOT-A-KEY"
 
@@ -91,11 +98,11 @@ def proxy_url_for_provider(proxy_url, provider_name):
 
 
 def mediated_env(provider, repo):
-    proxy_url = os.environ.get("NVT_EGRESS_FORWARD_PROXY_URL")
+    proxy_url = runtime_env_value("NVT_EGRESS_FORWARD_PROXY_URL")
     if not proxy_url:
         fail(f"provider {provider['name']} is mediated but NVT_EGRESS_FORWARD_PROXY_URL is not set")
     proxy_url = proxy_url_for_provider(proxy_url, provider["broker-provider"])
-    placeholder = os.environ.get("NVT_EGRESS_PLACEHOLDER") or PLACEHOLDER
+    placeholder = runtime_env_value("NVT_EGRESS_PLACEHOLDER") or PLACEHOLDER
     env = os.environ.copy()
     env["GH_TOKEN"] = placeholder
     for key in ("GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"):

--- a/runtime/plugins/github-watcher/README.md
+++ b/runtime/plugins/github-watcher/README.md
@@ -3,14 +3,19 @@
 `github-watcher` watches GitHub pull requests and turns selected PR activity
 into `agentd` events and optional prompts.
 
-It is a long-running `after-agent` plugin. In broker mode it reads GitHub through
-`brokerctl http request`, so the watcher does not receive a GitHub token for API
-reads. Direct mode remains available as a local/dev fallback and gets tokens from
-`git-host-credentials`:
+It is a long-running `after-agent` plugin. In mediated mode it delegates GitHub
+API reads to the exported `gh-auth` tool. `gh-auth` sends only the inert
+placeholder through the provider-selected egress proxy; egressd injects the real
+credential outside the agent. Direct mode remains available as a local/dev
+fallback and gets tokens from `git-host-credentials`:
 
 ```sh
 git-host-credential token --provider <provider>
 ```
+
+Mediated mode requires the `git-host-credentials` plugin so its exported
+`gh-auth` tool and exact provider mapping are available before the watcher
+starts.
 
 The watcher supports both static PRs from `agent.yaml` and dynamic registrations
 through the exported `github-watch` command. Dynamic registrations are persisted
@@ -110,10 +115,11 @@ comments, reviews, and checks.
 `labels` are metadata carried into published events and prompt text. They do not
 filter GitHub labels in v1.
 
-When `broker.enabled` is true, read-only GitHub API calls are executed through
-`brokerctl http request`. The watcher does not receive the GitHub App private
-key or installation token for those API reads. Direct mode remains available as
-a local/dev fallback.
+When `NVT_EGRESS_MODE=mediated`, read-only GitHub API calls use `gh-auth` and the
+watch's exact `provider`; the watcher never calls `brokerctl` or receives a real
+credential. Outside mediated mode, `broker.enabled` retains the compatibility
+path through `brokerctl http request`. Direct token mode remains available as a
+local/dev fallback.
 
 ## Dynamic Registration
 
@@ -262,10 +268,12 @@ and easier to maintain than listing every trusted username.
 In direct mode, this plugin receives GitHub API access through in-container
 provider tokens from `git-host-credentials`. That is local/dev behavior.
 
-In broker mode, read-only GitHub API calls go through `brokerctl http request`.
-That keeps the GitHub App private key and derived API token inside the broker
-for those reads. Token mode may still be used by Git credential helpers for
-operations that require a token, such as Git push.
+In mediated mode, read-only GitHub API calls go through `gh-auth` and egressd.
+The watcher gets only the inert placeholder; the GitHub App private key and
+derived API token remain in the broker. The provider name is carried as a
+non-secret proxy capability hint, so multiple GitHub providers for the same host
+remain deterministic. The legacy broker HTTP and token modes remain available
+outside mediated mode for compatibility and local development.
 
 The production operator direction is for GitHub credentials and egress to be
 broker-mediated so the autonomous agent container does not hold raw GitHub App

--- a/runtime/plugins/github-watcher/github_watcher_lib.py
+++ b/runtime/plugins/github-watcher/github_watcher_lib.py
@@ -16,6 +16,7 @@ import yaml
 DEFAULT_ASSOCIATIONS = ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]
 FAILURE_CONCLUSIONS = {"failure", "timed_out", "cancelled", "action_required"}
 PASSING_CONCLUSIONS = {"success", "skipped", "neutral"}
+MEDIATED_REQUEST_TIMEOUT_SECONDS = 120
 
 
 def fail(message):
@@ -339,6 +340,52 @@ def token_for_provider(provider, target):
     return token
 
 
+def mediated_egress_enabled():
+    return os.environ.get("NVT_EGRESS_MODE", "").strip().lower() == "mediated"
+
+
+def mediated_request(path, provider, query=None, paginate=False):
+    query_string = f"?{urlencode(query)}" if query else ""
+    command = [
+        "gh-auth",
+        "--provider",
+        provider,
+        "api",
+        "--method",
+        "GET",
+        f"{path.lstrip('/')}{query_string}",
+        "--header",
+        "Accept: application/vnd.github+json",
+        "--header",
+        "X-GitHub-Api-Version: 2022-11-28",
+    ]
+    if paginate:
+        command.extend(["--paginate", "--slurp"])
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=MEDIATED_REQUEST_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError as error:
+        raise WatchError(f"gh-auth not found: {error}") from error
+    except subprocess.TimeoutExpired as error:
+        raise WatchError("mediated GitHub request timed out") from error
+    if result.returncode != 0:
+        raise WatchError(f"mediated GitHub request failed: {result.stderr.strip() or result.stdout.strip()}")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise WatchError(f"mediated GitHub response was not valid JSON: {error}") from error
+    if not paginate:
+        return payload
+    if not isinstance(payload, list) or not all(isinstance(page, list) for page in payload):
+        raise WatchError("mediated paginated GitHub response was not a list of pages")
+    return [item for page in payload for item in page]
+
+
 def broker_request(path, provider, query=None, paginate=False, broker=None):
     broker = broker or {}
     broker_provider = broker.get("provider") or provider
@@ -380,6 +427,8 @@ def broker_request(path, provider, query=None, paginate=False, broker=None):
 
 
 def github_request(path, provider, query=None, broker=None, paginate=False):
+    if mediated_egress_enabled():
+        return mediated_request(path, provider, query, paginate)
     if broker and broker.get("enabled"):
         return broker_request(path, provider, query, paginate, broker)
     target = github_target_from_path(path)

--- a/runtime/plugins/github-watcher/github_watcher_lib.py
+++ b/runtime/plugins/github-watcher/github_watcher_lib.py
@@ -344,7 +344,7 @@ def mediated_egress_enabled():
     return os.environ.get("NVT_EGRESS_MODE", "").strip().lower() == "mediated"
 
 
-def mediated_request(path, provider, query=None, paginate=False):
+def _mediated_request_page(path, provider, query, timeout):
     query_string = f"?{urlencode(query)}" if query else ""
     command = [
         "gh-auth",
@@ -359,15 +359,13 @@ def mediated_request(path, provider, query=None, paginate=False):
         "--header",
         "X-GitHub-Api-Version: 2022-11-28",
     ]
-    if paginate:
-        command.extend(["--paginate", "--slurp"])
     try:
         result = subprocess.run(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            timeout=MEDIATED_REQUEST_TIMEOUT_SECONDS,
+            timeout=timeout,
         )
     except FileNotFoundError as error:
         raise WatchError(f"gh-auth not found: {error}") from error
@@ -379,11 +377,36 @@ def mediated_request(path, provider, query=None, paginate=False):
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         raise WatchError(f"mediated GitHub response was not valid JSON: {error}") from error
+    return payload
+
+
+def mediated_request(path, provider, query=None, paginate=False):
     if not paginate:
-        return payload
-    if not isinstance(payload, list) or not all(isinstance(page, list) for page in payload):
-        raise WatchError("mediated paginated GitHub response was not a list of pages")
-    return [item for page in payload for item in page]
+        return _mediated_request_page(path, provider, query, MEDIATED_REQUEST_TIMEOUT_SECONDS)
+
+    page_query = dict(query or {})
+    try:
+        page = int(page_query.get("page", 1))
+        per_page = int(page_query.get("per_page", 30))
+    except (TypeError, ValueError) as error:
+        raise WatchError("mediated GitHub pagination requires integer page values") from error
+    if page < 1 or per_page < 1 or per_page > 100:
+        raise WatchError("mediated GitHub pagination values are out of range")
+
+    deadline = time.monotonic() + MEDIATED_REQUEST_TIMEOUT_SECONDS
+    items = []
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise WatchError("mediated GitHub request timed out")
+        page_query["page"] = page
+        page_items = _mediated_request_page(path, provider, page_query, remaining)
+        if not isinstance(page_items, list):
+            raise WatchError("mediated paginated GitHub response page was not a list")
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            return items
+        page += 1
 
 
 def broker_request(path, provider, query=None, paginate=False, broker=None):

--- a/runtime/plugins/github-watcher/run.py
+++ b/runtime/plugins/github-watcher/run.py
@@ -31,7 +31,7 @@ from github_watcher_lib import (
 
 
 def fetch_comments(watch):
-    if watch.get("broker", {}).get("enabled"):
+    if mediated_egress_enabled() or watch.get("broker", {}).get("enabled"):
         return github_request(
             f"/repos/{watch['repo']}/issues/{watch['number']}/comments",
             watch["provider"],
@@ -55,7 +55,7 @@ def fetch_comments(watch):
 
 
 def fetch_reviews(watch):
-    if watch.get("broker", {}).get("enabled"):
+    if mediated_egress_enabled() or watch.get("broker", {}).get("enabled"):
         return github_request(
             f"/repos/{watch['repo']}/pulls/{watch['number']}/reviews",
             watch["provider"],

--- a/runtime/plugins/github-watcher/run.py
+++ b/runtime/plugins/github-watcher/run.py
@@ -11,6 +11,7 @@ from github_watcher_lib import (
     github_request,
     list_value,
     load_config,
+    mediated_egress_enabled,
     parse_time,
     plugin_state_dir,
     prompt_agent,
@@ -290,7 +291,10 @@ def run_loop():
 
 
 def doctor():
-    if shutil.which("git-host-credential") is None:
+    if mediated_egress_enabled():
+        if shutil.which("gh-auth") is None:
+            fail("gh-auth not found on PATH")
+    elif shutil.which("git-host-credential") is None:
         fail("git-host-credential not found on PATH")
     if shutil.which("agentdctl") is None:
         fail("agentdctl not found on PATH")

--- a/tests/runtime/git_host_credentials_test.go
+++ b/tests/runtime/git_host_credentials_test.go
@@ -315,6 +315,50 @@ providers:
 	}
 }
 
+func TestGhAuthMediatedProviderReadsRuntimeEnvFile(t *testing.T) {
+	f := newFixture(t)
+	f.writeBin("gh", `#!/usr/bin/env bash
+set -euo pipefail
+if [ "${GH_TOKEN:-}" != "runtime-placeholder" ]; then
+  echo "unexpected GH_TOKEN=${GH_TOKEN:-}" >&2
+  exit 1
+fi
+if [ "${HTTPS_PROXY:-}" != "http://github-main-app:x@127.0.0.1:8470" ]; then
+  echo "unexpected HTTPS_PROXY=${HTTPS_PROXY:-}" >&2
+  exit 1
+fi
+printf '%s\n' "$*"
+`)
+	config := f.writePluginConfig("git-host-credentials.yaml", `
+providers:
+  - name: github-main
+    type: broker
+    broker-provider: github-main-app
+    credential-kind: mediated
+    match:
+      - github.com/my-user/*
+`)
+	envDir := filepath.Join(f.home, ".nvt-agent")
+	if err := os.MkdirAll(envDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envDir, "env"), []byte(`export NVT_EGRESS_FORWARD_PROXY_URL="http://127.0.0.1:8470"
+export NVT_EGRESS_PLACEHOLDER="runtime-placeholder"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	output := f.runWithEnv(
+		ghAuthBin(f.root),
+		true,
+		[]string{"NVT_PLUGIN_CONFIG=" + config},
+		"--provider", "github-main", "api", "repos/my-user/project",
+	)
+	if strings.TrimSpace(output) != "api repos/my-user/project" {
+		t.Fatalf("unexpected gh output:\n%s", output)
+	}
+}
+
 func TestGhAuthMediatedProviderRequiresManagedProxyURL(t *testing.T) {
 	f := newFixture(t)
 	f.writeBin("gh", "#!/usr/bin/env bash\necho should-not-run >&2\nexit 1\n")

--- a/tests/runtime/github_watcher_test.go
+++ b/tests/runtime/github_watcher_test.go
@@ -554,14 +554,20 @@ printf '%%s\n' "$*" >> %s
 	}
 }
 
-func TestGithubWatcherMediatedPaginationUsesGhAuthSlurp(t *testing.T) {
+func TestGithubWatcherMediatedPaginationUsesExplicitPageRequests(t *testing.T) {
 	f := newFixture(t)
 	ghAuthLog := filepath.Join(f.home, "gh-auth.log")
+	ghAuthState := filepath.Join(f.home, "gh-auth.state")
 	f.writeBin("gh-auth", fmt.Sprintf(`#!/usr/bin/env bash
 set -euo pipefail
-printf '%%s\n' "$*" > %s
-printf '%%s\n' '[[{"id":1}],[{"id":2}]]'
-`, quoteYAML(ghAuthLog)))
+printf '%%s\n' "$*" >> %s
+if [[ ! -f %s ]]; then
+  touch %s
+  python3 -c 'import json; print(json.dumps([{"id": i} for i in range(100)]))'
+else
+  printf '%%s\n' '[{"id":100}]'
+fi
+`, quoteYAML(ghAuthLog), quoteYAML(ghAuthState), quoteYAML(ghAuthState)))
 	script := fmt.Sprintf(`
 import importlib.util
 import pathlib
@@ -581,7 +587,7 @@ payload = lib.github_request(
     {"enabled": True, "provider": "github-main-app"},
     paginate=True,
 )
-if payload != [{"id": 1}, {"id": 2}]:
+if len(payload) != 101 or payload[-1] != {"id": 100}:
     raise SystemExit(f"unexpected paginated payload: {payload}")
 `, quoteYAML(f.root))
 
@@ -590,8 +596,9 @@ if payload != [{"id": 1}, {"id": 2}]:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(args), "--provider github-main api --method GET repos/my-user/my-repo/issues/123/comments?per_page=100") ||
-		!strings.Contains(string(args), "--paginate --slurp") {
+	if !strings.Contains(string(args), "comments?per_page=100&page=1") ||
+		!strings.Contains(string(args), "comments?per_page=100&page=2") ||
+		strings.Contains(string(args), "--paginate") || strings.Contains(string(args), "--slurp") {
 		t.Fatalf("unexpected paginated gh-auth args:\n%s", args)
 	}
 }

--- a/tests/runtime/github_watcher_test.go
+++ b/tests/runtime/github_watcher_test.go
@@ -494,6 +494,108 @@ if requests != [("https://api.github.com/repos/my-user/my-repo/issues/123/commen
 	}
 }
 
+func TestGithubWatcherMediatedClosedPRUsesGhAuthAndRemovesRegistration(t *testing.T) {
+	f := newFixture(t)
+	config := f.writePluginConfig("github-watcher.yaml", `
+default-provider: github-main
+broker:
+  enabled: true
+  provider: github-main-app
+`)
+	writeGithubWatcherRegistry(t, f, `[{"repo":"my-user/my-repo","number":123,"provider":"github-main","closed":{"enabled":true,"remove":true,"publish":true,"prompt":false}}]`)
+
+	ghAuthLog := filepath.Join(f.home, "gh-auth.log")
+	brokerctlCalled := filepath.Join(f.home, "brokerctl-called")
+	agentdctlLog := filepath.Join(f.home, "agentdctl.log")
+	f.writeBin("gh-auth", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%%s\n' "$*" >> %s
+printf '%%s\n' '{"state":"closed","merged":false,"head":{"sha":"abc"},"html_url":"https://github.com/my-user/my-repo/pull/123","closed_at":"2026-07-15T15:00:00Z","merged_at":null}'
+`, quoteYAML(ghAuthLog)))
+	f.writeBin("brokerctl", fmt.Sprintf(`#!/usr/bin/env bash
+touch %s
+exit 99
+`, quoteYAML(brokerctlCalled)))
+	f.writeBin("git-host-credential", "#!/usr/bin/env bash\nexit 98\n")
+	f.writeBin("agentdctl", fmt.Sprintf(`#!/usr/bin/env bash
+printf '%%s\n' "$*" >> %s
+`, quoteYAML(agentdctlLog)))
+
+	f.runWithEnv(
+		githubWatcherRunBin(f.root),
+		true,
+		[]string{"NVT_PLUGIN_CONFIG=" + config, "NVT_EGRESS_MODE=mediated"},
+		"once",
+	)
+
+	if _, err := os.Stat(brokerctlCalled); err == nil {
+		t.Fatal("mediated watcher called brokerctl")
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	args, err := os.ReadFile(ghAuthLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "--provider github-main api --method GET repos/my-user/my-repo/pulls/123") {
+		t.Fatalf("unexpected gh-auth args:\n%s", args)
+	}
+	events, err := os.ReadFile(agentdctlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(events), "publish plugin.github.pr.closed") {
+		t.Fatalf("close event was not published:\n%s", events)
+	}
+	var registry map[string][]map[string]any
+	decodeJSONFile(t, filepath.Join(f.state, "plugins", "github-watcher", "registry.json"), &registry)
+	if len(registry["prs"]) != 0 {
+		t.Fatalf("closed mediated watch was not removed: %#v", registry)
+	}
+}
+
+func TestGithubWatcherMediatedPaginationUsesGhAuthSlurp(t *testing.T) {
+	f := newFixture(t)
+	ghAuthLog := filepath.Join(f.home, "gh-auth.log")
+	f.writeBin("gh-auth", fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%%s\n' "$*" > %s
+printf '%%s\n' '[[{"id":1}],[{"id":2}]]'
+`, quoteYAML(ghAuthLog)))
+	script := fmt.Sprintf(`
+import importlib.util
+import pathlib
+import sys
+
+root = pathlib.Path(%s)
+module_path = root / "runtime" / "plugins" / "github-watcher" / "github_watcher_lib.py"
+sys.path.insert(0, str(module_path.parent))
+spec = importlib.util.spec_from_file_location("github_watcher_lib", module_path)
+lib = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lib)
+
+payload = lib.github_request(
+    "/repos/my-user/my-repo/issues/123/comments",
+    "github-main",
+    {"per_page": 100},
+    {"enabled": True, "provider": "github-main-app"},
+    paginate=True,
+)
+if payload != [{"id": 1}, {"id": 2}]:
+    raise SystemExit(f"unexpected paginated payload: {payload}")
+`, quoteYAML(f.root))
+
+	f.runWithEnv("python3", true, []string{"NVT_EGRESS_MODE=mediated"}, "-c", script)
+	args, err := os.ReadFile(ghAuthLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "--provider github-main api --method GET repos/my-user/my-repo/issues/123/comments?per_page=100") ||
+		!strings.Contains(string(args), "--paginate --slurp") {
+		t.Fatalf("unexpected paginated gh-auth args:\n%s", args)
+	}
+}
+
 func TestGithubWatcherPaginatesCommentsAndReviews(t *testing.T) {
 	f := newFixture(t)
 	script := fmt.Sprintf(`


### PR DESCRIPTION
## Summary

- route GitHub watcher API reads through the existing `gh-auth` provider wrapper in mediated mode instead of calling `brokerctl` from the agent
- keep direct-token and legacy broker HTTP modes unchanged outside mediated mode
- let `gh-auth` read bootstrap-generated proxy and placeholder values from the managed runtime env file, so background plugins use the same zero-secret path as interactive shells
- preserve exact provider selection, pagination, bounded request time, terminal event publication, and dynamic watch removal
- document the mediated watcher dependency and security behavior

## Security

The agent still receives no broker or GitHub credential. `gh-auth` sends the inert placeholder and the non-secret provider hint through egressd; the paired egress identity fetches and injects the real provider credential. The mediated watcher path never calls `brokerctl`.

## Verification

- `python3 -m py_compile runtime/plugins/github-watcher/github_watcher_lib.py runtime/plugins/github-watcher/run.py runtime/plugins/git-host-credentials/gh-auth.py` (passed)
- `cd tests/runtime && PATH=/private/tmp/nvt-watcher-venv/bin:$PATH GOCACHE=/private/tmp/nvt-watcher-go-cache go test -run 'Test(GithubWatcher|GhAuth)' -count=1 ./...` (passed)
- `cd tests/runtime && PATH=/private/tmp/nvt-watcher-venv/bin:$PATH GOCACHE=/private/tmp/nvt-watcher-go-cache go test -skip '^TestAfterAgentPluginsStartConcurrently$' -count=1 ./...` (passed)
- live `nvt-smoke` kind proof against already-closed PR #99: broker audit recorded `github-main-app` injection for `GET /repos/mirkoSekulic/nvt-agent/pulls/99` through the paired egress identity with status 200; the watcher published the close event; AgentRun `default-7a329aa316` transitioned to `Completed`; agent and egressd Pods were deleted
- `git diff --check` (passed)

The unfiltered runtime suite also passed once before the final generic `gh-auth` env-reader test was added. Its final rerun was blocked only by the unrelated timing-racy `TestAfterAgentPluginsStartConcurrently`; that test failed independently in 7/10 repetitions because it waits for the second marker and immediately checks the first without waiting. All other runtime tests passed, and the complete suite excluding that test is green.
