### PR TITLE
fix: complete fresh-cluster mediated routing

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"

--- a/gateway/internal/gateway/admission_test.go
+++ b/gateway/internal/gateway/admission_test.go
@@ -59,8 +59,10 @@ func TestLoginAdmissionAllowsMemberAndResourceAuthorizationStillApplies(t *testi
 	ownedRun := ownedAgentRun("owned", "owned-key", "https://github.enterprise.test", "42", "member")
 	ownedRun.Annotations[AccessPortAnnotation] = strconv.Itoa(upstreamPort)
 	ownedPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "nvt", Name: "owned-agent", Labels: map[string]string{AgentRunPodLabel: "owned"}},
-		Status:     readyPodStatus(upstreamURL.Hostname()),
+		ObjectMeta: metav1.ObjectMeta{Namespace: "nvt", Name: "owned-agent", Labels: map[string]string{
+			AgentRunPodLabel: "owned", AgentRunRoleLabel: AgentRunRoleAgent,
+		}},
+		Status: readyPodStatus(upstreamURL.Hostname()),
 	}
 	server := mustNewServer(t, config, fakeClient(t, &otherRun, &ownedRun, ownedPod))
 	server.auth.httpClient = noRedirectClient(claimServer.Client())

--- a/gateway/internal/gateway/routing_test.go
+++ b/gateway/internal/gateway/routing_test.go
@@ -426,8 +426,10 @@ func pathRoutableAgentRun(t *testing.T, upstreamURL, key string) (nvtv1alpha1.Ag
 		},
 	}}
 	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "nvt", Name: "path-pod", Labels: map[string]string{AgentRunPodLabel: run.Name}},
-		Status:     readyPodStatus(parsed.Hostname()),
+		ObjectMeta: metav1.ObjectMeta{Namespace: "nvt", Name: "path-pod", Labels: map[string]string{
+			AgentRunPodLabel: run.Name, AgentRunRoleLabel: AgentRunRoleAgent,
+		}},
+		Status: readyPodStatus(parsed.Hostname()),
 	}
 	return run, pod
 }

--- a/gateway/internal/gateway/server.go
+++ b/gateway/internal/gateway/server.go
@@ -27,7 +27,9 @@ const (
 	RequestedByAnnotation = "nvt.dev/requested-by"
 	AccessPortAnnotation  = "nvt.dev/access-port"
 
-	AgentRunPodLabel = "nvt.dev/agentrun"
+	AgentRunPodLabel  = "nvt.dev/agentrun"
+	AgentRunRoleLabel = "nvt.dev/role"
+	AgentRunRoleAgent = "agent"
 )
 
 type Config struct {
@@ -550,7 +552,10 @@ func (s *Server) resolveAgentRun(ctx context.Context, accessKey string) (nvtv1al
 
 func (s *Server) runningPodForAgentRun(ctx context.Context, agentRunName string) (corev1.Pod, bool, error) {
 	var pods corev1.PodList
-	if err := s.client.List(ctx, &pods, ctrlclient.InNamespace(s.namespace), ctrlclient.MatchingLabels{AgentRunPodLabel: agentRunName}); err != nil {
+	if err := s.client.List(ctx, &pods, ctrlclient.InNamespace(s.namespace), ctrlclient.MatchingLabels{
+		AgentRunPodLabel:  agentRunName,
+		AgentRunRoleLabel: AgentRunRoleAgent,
+	}); err != nil {
 		return corev1.Pod{}, false, fmt.Errorf("list AgentRun pods: %w", err)
 	}
 	sort.Slice(pods.Items, func(i, j int) bool {

--- a/gateway/internal/gateway/server_test.go
+++ b/gateway/internal/gateway/server_test.go
@@ -62,8 +62,22 @@ func TestResolveTarget(t *testing.T) {
 		&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "nvt",
+				Name:      "run-1-egressd",
+				Labels: map[string]string{
+					AgentRunPodLabel:  "run-1",
+					AgentRunRoleLabel: "egressd",
+				},
+			},
+			Status: readyPodStatus("10.0.0.8"),
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "nvt",
 				Name:      "run-1-agent",
-				Labels:    map[string]string{AgentRunPodLabel: "run-1"},
+				Labels: map[string]string{
+					AgentRunPodLabel:  "run-1",
+					AgentRunRoleLabel: AgentRunRoleAgent,
+				},
 			},
 			Status: readyPodStatus("10.0.0.9"),
 		},
@@ -91,7 +105,10 @@ func TestResolveTargetNoRunningPod(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "nvt",
 				Name:      "run-1-agent",
-				Labels:    map[string]string{AgentRunPodLabel: "run-1"},
+				Labels: map[string]string{
+					AgentRunPodLabel:  "run-1",
+					AgentRunRoleLabel: AgentRunRoleAgent,
+				},
 			},
 			Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.9"},
 		},
@@ -124,7 +141,10 @@ func TestDashboardListsAgentRuns(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "nvt",
 				Name:      "run-1-agent",
-				Labels:    map[string]string{AgentRunPodLabel: "run-1"},
+				Labels: map[string]string{
+					AgentRunPodLabel:  "run-1",
+					AgentRunRoleLabel: AgentRunRoleAgent,
+				},
 			},
 			Status: readyPodStatus("10.0.0.9"),
 		},

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -224,7 +224,7 @@ The supported selector is HTTP proxy Basic auth where the username is the
 broker provider name, e.g. a proxy URL shaped like:
 
 ```text
-http://github-altinn-app@egressd:8473
+http://github-altinn-app:x@egressd:8473
 ```
 
 The password is ignored. The selector is consumed by `egressd` and never
@@ -240,7 +240,7 @@ variants:
 
 ```text
 NVT_EGRESS_FORWARD_PROXY_URL=http://egressd:8473
-NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN=http://codex-main@egressd:8473
+NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN=http://codex-main:x@egressd:8473
 ```
 
 Tool wrappers or preseeded runtime profiles that explicitly reference a broker

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -182,7 +182,10 @@ def proxy_url_for_provider(proxy_url, provider):
     netloc = host
     if parts.port is not None:
         netloc = f"{netloc}:{parts.port}"
-    netloc = f"{quote(provider, safe='')}@{netloc}"
+    # A fixed, inert password makes HTTP clients emit Proxy-Authorization
+    # without prompting. Egressd consumes the username as the non-secret
+    # provider selector and ignores the password.
+    netloc = f"{quote(provider, safe='')}:x@{netloc}"
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 

--- a/tests/runtime/mediated_smoke_test.go
+++ b/tests/runtime/mediated_smoke_test.go
@@ -742,7 +742,7 @@ code-server:
 	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL="http://127.0.0.1:8470"`) {
 		t.Fatalf("forward proxy URL not exported for mediated tools:\n%s", envFile)
 	}
-	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN="http://codex-main@127.0.0.1:8470"`) {
+	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_CODEX_MAIN="http://codex-main:x@127.0.0.1:8470"`) {
 		t.Fatalf("provider-selected forward proxy URL not exported for mediated tools:\n%s", envFile)
 	}
 	if !strings.Contains(envFile, `export HTTPS_PROXY="http://127.0.0.1:8470"`) ||
@@ -912,7 +912,7 @@ code-server:
 	if !strings.Contains(envFile, `export HTTPS_PROXY="http://127.0.0.1:8470"`) {
 		t.Fatalf("runtime proxy env not bound for header-inject grant:\n%s", envFile)
 	}
-	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_STATIC_BEARER_MAIN="http://static-bearer-main@127.0.0.1:8470"`) {
+	if !strings.Contains(envFile, `export NVT_EGRESS_FORWARD_PROXY_URL_STATIC_BEARER_MAIN="http://static-bearer-main:x@127.0.0.1:8470"`) {
 		t.Fatalf("provider-selected proxy URL not exported for tools:\n%s", envFile)
 	}
 }


### PR DESCRIPTION
## Summary

- emit provider-scoped proxy URLs with an inert Basic-auth password so non-interactive clients such as Git send the provider selector without prompting
- make the gateway select only the AgentRun's agent Pod, never the separate egressd Pod
- release the fixes as chart version 0.8.1

## Verification

- `cd gateway && GOCACHE=/private/tmp/nvt-go-cache go test -count=1 ./...`
- `cd gateway && GOCACHE=/private/tmp/nvt-go-cache go vet ./...`
- focused mediated runtime bootstrap tests pass
- `helm lint charts/nvt`
- fresh Calico Kind cluster: GitHub comment producer created a mediated/enforced/transparent Codex AgentRun; checkout, arbitrary HTTPS, mediated GitHub API, Codex API, PR creation, gateway routing, PR-close lifecycle event, and completed-TTL resource cleanup all passed

The full runtime suite was also attempted. It reached unrelated local-environment failures: PyYAML was unavailable to a child Python process, macOS generated an overlong tmux socket path, and the dependent supervisor timing case failed.
