### PR TITLE
fix: use portable DinD loop cleanup

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.15
-appVersion: "0.8.15"
+version: 0.8.16
+appVersion: "0.8.16"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.15`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.16`; otherwise the API server will prune or reject
 new AgentRun and schedule fields such as container capabilities, dedicated
 Docker storage size, broker grant preparations, profile workspace instructions,
 or workflow producer policies.
@@ -44,11 +44,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.15 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.16 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.15 --namespace nvt --create-namespace
+  --version 0.8.16 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/dind/nvt-dind-entrypoint.sh
+++ b/dind/nvt-dind-entrypoint.sh
@@ -86,7 +86,7 @@ new_loop=0
 if [ -n "${associated}" ]; then
   loop_device="${associated}"
 else
-  loop_device="$(losetup --find --show --autoclear "${image}")" || fail "could not attach the Docker backing image"
+  loop_device="$(losetup --find --show "${image}")" || fail "could not attach the Docker backing image"
   new_loop=1
 fi
 
@@ -106,11 +106,20 @@ if ! mount -t ext4 -o noatime "${loop_device}" "${data_root}"; then
   [ "${new_loop}" = 0 ] || losetup -d "${loop_device}" >/dev/null 2>&1 || true
   fail "could not mount the Docker backing filesystem"
 fi
-mounted_type="$(findmnt -n -o FSTYPE --target "${data_root}" 2>/dev/null || true)"
-if [ "${mounted_type}" != "ext4" ]; then
+mounted_source_type="$(findmnt -rn -o SOURCE,FSTYPE --mountpoint "${data_root}" 2>/dev/null | tail -n 1 || true)"
+if [ "${mounted_source_type}" != "${loop_device} ext4" ]; then
   umount "${data_root}" >/dev/null 2>&1 || true
   [ "${new_loop}" = 0 ] || losetup -d "${loop_device}" >/dev/null 2>&1 || true
-  fail "Docker data root is not backed by ext4 after mount"
+  fail "Docker data root is not backed by the expected ext4 loop device after mount"
+fi
+
+# util-linux losetup has no --autoclear attach option. Detaching a busy loop
+# device marks it for lazy destruction: the mounted filesystem remains usable,
+# and the kernel releases the device when the container mount disappears.
+if ! losetup -d "${loop_device}"; then
+  umount "${data_root}" >/dev/null 2>&1 || true
+  losetup -d "${loop_device}" >/dev/null 2>&1 || true
+  fail "could not mark the Docker loop device for automatic cleanup"
 fi
 
 printf '%s\n' overlay2 >"${required_driver_file}"

--- a/dind/test.sh
+++ b/dind/test.sh
@@ -15,7 +15,12 @@ set -euo pipefail
 printf 'findmnt %s\n' "$*" >>"${FAKE_LOG}"
 [[ "${FAKE_FINDMNT_FAIL:-0}" != 1 ]] || exit 1
 if [[ -f "${FAKE_MOUNT_MARKER}" ]]; then
-  printf 'ext4\n'
+  if [[ " $* " == *" SOURCE,FSTYPE "* ]]; then
+    # Model a Kubernetes/Docker volume overmounted by the ext4 loop device.
+    printf '/dev/pvc ext4\n/dev/loop0 ext4\n'
+  else
+    printf 'ext4\n'
+  fi
 else
   printf '%s\n' "${FAKE_FS_TYPE:-ext4}"
 fi
@@ -39,6 +44,9 @@ cat >"${BIN}/losetup" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'losetup %s\n' "$*" >>"${FAKE_LOG}"
+for arg in "$@"; do
+  [[ "${arg}" != "--autoclear" ]] || exit 2
+done
 case "${1:-}" in
   -f)
     if [[ "${FAKE_NEED_LOOP_NODES:-0}" == 1 && ! -f "${FAKE_DEVICE_DIR}/loop-control" ]]; then
@@ -56,6 +64,7 @@ case "${1:-}" in
     printf '/dev/loop0\n'
     ;;
   -d)
+    [[ "${FAKE_LOOP_DETACH_FAIL:-0}" != 1 ]] || exit 1
     rm -f "${FAKE_ASSOCIATED_MARKER}"
     ;;
   *) exit 2 ;;
@@ -81,7 +90,9 @@ cat >"${BIN}/mount" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'mount %s\n' "$*" >>"${FAKE_LOG}"
-[[ "${FAKE_MOUNT_FAIL:-0}" != 1 ]]
+if [[ "${FAKE_MOUNT_FAIL:-0}" == 1 ]]; then
+  exit 1
+fi
 : >"${FAKE_MOUNT_MARKER}"
 FAKE
 
@@ -121,6 +132,7 @@ new_fixture() {
   export FAKE_DEVICE_DIR="${FIXTURE}/dev"
   : >"${FAKE_LOG}"
   unset FAKE_FINDMNT_FAIL FAKE_MKFS_FAIL FAKE_MOUNT_FAIL FAKE_FSCK_STATUS FAKE_FSCK_DELAY FAKE_NEED_LOOP_NODES FAKE_DOCKER_DRIVER
+  unset FAKE_LOOP_DETACH_FAIL
   unset FAKE_PERSISTENT_STORAGE
 }
 
@@ -191,7 +203,12 @@ run_entrypoint
 grep -q '^truncate -s 1073741824 .*\.creating$' "${FAKE_LOG}"
 grep -q '^mkfs.ext4 -q -F .*\.creating$' "${FAKE_LOG}"
 grep -q '^mknod .*/loop-control c 10 237$' "${FAKE_LOG}"
+grep -q '^losetup --find --show .*/docker-data\.ext4$' "${FAKE_LOG}"
 grep -q '^mount -t ext4 -o noatime /dev/loop0 .*/data$' "${FAKE_LOG}"
+grep -q '^losetup -d /dev/loop0$' "${FAKE_LOG}"
+mount_line="$(grep -n '^mount -t ext4 -o noatime /dev/loop0 ' "${FAKE_LOG}" | cut -d: -f1)"
+detach_line="$(grep -n '^losetup -d /dev/loop0$' "${FAKE_LOG}" | cut -d: -f1)"
+[[ "${mount_line}" -lt "${detach_line}" ]]
 grep -q '^dockerd --host=tcp://127.0.0.1:2375 --tls=false --storage-driver=overlay2$' "${FAKE_LOG}"
 grep -qx overlay2 "${FIXTURE}/run/required-storage-driver"
 
@@ -277,6 +294,19 @@ if run_entrypoint >"${FIXTURE}/stdout" 2>"${FIXTURE}/stderr"; then
 fi
 grep -q 'could not mount the Docker backing filesystem' "${FIXTURE}/stderr"
 grep -qx 'do-not-destroy' "${FIXTURE}/backing/docker-data.ext4"
+! grep -q '^dockerd ' "${FAKE_LOG}"
+
+new_fixture detach-failure
+export FAKE_FS_TYPE=virtiofs
+printf 'do-not-destroy' >"${FIXTURE}/backing/docker-data.ext4"
+export FAKE_LOOP_DETACH_FAIL=1
+if run_entrypoint >"${FIXTURE}/stdout" 2>"${FIXTURE}/stderr"; then
+  echo "Docker startup continued without loop-device cleanup" >&2
+  exit 1
+fi
+grep -q 'could not mark the Docker loop device for automatic cleanup' "${FIXTURE}/stderr"
+grep -qx 'do-not-destroy' "${FIXTURE}/backing/docker-data.ext4"
+grep -q '^umount .*/data$' "${FAKE_LOG}"
 ! grep -q '^dockerd ' "${FAKE_LOG}"
 
 new_fixture driver-check

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.15" || "${CHART_APP_VERSION}" != "0.8.15" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.15, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.16" || "${CHART_APP_VERSION}" != "0.8.16" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.16, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.15' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.16' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"

--- a/tests/operator/kata/README.md
+++ b/tests/operator/kata/README.md
@@ -12,7 +12,7 @@ KATA_DIND_RUNTIME_CLASS=kata-vm-isolation \
 KATA_DIND_STORAGE_CLASS=managed-csi \
 KATA_DIND_DOCKER_SIZE=30Gi \
 KATA_DIND_TOLERATIONS_JSON='[{"key":"purpose","operator":"Equal","value":"nvt-agent","effect":"NoSchedule"}]' \
-KATA_DIND_RUNTIME_IMAGE=ghcr.io/mirkosekulic/nvt-agent-runtime:0.8.15-<release-sha> \
+KATA_DIND_RUNTIME_IMAGE=ghcr.io/mirkosekulic/nvt-agent-runtime:0.8.16-<release-sha> \
 bash tests/operator/kata/dind-overlay2-smoke.sh
 ```
 


### PR DESCRIPTION
## Summary

- replace the unsupported `losetup --autoclear` attach option with the portable attach, mount, then lazy-detach lifecycle
- verify the topmost mount is the expected ext4 loop device when `/var/lib/docker` overmounts an existing Kubernetes volume
- make the storage fixture reject the unsupported option and cover overmount selection, detach ordering, and detach failure
- bump the coordinated chart release to `0.8.16`

## Verification

- `bash -n dind/nvt-dind-entrypoint.sh dind/nvt-dind-ready.sh dind/test.sh`
- `bash dind/test.sh`
- `bash tests/operator/helm/test.sh`
- `helm lint charts/nvt`
- `bash .github/scripts/release-scripts-test.sh`
- `git diff --check`
- built `nvt-dind:loop-fix` and ran it privileged with the exact Kubernetes dockerd arguments; readiness passed, Docker reported `overlay2`, `/var/lib/docker` resolved to `/dev/loop0 ext4`, and util-linux reported `AUTOCLEAR=1`

The original staging failure was `losetup: unrecognized option: autoclear` in `0.8.15-28ced9b`.