### PR TITLE
fix(runtime): prepare agentd socket for non-root users

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.4
-appVersion: "0.8.4"
+version: 0.8.5
+appVersion: "0.8.5"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.4`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.5`; otherwise the API server will prune or reject
 the new scheduling fields.
 
 For Flux, configure the `HelmRelease` to create or replace CRDs consistently on
@@ -42,11 +42,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.4 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.5 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.4 --namespace nvt --create-namespace
+  --version 0.8.5 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/runtime/core/entrypoint.sh
+++ b/runtime/core/entrypoint.sh
@@ -21,6 +21,13 @@ fi
 
 mkdir -p "$HOME/.nvt-agent" "$NVT_STATE_DIR" "${NVT_WORKSPACE:-/workspace}"
 
+# The default agentd socket lives under /run, which is root-owned. Prepare its
+# parent for the selected runtime user before agentd starts. nvt-as-root is a
+# passthrough for root and uses the image's passwordless sudo in non-root mode.
+agentd_socket="${NVT_AGENTD_SOCKET:-/run/nvt-agent/agentd.sock}"
+agentd_runtime_dir="$(dirname "$agentd_socket")"
+nvt-as-root install -d -m 0700 -o "$(id -u)" -g "$(id -g)" "$agentd_runtime_dir"
+
 export MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.local/share/mise/shims:${PATH}"
 

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.4" || "${CHART_APP_VERSION}" != "0.8.4" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.4, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.5" || "${CHART_APP_VERSION}" != "0.8.5" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.5, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.4' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.5' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"

--- a/tests/runtime/session_supervisor_test.go
+++ b/tests/runtime/session_supervisor_test.go
@@ -214,9 +214,11 @@ func TestEntrypointIntentionalTERMForwardsToAndReapsSupervisor(t *testing.T) {
 	f := newFixture(t)
 	started := filepath.Join(f.home, "entrypoint-supervisor-started")
 	terminated := filepath.Join(f.home, "entrypoint-supervisor-terminated")
+	agentdSocket := filepath.Join(f.home, "run", "nvt-agent", "agentd.sock")
 	for _, command := range []string{"bootstrap", "export-plugin-tools", "write-agent-instructions", "run-plugins", "agentd", "start-code-server", "start-agent-session"} {
 		f.writeBin(command, "#!/usr/bin/env bash\nexit 0\n")
 	}
+	f.writeBin("sudo", "#!/usr/bin/env bash\nexec \"$@\"\n")
 	f.writeBin("supervise-agent-session", `#!/usr/bin/env bash
 set -u
 trap 'touch "$NVT_TEST_SUPERVISOR_TERMINATED"; exit 0' TERM INT
@@ -231,6 +233,7 @@ done
 		"NVT_TEST_SUPERVISOR_STARTED="+started,
 		"NVT_TEST_SUPERVISOR_TERMINATED="+terminated,
 		"NVT_AGENT_CONFIG_FILE="+filepath.Join(f.home, "agent.yaml"),
+		"NVT_AGENTD_SOCKET="+agentdSocket,
 	))
 	output := &bytes.Buffer{}
 	cmd.Stdout = output
@@ -238,7 +241,18 @@ done
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
-	waitForFile(t, started, time.Second)
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("entrypoint did not start supervisor:\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatal(err)
 	}
@@ -247,6 +261,13 @@ done
 	}
 	if _, err := os.Stat(terminated); err != nil {
 		t.Fatalf("entrypoint did not terminate and reap supervisor: %v", err)
+	}
+	runtimeDirInfo, err := os.Stat(filepath.Dir(agentdSocket))
+	if err != nil {
+		t.Fatalf("entrypoint did not prepare agentd runtime directory: %v", err)
+	}
+	if got := runtimeDirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("agentd runtime directory mode = %04o, want 0700", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- prepare the configured agentd socket directory for the active runtime UID/GID before agentd starts
- keep the directory private with mode 0700 for root and non-root runtimes
- publish the fix as coordinated chart release 0.8.5

## Tests
- `GOCACHE=/private/tmp/nvt-runtime-go-cache go test -run "TestEntrypointIntentionalTERMForwardsToAndReapsSupervisor|TestRuntimeImageAndEntrypointInstallSessionSupervisor" -count=1 -v .` in `tests/runtime`
- `make runtime-build`
- non-root image smoke: agentd + agentdctl over `/run/nvt-agent/agentd.sock`
- `helm lint charts/nvt`
- `bash tests/operator/helm/test.sh`
- `bash -n runtime/core/entrypoint.sh`
- `git diff --check`

The full local runtime suite was attempted but the host Python subprocesses lacked PyYAML; the focused changed-path tests pass.