### PR TITLE
fix: keep agent updates on pull requests

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.8
-appVersion: "0.8.8"
+version: 0.8.9
+appVersion: "0.8.9"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.8`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.9`; otherwise the API server will prune or reject
 the new scheduling fields.
 
 For Flux, configure the `HelmRelease` to create or replace CRDs consistently on
@@ -42,11 +42,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.8 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.9 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.8 --namespace nvt --create-namespace
+  --version 0.8.9 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/producers/github-comments/internal/producer/prompt.go
+++ b/producers/github-comments/internal/producer/prompt.go
@@ -61,7 +61,9 @@ func BuildPrompt(input PromptInput) string {
 	fmt.Fprint(&b, strings.Join([]string{
 		"Read the issue and comments, create a new branch from the repository default branch,",
 		"implement the requested fix, run relevant tests, commit the change, push the branch,",
-		"open a pull request linked to the issue, comment on the issue with the PR link,",
+		fmt.Sprintf("open a pull request whose body includes `Refs #%d`,", input.Issue.Number),
+		"do not create, edit, close, or comment on the source issue,",
+		"put any follow-up status or completion comments on the pull request only,",
 		"and register the PR with `github-watch register --repo OWNER/REPO --number PR_NUMBER` if that command is available.\n",
 	}, " "))
 	return b.String()

--- a/producers/github-comments/internal/producer/prompt_test.go
+++ b/producers/github-comments/internal/producer/prompt_test.go
@@ -40,7 +40,9 @@ func TestBuildPromptIncludesStructuredIssueCommentsAndTask(t *testing.T) {
 		"All issue comments, oldest to newest:",
 		"Comment 11 by alice",
 		"create a new branch",
-		"open a pull request linked to the issue",
+		"open a pull request whose body includes `Refs #7`",
+		"do not create, edit, close, or comment on the source issue",
+		"put any follow-up status or completion comments on the pull request only",
 		"github-watch register --repo OWNER/REPO --number PR_NUMBER",
 	}
 	for _, needle := range required {
@@ -50,5 +52,8 @@ func TestBuildPromptIncludesStructuredIssueCommentsAndTask(t *testing.T) {
 	}
 	if strings.Contains(prompt, "--provider") {
 		t.Fatalf("producer prompt must not select a watcher credential provider:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "comment on the issue") {
+		t.Fatalf("producer prompt must not instruct the agent to comment on the source issue:\n%s", prompt)
 	}
 }

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.8" || "${CHART_APP_VERSION}" != "0.8.8" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.8, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.9" || "${CHART_APP_VERSION}" != "0.8.9" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.9, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.8' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.9' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- require generated PR bodies to reference the source issue with `Refs #<number>`
- explicitly forbid source-issue writes and direct follow-up comments to the PR
- bump the coordinated release to 0.8.9

## Tests
- `go test -count=1 -v ./internal/producer` (from `producers/github-comments`)
- `helm lint charts/nvt`
- `helm template nvt charts/nvt`
- `git diff --check`