### PR TITLE
fix(runtime): seed Claude Code first-run state for headless sessions

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.6
-appVersion: "0.8.6"
+version: 0.8.7
+appVersion: "0.8.7"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.6`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.7`; otherwise the API server will prune or reject
 the new scheduling fields.
 
 For Flux, configure the `HelmRelease` to create or replace CRDs consistently on
@@ -42,11 +42,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.6 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.7 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.6 --namespace nvt --create-namespace
+  --version 0.8.7 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -121,6 +121,16 @@ For enforced Kubernetes workloads, combine mediated mode with transparent
 transport. This prevents tools from bypassing egressd while allowing ordinary
 non-injection traffic as policy-approved blind tunnels.
 
+## First-Run State
+
+A credentials file alone does not start a session: Claude Code first runs an
+interactive first-run wizard (onboarding, login method, workspace trust) that a
+headless session can never answer. When `runtime.command` is `claude`,
+bootstrap seeds `~/.claude.json` with onboarding completed and the workspace
+trusted so the session starts directly. An existing `~/.claude.json` is left
+untouched; this seeding is independent of egress mode and of the credentials
+file.
+
 ## Refresh
 
 Before injection or direct file vending, the broker refreshes when `expiresAt`

--- a/runtime/core/bootstrap.py
+++ b/runtime/core/bootstrap.py
@@ -674,6 +674,22 @@ def apply_placeholder_files(egress):
             write_placeholder_file(target, content, mode, home)
 
 
+def seed_claude_state(command):
+    if Path(command).name != "claude":
+        return
+    target = Path.home() / ".claude.json"
+    if target.exists():
+        print(f"bootstrap: claude state file {target} already exists", flush=True)
+        return
+    state = {
+        "hasCompletedOnboarding": True,
+        "theme": "dark",
+        "projects": {str(workspace()): {"hasTrustDialogAccepted": True}},
+    }
+    write_placeholder_file(target, json.dumps(state, indent=2, sort_keys=True) + "\n", 0o600, Path.home())
+    print(f"bootstrap: seeded claude state file {target}", flush=True)
+
+
 def apply_additional_paths(paths):
     for path in reversed(paths):
         prepend_path(expand_path(path))
@@ -842,6 +858,7 @@ def main():
     # Placeholder-file materialization is independent of egress mode: it writes
     # inert placeholder auth files whether or not mediated routing is applied.
     apply_placeholder_files(egress)
+    seed_claude_state(effective_command)
     if command:
         # Kept for older helper scripts and diagnostics; start-agent-session uses
         # agent-command.json so runtime.args are passed without shell parsing.

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.6" || "${CHART_APP_VERSION}" != "0.8.6" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.6, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.7" || "${CHART_APP_VERSION}" != "0.8.7" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.7, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.6' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.7' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"

--- a/tests/runtime/claude_state_test.go
+++ b/tests/runtime/claude_state_test.go
@@ -1,0 +1,93 @@
+package runtime_test
+
+// Bootstrap seeding of Claude Code's state file (~/.claude.json): a claude
+// runtime gets onboarding and workspace trust marked complete so a headless
+// session is never blocked on the interactive first-run wizard; the file is
+// never overwritten and non-claude runtimes are untouched.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func readClaudeState(t *testing.T, f *fixture) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(f.home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("invalid claude state JSON: %v\n%s", err, data)
+	}
+	return state
+}
+
+func TestBootstrapSeedsClaudeStateForClaudeRuntime(t *testing.T) {
+	f := newFixture(t)
+	config := f.writeAgentConfig(`
+runtime:
+  command: claude
+`)
+
+	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
+
+	state := readClaudeState(t, f)
+	if state["hasCompletedOnboarding"] != true {
+		t.Fatalf("expected hasCompletedOnboarding true, got %#v", state)
+	}
+	projects, ok := state["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected projects object, got %#v", state)
+	}
+	project, ok := projects[f.workspace].(map[string]any)
+	if !ok {
+		t.Fatalf("expected project entry for %s, got %#v", f.workspace, projects)
+	}
+	if project["hasTrustDialogAccepted"] != true {
+		t.Fatalf("expected hasTrustDialogAccepted true, got %#v", project)
+	}
+	info, err := os.Stat(filepath.Join(f.home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected mode 0600, got %v", info.Mode().Perm())
+	}
+}
+
+func TestBootstrapPreservesExistingClaudeState(t *testing.T) {
+	f := newFixture(t)
+	existing := `{"hasCompletedOnboarding":true,"customKey":"user-managed"}`
+	mustWriteFile(t, filepath.Join(f.home, ".claude.json"), existing)
+	config := f.writeAgentConfig(`
+runtime:
+  command: claude
+`)
+
+	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
+
+	data, err := os.ReadFile(filepath.Join(f.home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != existing {
+		t.Fatalf("bootstrap rewrote existing claude state:\n%s", data)
+	}
+}
+
+func TestBootstrapDoesNotSeedClaudeStateForOtherRuntimes(t *testing.T) {
+	f := newFixture(t)
+	config := f.writeAgentConfig(`
+runtime:
+  command: codex
+`)
+
+	f.runWithEnv(bootstrapBin(f.root), true, nil, config)
+
+	if _, err := os.Stat(filepath.Join(f.home, ".claude.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no claude state file for codex runtime, err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Claude Code v2.1.218+ blocks session start on its interactive first-run wizard (onboarding, login method, workspace trust) even when a valid credentials file exists. Headless claude runtimes stalled at the login picker (observed on studio-staging-aks run `default-58cdc71b4d`: the mediated placeholder `.credentials.json` was in place, but the tmux session sat at "Select login method" until the run failed).
- Bootstrap now seeds `~/.claude.json` with onboarding completed, a theme, and workspace trust accepted when `runtime.command` resolves to `claude`. An existing `~/.claude.json` is never modified, and non-claude runtimes are untouched.
- The seeded fields were validated against Claude Code v2.1.218: with this file present it starts straight into the session using the placeholder credentials; without it the wizard prompts for login and trust interactively.
- Documents the behavior in `docs/claude-auth.md` and bumps the coordinated chart to 0.8.7.

## Tests
- `go test -count=1 ./...` in `tests/runtime` — new `claude_state_test.go` covers seeding for claude runtimes (fields + 0600 mode), preserving an existing file, and skipping non-claude runtimes.
- Full runtime suite green except the pre-existing `TestAgentSessionSupervisorDetectsRealTmuxSessionLoss` failure on macOS (tmux socket path length in the Go temp dir; fails identically on a clean checkout of main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)