### PR TITLE
fix: preserve Claude feature beta headers

### DIFF
--- a/broker/README.md
+++ b/broker/README.md
@@ -131,7 +131,9 @@ providers:
 `9d1c250a-e61b-44d9-88ed-5944d1962f5e`, the default `refresh-scope`, and
 `User-Agent: axios/1.15.2`. Refresh does not send `anthropic-beta`; that
 header belongs under `injection-extra-headers` when an injected API request
-requires it.
+requires it. Claude Code may send additional version-specific beta tokens;
+egressd preserves those client values and appends/deduplicates the configured
+non-secret feature tokens.
 These values are not user/subscription secrets and can be overridden with
 `token-url`, `client-id` / `client-id-env`, `refresh-scope` /
 `refresh-scope-env`, and `user-agent` if

--- a/broker/core/executable_provider.py
+++ b/broker/core/executable_provider.py
@@ -231,11 +231,18 @@ class ExecutableProviderAdapter(ProviderAdapter):
             "request_id": request_id, "grant": grant,
         })
         result = self._object(result, "injection.headers result")
-        self._require_keys(result, {"headers", "expires_at", "strip_request_headers"}, "injection.headers result")
+        self._require_keys(
+            result,
+            {"headers", "expires_at", "strip_request_headers"},
+            "injection.headers result",
+            optional={"append_headers"},
+        )
         self._string_map(result["headers"], "injection.headers result headers")
+        append_headers = result.get("append_headers", {})
+        self._string_map(append_headers, "injection.headers result append_headers")
         self._optional_string(result["expires_at"], "injection.headers result expires_at")
         self._string_list(result["strip_request_headers"], "injection.headers result strip_request_headers")
-        return result["headers"], result["expires_at"], result["strip_request_headers"]
+        return result["headers"], result["expires_at"], result["strip_request_headers"], append_headers
 
     def close(self):
         with self._lock:

--- a/broker/core/providers.py
+++ b/broker/core/providers.py
@@ -78,7 +78,11 @@ class InProcessProviderAdapter(ProviderAdapter):
         return self._provider.placeholder_files(agent_id, audit, request_id, grant)
 
     def injection_headers(self, host, method, path, agent_id, audit, request_id, grant):
-        return self._provider.injection_headers(host, method, path, agent_id, audit, request_id, grant)
+        result = self._provider.injection_headers(host, method, path, agent_id, audit, request_id, grant)
+        if len(result) == 3:
+            headers, expires_at, strip = result
+            return headers, expires_at, strip, {}
+        return result
 
 
 def load_providers(config) -> dict[str, ProviderAdapter]:

--- a/broker/core/server.py
+++ b/broker/core/server.py
@@ -304,7 +304,18 @@ class Broker:
         provider, hosts = self._injection_provider(capability)
         if host not in hosts:
             raise ProviderError("host-not-allowed", f"host {host} is not allowed for {capability}", 403)
-        headers, expires_at, strip = provider.injection_headers(host, method, path, paired["id"], self.audit, request_id, grant)
+        headers, expires_at, strip, append_headers = provider.injection_headers(
+            host, method, path, paired["id"], self.audit, request_id, grant
+        )
+        replaced = {name.lower() for name in headers}
+        appended = {name.lower() for name in append_headers}
+        stripped = {name.lower() for name in strip}
+        if replaced & appended or stripped & appended:
+            raise ProviderError(
+                "injection-headers-invalid",
+                "provider returned overlapping replacement, append, or strip headers",
+                502,
+            )
         self.audit.write(
             request_id=request_id,
             agent=identity["id"],
@@ -317,7 +328,13 @@ class Broker:
             allowed=True,
             expires_at=expires_at,
         )
-        return {"ok": True, "headers": headers, "expires_at": expires_at, "strip_request_headers": strip}
+        return {
+            "ok": True,
+            "headers": headers,
+            "append_headers": append_headers,
+            "expires_at": expires_at,
+            "strip_request_headers": strip,
+        }
 
     def injection_routing(self, request_id, payload, authorization):
         identity = self.agents.authenticate(authorization)

--- a/broker/plugins/claude_oauth/provider.py
+++ b/broker/plugins/claude_oauth/provider.py
@@ -789,12 +789,13 @@ class ClaudeOAuthProvider:
             agent_id, audit, request_id, "injection"
         )
         headers = {"authorization": f"Bearer {access_token}"}
-        headers.update(self.injection_extra_headers)
-        # Every injected name is stripped from the incoming request so the
-        # agent's placeholder version is removed before injection.
-        strip = list(headers.keys())
+        # Claude Code supplies version-specific feature betas. Preserve those
+        # client values and append the broker-required OAuth beta instead of
+        # replacing the complete anthropic-beta header.
+        append_headers = dict(self.injection_extra_headers)
+        strip = ["authorization"]
         expires_at = rfc3339(exp) if exp is not None else None
-        return headers, expires_at, strip
+        return headers, expires_at, strip, append_headers
 
     # --- manual refresh probe (broker-side operator tool) -------------------
 

--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.9
-appVersion: "0.8.9"
+version: 0.8.10
+appVersion: "0.8.10"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.9`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.10`; otherwise the API server will prune or reject
 the new scheduling fields.
 
 For Flux, configure the `HelmRelease` to create or replace CRDs consistently on
@@ -42,11 +42,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.9 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.10 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.9 --namespace nvt --create-namespace
+  --version 0.8.10 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/docs/claude-auth.md
+++ b/docs/claude-auth.md
@@ -60,6 +60,12 @@ Seed this file by logging in with Claude Code in a trusted environment. The
 credential is import material for the broker; mediated agents never receive a
 usable copy.
 
+Claude Code selects additional `anthropic-beta` feature tokens as its request
+schema evolves. The broker declares the OAuth token above, and egressd appends
+it to the client-supplied beta list instead of replacing that list. Keep
+credentials in replacement headers; append-only headers are for non-secret
+feature negotiation only.
+
 `credentials-env` is also supported, but it cannot persist refresh-token
 rotation. Use it only when another system continuously replaces the credential.
 Production OAuth refresh should use `credentials-file`.

--- a/egressd/internal/egress/broker.go
+++ b/egressd/internal/egress/broker.go
@@ -9,12 +9,13 @@ import (
 	"time"
 )
 
-// Material is one injectable-header response from the broker. Header values
-// are credentials: Material must never be logged or serialized.
+// Material is one injectable-header response from the broker. It may contain
+// credentials, so Material must never be logged or serialized.
 type Material struct {
-	Headers   map[string]string
-	Strip     []string
-	ExpiresAt time.Time // zero when the broker reported no expiry
+	Headers       map[string]string
+	AppendHeaders map[string]string
+	Strip         []string
+	ExpiresAt     time.Time // zero when the broker reported no expiry
 }
 
 // BrokerClient calls brokerd's injection endpoint under the egress-role
@@ -36,6 +37,7 @@ type injectionResponse struct {
 	OK                  bool              `json:"ok"`
 	Error               string            `json:"error"`
 	Headers             map[string]string `json:"headers"`
+	AppendHeaders       map[string]string `json:"append_headers"`
 	ExpiresAt           string            `json:"expires_at"`
 	StripRequestHeaders []string          `json:"strip_request_headers"`
 }
@@ -73,7 +75,14 @@ func (b *BrokerClient) FetchHeaders(ctx context.Context, capability, host, metho
 		// never a header value; safe to wrap.
 		return nil, fmt.Errorf("broker denied injection: %s", decoded.Error)
 	}
-	material := &Material{Headers: decoded.Headers, Strip: decoded.StripRequestHeaders}
+	if overlappingHeaderNames(decoded.Headers, decoded.AppendHeaders, decoded.StripRequestHeaders) {
+		return nil, fmt.Errorf("broker returned overlapping replacement, append, or strip headers")
+	}
+	material := &Material{
+		Headers:       decoded.Headers,
+		AppendHeaders: decoded.AppendHeaders,
+		Strip:         decoded.StripRequestHeaders,
+	}
 	if decoded.ExpiresAt != "" {
 		expires, parseErr := time.Parse(time.RFC3339, decoded.ExpiresAt)
 		if parseErr != nil {
@@ -82,6 +91,22 @@ func (b *BrokerClient) FetchHeaders(ctx context.Context, capability, host, metho
 		material.ExpiresAt = expires
 	}
 	return material, nil
+}
+
+func overlappingHeaderNames(headers, appendHeaders map[string]string, strip []string) bool {
+	restricted := make(map[string]struct{}, len(headers)+len(strip))
+	for name := range headers {
+		restricted[http.CanonicalHeaderKey(name)] = struct{}{}
+	}
+	for _, name := range strip {
+		restricted[http.CanonicalHeaderKey(name)] = struct{}{}
+	}
+	for name := range appendHeaders {
+		if _, exists := restricted[http.CanonicalHeaderKey(name)]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 // ReportRequests posts a batch of per-request audit entries to the broker.

--- a/egressd/internal/egress/proxy.go
+++ b/egressd/internal/egress/proxy.go
@@ -211,11 +211,35 @@ func (p *Proxy) buildOutbound(r *http.Request, material *Material) (*http.Reques
 	for name, value := range material.Headers {
 		outbound.Header.Set(name, value)
 	}
+	for name, value := range material.AppendHeaders {
+		appendHeaderTokens(outbound.Header, name, value)
+	}
 	if isUpgradeRequest(r) {
 		copyUpgradeHeaders(outbound.Header, r.Header)
 	}
 	outbound.Host = p.Route.Upstream
 	return outbound, nil
+}
+
+func appendHeaderTokens(header http.Header, name, value string) {
+	values := append([]string(nil), header.Values(name)...)
+	values = append(values, value)
+	seen := make(map[string]struct{})
+	tokens := make([]string, 0, len(values))
+	for _, current := range values {
+		for _, raw := range strings.Split(current, ",") {
+			token := strings.TrimSpace(raw)
+			if token == "" {
+				continue
+			}
+			if _, exists := seen[token]; exists {
+				continue
+			}
+			seen[token] = struct{}{}
+			tokens = append(tokens, token)
+		}
+	}
+	header.Set(name, strings.Join(tokens, ","))
 }
 
 func (p *Proxy) serveUpgrade(w http.ResponseWriter, r *http.Request, outbound *http.Request) {

--- a/egressd/internal/egress/proxy_test.go
+++ b/egressd/internal/egress/proxy_test.go
@@ -27,6 +27,7 @@ type fakeBroker struct {
 	calls     int
 	fail      bool
 	expiresAt string
+	append    map[string]string
 	requests  []map[string]string
 }
 
@@ -57,6 +58,7 @@ func (b *fakeBroker) handle(w http.ResponseWriter, r *http.Request) {
 	b.requests = append(b.requests, payload)
 	fail := b.fail
 	expiresAt := b.expiresAt
+	appendHeaders := b.append
 	b.mu.Unlock()
 	if fail {
 		w.WriteHeader(http.StatusBadGateway)
@@ -66,6 +68,7 @@ func (b *fakeBroker) handle(w http.ResponseWriter, r *http.Request) {
 	response := map[string]any{
 		"ok":                    true,
 		"headers":               map[string]string{"authorization": "Bearer " + realToken},
+		"append_headers":        appendHeaders,
 		"strip_request_headers": []string{"authorization"},
 	}
 	if expiresAt != "" {
@@ -85,6 +88,12 @@ func (b *fakeBroker) setExpiresAt(value string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.expiresAt = value
+}
+
+func (b *fakeBroker) setAppendHeaders(value map[string]string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.append = value
 }
 
 func (b *fakeBroker) callCount() int {
@@ -324,6 +333,62 @@ func TestPlaceholderStrippedFromAnyHeader(t *testing.T) {
 	record := upstream.last(t)
 	if record.header.Get("X-Api-Key") != "" {
 		t.Fatal("placeholder-bearing header forwarded to upstream")
+	}
+}
+
+// TestAppendHeadersPreserveClientFeatureValues pins additive injection for
+// provider feature negotiation: client-declared betas survive, broker-required
+// values are appended once, and credential replacement remains unchanged.
+func TestAppendHeadersPreserveClientFeatureValues(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setAppendHeaders(map[string]string{
+		"anthropic-beta": "oauth-2025-04-20,prompt-caching-scope-2026-01-05",
+	})
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	request, err := http.NewRequest(http.MethodPost, proxy.URL+"/v1/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+Placeholder)
+	request.Header.Set("Anthropic-Beta", "prompt-caching-scope-2026-01-05,prompt-caching-evict-2026-05-12")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from upstream, got %d", response.StatusCode)
+	}
+
+	record := upstream.last(t)
+	if got := record.header.Get("Anthropic-Beta"); got != "prompt-caching-scope-2026-01-05,prompt-caching-evict-2026-05-12,oauth-2025-04-20" {
+		t.Fatalf("upstream anthropic-beta = %q", got)
+	}
+	if got := record.header.Get("Authorization"); got != "Bearer "+realToken {
+		t.Fatalf("upstream authorization = %q", got)
+	}
+}
+
+func TestOverlappingAppendHeaderFailsClosed(t *testing.T) {
+	broker := newFakeBroker(t)
+	broker.setAppendHeaders(map[string]string{"Authorization": "not-allowed"})
+	upstream := newFakeUpstream(t)
+	proxy := newTestProxy(t, broker, upstream)
+
+	response, err := http.Get(proxy.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", response.StatusCode)
+	}
+	upstream.mu.Lock()
+	defer upstream.mu.Unlock()
+	if len(upstream.records) != 0 {
+		t.Fatal("request reached upstream with ambiguous injection material")
 	}
 }
 

--- a/protocol/broker-provider.md
+++ b/protocol/broker-provider.md
@@ -170,7 +170,10 @@ the sole audit writer; provider-generated audit records are not supported.
 - `placeholder-files`: `{agent_id,request_id,grant}` →
   `{files,hosts,expires_at}`.
 - `injection.headers`: `{host,method,path,agent_id,request_id,grant}` →
-  `{headers,expires_at,strip_request_headers}`.
+  `{headers,expires_at,strip_request_headers,append_headers?}`.
+  `append_headers` contains only non-secret, comma-separated feature tokens;
+  credential headers belong in `headers`. Providers that do not need additive
+  composition may omit it.
 - `shutdown`: `{}` → any JSON result. The broker bounds this request, then
   terminates and reaps the child if it does not exit.
 

--- a/protocol/broker.md
+++ b/protocol/broker.md
@@ -430,9 +430,10 @@ custody and exposes the same three materialization surfaces:
   guarded so a copied value that is too long or JWT-shaped is refused
   (`placeholder-claim-unsafe`) rather than smuggled into the placeholder.
 - **mediated / edge injection** (`/v1/injection/headers`): returns
-  `authorization: Bearer <access token>` plus any configured
-  `injection-extra-headers`, with all injected names listed in
-  `strip_request_headers`. Only the paired `egress` identity may fetch it.
+  `authorization: Bearer <access token>` as a replacement header. Configured
+  `injection-extra-headers` are returned as non-secret append-only feature
+  headers, allowing Claude Code's version-specific `anthropic-beta` values to
+  survive. Only the paired `egress` identity may fetch it.
 
 Rules:
 
@@ -448,7 +449,9 @@ Rules:
 - `placeholder-file.hosts` must be a subset of `injection-hosts`, so the
   materialized host bindings can never drift from what the edge can inject for.
 - `injection-extra-headers` may not override `authorization` and may not
-  contain the injection placeholder.
+  contain the injection placeholder. For `claude-oauth`, these values must be
+  comma-separated feature-negotiation tokens, not credentials; egressd
+  preserves client values and appends/deduplicates the configured values.
 - The API-key authentication path (`x-api-key`) does **not** need this provider:
   a generic `token` provider with `injection-header: x-api-key` and an
   `injection-extra-headers` `anthropic-version` already injects an Anthropic API
@@ -660,10 +663,11 @@ providers:
 ```
 
 The `token`, `codex-oauth`, and `claude-oauth` plugins support injection. For
-`codex-oauth` and `claude-oauth`, injected material is
+`codex-oauth` and `claude-oauth`, replacement material is
 `authorization: Bearer <access token>` using the same broker-side refresh flow
-as file vending. `claude-oauth` also returns any configured
-`injection-extra-headers` (e.g. `anthropic-beta`). Audit entries use the
+as file vending. `claude-oauth` returns configured
+`injection-extra-headers` (e.g. `anthropic-beta`) as append-only non-secret
+feature tokens so client-selected values remain intact. Audit entries use the
 `injection.*` operation prefix. Grants must carry `materialization:
 header-inject` **or** `materialization:
 placeholder-file` (both are zero-possession; see `protocol/injection.md` for the

--- a/protocol/injection.md
+++ b/protocol/injection.md
@@ -137,6 +137,7 @@ Response:
   "headers": {
     "authorization": "Bearer ..."
   },
+  "append_headers": {},
   "expires_at": "2026-07-05T12:00:00Z",
   "strip_request_headers": ["authorization"]
 }
@@ -153,6 +154,14 @@ Rules:
   `:port` from its pinned upstream before asking; the port applies only to
   the dial target.
 - Response header names are lowercased.
+- `headers` replaces caller-supplied values and is the only map used for
+  credentials. `append_headers` is optional and is limited to non-secret,
+  comma-separated feature-negotiation values that must compose with values
+  selected by the client. `egressd` preserves the client tokens, appends the
+  provider tokens, and removes duplicates.
+- A header name may not appear in both maps or in both `append_headers` and
+  `strip_request_headers`. The broker and `egressd` reject ambiguous material
+  before contacting the upstream.
 - `expires_at` is the cache ceiling. `egressd` must not serve cached material
   past it and must not fall back to stale material when a refetch fails
   (fail closed).

--- a/tests/broker/claude_auth_conformance_test.go
+++ b/tests/broker/claude_auth_conformance_test.go
@@ -161,8 +161,8 @@ func TestClaudeInjectionIsEgressIdentityScoped(t *testing.T) {
 		"path":       "/v1/messages",
 	}
 
-	// Paired egress: real Bearer token plus configured extra header, both
-	// stripped from the incoming request.
+	// Paired egress: replace the credential, but append the configured
+	// non-secret feature header without stripping Claude Code's own betas.
 	status, body := f.postJSONWithToken("frontend-egress-token", "/v1/injection/headers", req)
 	if status != http.StatusOK || body["ok"] != true {
 		t.Fatalf("paired egress must obtain injection headers: status=%d body=%v", status, body)
@@ -171,15 +171,19 @@ func TestClaudeInjectionIsEgressIdentityScoped(t *testing.T) {
 	if headers["authorization"] != "Bearer real-claude-access-token-secret" {
 		t.Fatalf("expected the real Bearer access token, got %v", headers["authorization"])
 	}
-	if headers["anthropic-beta"] != "oauth-2025-04-20" {
-		t.Fatalf("expected the configured anthropic-beta extra header, got %v", headers["anthropic-beta"])
+	if _, exists := headers["anthropic-beta"]; exists {
+		t.Fatalf("anthropic-beta must not use replacement semantics: %v", headers)
+	}
+	appendHeaders := body["append_headers"].(map[string]any)
+	if appendHeaders["anthropic-beta"] != "oauth-2025-04-20" {
+		t.Fatalf("expected the configured anthropic-beta append header, got %v", appendHeaders["anthropic-beta"])
 	}
 	strip := map[string]bool{}
 	for _, name := range body["strip_request_headers"].([]any) {
 		strip[name.(string)] = true
 	}
-	if !strip["authorization"] || !strip["anthropic-beta"] {
-		t.Fatalf("every injected header must be stripped, got %v", body["strip_request_headers"])
+	if !strip["authorization"] || strip["anthropic-beta"] {
+		t.Fatalf("only replacement headers may be stripped, got %v", body["strip_request_headers"])
 	}
 
 	mcpReq := map[string]any{

--- a/tests/broker/executable_provider_fixture/main.go
+++ b/tests/broker/executable_provider_fixture/main.go
@@ -179,7 +179,16 @@ func (s *server) handle(req request) {
 	case "placeholder-files":
 		s.success(req.ID, map[string]any{"files": []map[string]string{{"path": ".fixture/auth.json", "content": "placeholder", "mode": "0600"}}, "hosts": []string{"api.example.test"}, "expires_at": nil})
 	case "injection.headers":
-		s.success(req.ID, map[string]any{"headers": map[string]string{"authorization": "Bearer " + s.secret}, "expires_at": nil, "strip_request_headers": []string{"authorization"}})
+		appendHeaders := map[string]string{"x-fixture-feature": "required"}
+		if path, _ := req.Params["path"].(string); path == "/overlap" {
+			appendHeaders = map[string]string{"Authorization": "not-allowed"}
+		}
+		s.success(req.ID, map[string]any{
+			"headers":               map[string]string{"authorization": "Bearer " + s.secret},
+			"append_headers":        appendHeaders,
+			"expires_at":            nil,
+			"strip_request_headers": []string{"authorization"},
+		})
 	default:
 		s.failure(req.ID, "method-not-found", 404, "unsupported provider method")
 	}

--- a/tests/broker/executable_provider_test.go
+++ b/tests/broker/executable_provider_test.go
@@ -269,6 +269,23 @@ func TestExecutableProviderUsesTheSameNamedInjectionContract(t *testing.T) {
 	if !ok || headers["authorization"] != "Bearer "+executableCanary {
 		t.Fatalf("executable provider did not supply its named injection result: %#v", body)
 	}
+	appendHeaders, ok := body["append_headers"].(map[string]any)
+	if !ok || appendHeaders["x-fixture-feature"] != "required" {
+		t.Fatalf("executable provider did not supply append-only headers: %#v", body)
+	}
+}
+
+func TestInjectionRejectsOverlappingAppendHeaders(t *testing.T) {
+	f := newExecutableBrokerFixture(t)
+	status, body := f.post(f.egress, "/v1/injection/headers", map[string]any{
+		"capability": "fixture-inject",
+		"host":       "api.example.test",
+		"method":     "GET",
+		"path":       "/overlap",
+	})
+	if status != http.StatusBadGateway || body["error"] != "injection-headers-invalid" {
+		t.Fatalf("overlapping injection headers must fail closed: status=%d body=%#v", status, body)
+	}
 }
 
 func TestExecutableProviderOutOfOrderAndSafeDeclaredError(t *testing.T) {

--- a/tests/broker/placeholder_config_validation_test.go
+++ b/tests/broker/placeholder_config_validation_test.go
@@ -337,7 +337,7 @@ def boom(*a, **k):
 env._refresh = boom
 
 # Near-expiry valid: mediated injection serves the current token, no refresh.
-headers, _exp, _strip = env.injection_headers("api.anthropic.com", "POST", "/v1/messages", "agent", None, "rid")
+headers, _exp, _strip, _append = env.injection_headers("api.anthropic.com", "POST", "/v1/messages", "agent", None, "rid")
 assert headers["authorization"] == "Bearer env-access", headers
 
 # Expired: mediated injection fails closed (no refresh), direct files vends it.

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.9" || "${CHART_APP_VERSION}" != "0.8.9" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.9, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.10" || "${CHART_APP_VERSION}" != "0.8.10" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.10, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.9' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.10' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- add a generic optional `append_headers` injection contract for non-secret feature-negotiation headers
- preserve Claude Code's client-selected `anthropic-beta` tokens while appending and deduplicating the broker-required OAuth beta
- reject replacement/append/strip overlap in both broker and egressd before contacting upstream
- keep existing embedded and executable providers backward compatible
- bump the coordinated release to `0.8.10`

This fixes Claude Code 2.1.218 requests rejected with `system.2.cache_control.ephemeral.scope: Extra inputs are not permitted` after mediation replaced the client's complete beta list.

## Tests

- `go test -race -count=1 ./...` in `egressd/`
- `go test -count=1 ./... -skip '^TestBrokerSeed'` in `tests/broker/`
- focused broker tests for Claude append semantics, executable-provider compatibility, and overlap rejection
- `python3 -m py_compile` for changed broker modules
- `go vet ./...` in `egressd/`
- `helm lint charts/nvt`
- `bash tests/operator/helm/test.sh`
- `bash .github/scripts/release-scripts-test.sh`

The complete broker suite was also run. One unrelated existing test remained flaky: `TestBrokerSeedValidationAndProjectedSecretUpdates` reported that a mixed projected generation was accepted; all non-seed broker tests passed.
