### PR TITLE
fix: allocate resources for Kata agent VMs

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.5
-appVersion: "0.8.5"
+version: 0.8.6
+appVersion: "0.8.6"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.5`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.6`; otherwise the API server will prune or reject
 the new scheduling fields.
 
 For Flux, configure the `HelmRelease` to create or replace CRDs consistently on
@@ -42,11 +42,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.5 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.6 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.5 --namespace nvt --create-namespace
+  --version 0.8.6 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being
@@ -268,6 +268,9 @@ Scheduling fields in the shared template are passed to the generated agent Pod:
 agentSchedule:
   template:
     runtimeClassName: kata-vm-isolation
+    resources:
+      requests: {cpu: "2", memory: 8Gi}
+      limits: {cpu: "2", memory: 8Gi}
     tolerations:
       - key: purpose
         operator: Equal
@@ -279,6 +282,9 @@ RuntimeClass scheduling may select the runtime/node environment. A toleration
 permits the agent Pod to schedule onto a matching tainted pool, but does not
 select a node or remove the taint. These are generic Kubernetes values. They do
 not move the separate egress service Pod or any nvt platform Deployment.
+`resources` is applied to the agent container. On AKS Pod Sandboxing, the CPU
+and memory limits determine the Kata Pod VM allocation; set requests equal to
+limits when predictable VM capacity is required.
 
 When `agentSchedule.template` is non-empty, an absent or empty `image` defaults
 to the coordinated runtime image (`runtime.image` with the published chart's

--- a/charts/nvt/crds/nvt.dev_agentruns.yaml
+++ b/charts/nvt/crds/nvt.dev_agentruns.yaml
@@ -80,6 +80,38 @@ spec:
                   minLength: 1
                 runtimeClassName:
                   type: string
+                resources:
+                  description: Resources controls the agent container and VM-backed Pod sizing.
+                  type: object
+                  properties:
+                    claims:
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                      items:
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            type: string
+                    limits:
+                      type: object
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                        x-kubernetes-int-or-string: true
+                    requests:
+                      type: object
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                        x-kubernetes-int-or-string: true
                 tolerations:
                   type: array
                   items:

--- a/charts/nvt/crds/nvt.dev_agentschedules.yaml
+++ b/charts/nvt/crds/nvt.dev_agentschedules.yaml
@@ -53,6 +53,38 @@ spec:
                       minLength: 1
                     runtimeClassName:
                       type: string
+                    resources:
+                      description: Resources is snapshotted into the generated AgentRun and applied to its agent container.
+                      type: object
+                      properties:
+                        claims:
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                          items:
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                type: string
+                        limits:
+                          type: object
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          type: object
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                            x-kubernetes-int-or-string: true
                     tolerations:
                       type: array
                       items:

--- a/operator/api/v1alpha1/agentrun_types.go
+++ b/operator/api/v1alpha1/agentrun_types.go
@@ -74,6 +74,9 @@ type AgentRunSpec struct {
 	RuntimeAuth      *AgentRunRuntimeAuth `json:"runtimeAuth,omitempty"`
 	Image            string               `json:"image"`
 	RuntimeClassName *string              `json:"runtimeClassName,omitempty"`
+	// Resources controls the agent container. For VM-backed runtimes such as
+	// Kata, its limits also determine the Pod VM CPU and memory allocation.
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Tolerations applies only to the dynamically generated agent Pod.
 	Tolerations               []corev1.Toleration `json:"tolerations,omitempty"`
 	Egress                    AgentRunEgressMode  `json:"egress,omitempty"`
@@ -284,6 +287,7 @@ func (in *AgentRunSpec) DeepCopy() *AgentRunSpec {
 		out.RuntimeClassName = new(string)
 		*out.RuntimeClassName = *in.RuntimeClassName
 	}
+	out.Resources = *in.Resources.DeepCopy()
 	if in.Tolerations != nil {
 		out.Tolerations = make([]corev1.Toleration, len(in.Tolerations))
 		for i := range in.Tolerations {

--- a/operator/api/v1alpha1/agentschedule_types.go
+++ b/operator/api/v1alpha1/agentschedule_types.go
@@ -34,6 +34,8 @@ type AgentScheduleSpec struct {
 type AgentScheduleTemplate struct {
 	Image            string  `json:"image"`
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+	// Resources is snapshotted into the generated AgentRun and applied to its agent container.
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Tolerations is snapshotted into the generated AgentRun and applies only to its agent Pod.
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	Workspace   AgentRunWorkspace   `json:"workspace"`
@@ -165,6 +167,7 @@ func (in *AgentScheduleTemplate) DeepCopy() *AgentScheduleTemplate {
 		out.RuntimeClassName = new(string)
 		*out.RuntimeClassName = *in.RuntimeClassName
 	}
+	out.Resources = *in.Resources.DeepCopy()
 	if in.Tolerations != nil {
 		out.Tolerations = make([]corev1.Toleration, len(in.Tolerations))
 		for i := range in.Tolerations {

--- a/operator/config/crd/bases/nvt.dev_agentruns.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentruns.yaml
@@ -80,6 +80,38 @@ spec:
                   minLength: 1
                 runtimeClassName:
                   type: string
+                resources:
+                  description: Resources controls the agent container and VM-backed Pod sizing.
+                  type: object
+                  properties:
+                    claims:
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                      items:
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            type: string
+                    limits:
+                      type: object
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                        x-kubernetes-int-or-string: true
+                    requests:
+                      type: object
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                        x-kubernetes-int-or-string: true
                 tolerations:
                   type: array
                   items:

--- a/operator/config/crd/bases/nvt.dev_agentschedules.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentschedules.yaml
@@ -53,6 +53,38 @@ spec:
                       minLength: 1
                     runtimeClassName:
                       type: string
+                    resources:
+                      description: Resources is snapshotted into the generated AgentRun and applied to its agent container.
+                      type: object
+                      properties:
+                        claims:
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                          items:
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                type: string
+                        limits:
+                          type: object
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          type: object
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: '^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([eE](\\+|-)?[0-9]+)|[numkKMGTPCE]i?)?$'
+                            x-kubernetes-int-or-string: true
                     tolerations:
                       type: array
                       items:

--- a/operator/docs/agentrun.md
+++ b/operator/docs/agentrun.md
@@ -18,6 +18,9 @@ spec:
     user: non-root
   image: nvt-agent-runtime:latest
   runtimeClassName: kata-vm-isolation
+  resources:
+    requests: {cpu: "2", memory: 8Gi}
+    limits: {cpu: "2", memory: 8Gi}
   tolerations:
     - key: purpose
       operator: Equal
@@ -83,7 +86,8 @@ custody and placeholders instead.
 
 `image` selects the runtime image. `runtimeClassName` requests a runtime handler;
 the cluster's RuntimeClass scheduling configuration may select the node/runtime
-environment. `tolerations` optionally permits only the generated agent Pod to
+environment. `resources` is applied to the agent container; VM-backed runtimes
+can use its limits to size the Pod VM. `tolerations` optionally permits only the generated agent Pod to
 schedule onto matching tainted nodes, but a toleration does not select a node or
 remove the taint. The separate egress service Pod and platform Deployments do
 not inherit AgentRun tolerations.

--- a/operator/docs/agentschedule.md
+++ b/operator/docs/agentschedule.md
@@ -12,8 +12,8 @@ may submit work. See
 [`operator/examples/agentschedule-profiled.yaml`](../examples/agentschedule-profiled.yaml)
 for a complete resource.
 
-The common `template` owns the runtime image, RuntimeClass, optional agent-Pod
-tolerations, workspace, shared agent config (packages, tools, and plugins),
+The common `template` owns the runtime image, RuntimeClass, agent-container
+resources, optional agent-Pod tolerations, workspace, shared agent config (packages, tools, and plugins),
 lifecycle defaults, and TTL. RuntimeClass scheduling may select a runtime/node
 environment. Tolerations permit the generated agent Pod to schedule onto
 matching tainted nodes, but do not select a node or remove a taint. The template

--- a/operator/examples/agentrun-basic.yaml
+++ b/operator/examples/agentrun-basic.yaml
@@ -9,6 +9,9 @@ spec:
 
   image: nvt-agent-runtime:latest
   runtimeClassName: kata-vm-isolation
+  resources:
+    requests: {cpu: "2", memory: 8Gi}
+    limits: {cpu: "2", memory: 8Gi}
 
   workspace:
     mode: Ephemeral

--- a/operator/examples/agentschedule-profiled.yaml
+++ b/operator/examples/agentschedule-profiled.yaml
@@ -10,6 +10,9 @@ spec:
   template:
     image: nvt-agent-runtime:latest
     runtimeClassName: kata-vm-isolation
+    resources:
+      requests: {cpu: "2", memory: 8Gi}
+      limits: {cpu: "2", memory: 8Gi}
     tolerations:
       - key: purpose
         operator: Equal

--- a/operator/internal/controller/agentrun_controller.go
+++ b/operator/internal/controller/agentrun_controller.go
@@ -3151,6 +3151,7 @@ ip6tables -t nat -C PREROUTING -j NVT_DIND 2>/dev/null || ip6tables -t nat -I PR
 			Name:            "agent",
 			Image:           agentRun.Spec.Image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
+			Resources:       *agentRun.Spec.Resources.DeepCopy(),
 			WorkingDir:      workspaceMountPath,
 			Env:             agentEnv,
 			VolumeMounts:    agentVolumeMounts,

--- a/operator/internal/controller/agentrun_controller_test.go
+++ b/operator/internal/controller/agentrun_controller_test.go
@@ -129,6 +129,10 @@ func TestReconcileCreatesAgentPod(t *testing.T) {
 	agentRun := testAgentRun()
 	runtimeClassName := "kata-vm-isolation"
 	agentRun.Spec.RuntimeClassName = &runtimeClassName
+	agentRun.Spec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("8Gi")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("8Gi")},
+	}
 	tolerationSeconds := int64(120)
 	agentRun.Spec.Tolerations = []corev1.Toleration{{
 		Key: "purpose", Operator: corev1.TolerationOpEqual, Value: "nvt-agent",
@@ -176,6 +180,13 @@ func TestReconcileCreatesAgentPod(t *testing.T) {
 	}
 
 	agentContainer := requireContainer(t, pod, "agent")
+	if !reflect.DeepEqual(agentContainer.Resources, agentRun.Spec.Resources) {
+		t.Fatalf("expected agent resources %#v, got %#v", agentRun.Spec.Resources, agentContainer.Resources)
+	}
+	agentContainer.Resources.Limits[corev1.ResourceMemory] = resource.MustParse("1Gi")
+	if agentRun.Spec.Resources.Limits.Memory().Cmp(resource.MustParse("8Gi")) != 0 {
+		t.Fatal("desired Pod resources alias AgentRun API storage")
+	}
 	if agentContainer.Image != agentRun.Spec.Image {
 		t.Fatalf("expected agent image %q, got %q", agentRun.Spec.Image, agentContainer.Image)
 	}
@@ -312,10 +323,17 @@ func TestWorkspaceValidation(t *testing.T) {
 func TestPersistentWorkspaceDeepCopyDoesNotAliasQuantity(t *testing.T) {
 	run := testAgentRun()
 	run.Spec.Workspace = persistentWorkspace("5Gi", "")
+	run.Spec.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+	}
 	copy := run.DeepCopyObject().(*nvtv1alpha1.AgentRun)
 	copy.Spec.Workspace.Size.Add(resource.MustParse("1Gi"))
+	copy.Spec.Resources.Limits[corev1.ResourceMemory] = resource.MustParse("1Gi")
 	if run.Spec.Workspace.Size.Cmp(resource.MustParse("5Gi")) != 0 || copy.Spec.Workspace.Size.Cmp(resource.MustParse("6Gi")) != 0 {
 		t.Fatalf("workspace quantity was aliased: original=%s copy=%s", run.Spec.Workspace.Size, copy.Spec.Workspace.Size)
+	}
+	if run.Spec.Resources.Limits.Memory().Cmp(resource.MustParse("8Gi")) != 0 {
+		t.Fatal("resource requirements were aliased")
 	}
 }
 

--- a/operator/internal/controller/agentschedule_controller_test.go
+++ b/operator/internal/controller/agentschedule_controller_test.go
@@ -47,6 +47,9 @@ func TestAgentScheduleAPIDeepCopyAndScheme(t *testing.T) {
 	workspaceSize := resource.MustParse("5Gi")
 	schedule.Spec.Template = &nvtv1alpha1.AgentScheduleTemplate{}
 	schedule.Spec.Template.Workspace = nvtv1alpha1.AgentRunWorkspace{Mode: nvtv1alpha1.AgentRunWorkspacePersistent, Size: &workspaceSize}
+	schedule.Spec.Template.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+	}
 	tolerationSeconds := int64(90)
 	schedule.Spec.Template.Tolerations = []corev1.Toleration{{
 		Key: "purpose", Operator: corev1.TolerationOpEqual, Value: "nvt-agent",
@@ -54,10 +57,14 @@ func TestAgentScheduleAPIDeepCopyAndScheme(t *testing.T) {
 	}}
 	copied = schedule.DeepCopyObject().(*nvtv1alpha1.AgentSchedule)
 	copied.Spec.Template.Workspace.Size.Add(resource.MustParse("1Gi"))
+	copied.Spec.Template.Resources.Limits[corev1.ResourceMemory] = resource.MustParse("1Gi")
 	copied.Spec.Template.Tolerations[0].Key = "changed"
 	*copied.Spec.Template.Tolerations[0].TolerationSeconds = 1
 	if schedule.Spec.Template.Workspace.Size.Cmp(resource.MustParse("5Gi")) != 0 {
 		t.Fatal("expected template workspace quantity to be deep-copied")
+	}
+	if schedule.Spec.Template.Resources.Limits.Memory().Cmp(resource.MustParse("8Gi")) != 0 {
+		t.Fatal("expected template resources to be deep-copied")
 	}
 	if schedule.Spec.Template.Tolerations[0].Key != "purpose" || *schedule.Spec.Template.Tolerations[0].TolerationSeconds != tolerationSeconds {
 		t.Fatal("expected template tolerations to be deep-copied")

--- a/operator/internal/controller/execution_profile.go
+++ b/operator/internal/controller/execution_profile.go
@@ -190,6 +190,7 @@ func buildProfiledAgentRun(
 			RuntimeAuth:               profile.RuntimeAuth.DeepCopy(),
 			Image:                     template.Image,
 			RuntimeClassName:          copyStringPointer(template.RuntimeClassName),
+			Resources:                 *template.Resources.DeepCopy(),
 			Tolerations:               copyTolerations(template.Tolerations),
 			Egress:                    profile.Egress,
 			EgressAllowInsecureBroker: profile.EgressAllowInsecureBroker,

--- a/operator/internal/controller/execution_profile_test.go
+++ b/operator/internal/controller/execution_profile_test.go
@@ -108,6 +108,10 @@ func TestProfiledScheduleDefaultAndExactSelection(t *testing.T) {
 	runtimeClassName := "kata-vm-isolation"
 	tolerationSeconds := int64(60)
 	schedule.Spec.Template.RuntimeClassName = &runtimeClassName
+	schedule.Spec.Template.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("8Gi")},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("8Gi")},
+	}
 	schedule.Spec.Template.Tolerations = []corev1.Toleration{{
 		Key: "purpose", Operator: corev1.TolerationOpEqual, Value: "nvt-agent",
 		Effect: corev1.TaintEffectNoExecute, TolerationSeconds: &tolerationSeconds,
@@ -120,12 +124,17 @@ func TestProfiledScheduleDefaultAndExactSelection(t *testing.T) {
 	defaultRun := fixture.run(t, defaultDecoded.AgentRun.Name)
 	assertResolvedProfile(t, &defaultRun, "codex-default", "codex-default", "codex-default")
 	if defaultRun.Spec.RuntimeClassName == nil || *defaultRun.Spec.RuntimeClassName != runtimeClassName ||
+		!reflect.DeepEqual(defaultRun.Spec.Resources, schedule.Spec.Template.Resources) ||
 		!reflect.DeepEqual(defaultRun.Spec.Tolerations, schedule.Spec.Template.Tolerations) {
 		t.Fatalf("shared scheduling fields were not propagated: %#v", defaultRun.Spec)
 	}
 	defaultRun.Spec.Tolerations[0].TolerationSeconds = ptrTo(int64(1))
+	defaultRun.Spec.Resources.Limits[corev1.ResourceMemory] = resource.MustParse("1Gi")
 	if *schedule.Spec.Template.Tolerations[0].TolerationSeconds != tolerationSeconds {
 		t.Fatal("resolved AgentRun tolerations alias the AgentSchedule template")
+	}
+	if schedule.Spec.Template.Resources.Limits.Memory().Cmp(resource.MustParse("8Gi")) != 0 {
+		t.Fatal("resolved AgentRun resources alias the AgentSchedule template")
 	}
 	if defaultRun.Spec.ProfileProvenance.Principal != nil {
 		t.Fatalf("default admission unexpectedly recorded a principal: %#v", defaultRun.Spec.ProfileProvenance)

--- a/tests/operator/helm/profile-values.yaml
+++ b/tests/operator/helm/profile-values.yaml
@@ -2,6 +2,13 @@ agentSchedule:
   template:
     image: runtime:test
     runtimeClassName: kata-vm-isolation
+    resources:
+      requests:
+        cpu: "2"
+        memory: 8Gi
+      limits:
+        cpu: "2"
+        memory: 8Gi
     tolerations:
       - key: purpose
         operator: Equal

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.5" || "${CHART_APP_VERSION}" != "0.8.5" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.5, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.6" || "${CHART_APP_VERSION}" != "0.8.6" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.6, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.5' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.6' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"
@@ -590,6 +590,8 @@ grep -q 'provider: codex-main' "${PROFILE_RENDER}"
 grep -q 'onNoMatch: useDefault' "${PROFILE_RENDER}"
 grep -q 'system:serviceaccount:custom-ns:producer' "${PROFILE_RENDER}"
 grep -q 'runtimeClassName: kata-vm-isolation' "${PROFILE_RENDER}"
+grep -A6 'resources:' "${PROFILE_RENDER}" | grep -q 'cpu: "2"'
+grep -A6 'resources:' "${PROFILE_RENDER}" | grep -q 'memory: 8Gi'
 grep -A5 'tolerations:' "${PROFILE_RENDER}" | grep -q 'key: purpose'
 grep -A5 'tolerations:' "${PROFILE_RENDER}" | grep -q 'operator: Equal'
 grep -A5 'tolerations:' "${PROFILE_RENDER}" | grep -q 'value: nvt-agent'


### PR DESCRIPTION
## Summary
- add generic agent-container resource requirements to AgentRun and AgentSchedule templates
- propagate immutable requests/limits into generated agent Pods so AKS can size Kata Pod VMs
- document and test matching 2 CPU / 8 GiB requests and limits; bump the coordinated chart to 0.8.6

## Tests
- `GOCACHE=/private/tmp/nvt-kata-resources-go-cache go test -count=1 ./internal/controller` (from `operator/`)
- `bash tests/operator/helm/test.sh`
- `git diff --check`