### PR TITLE
fix: recreate missing Kata loop devices

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.16
-appVersion: "0.8.16"
+version: 0.8.17
+appVersion: "0.8.17"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.16`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.17`; otherwise the API server will prune or reject
 new AgentRun and schedule fields such as container capabilities, dedicated
 Docker storage size, broker grant preparations, profile workspace instructions,
 or workflow producer policies.
@@ -44,11 +44,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.16 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.17 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.16 --namespace nvt --create-namespace
+  --version 0.8.17 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/dind/nvt-dind-entrypoint.sh
+++ b/dind/nvt-dind-entrypoint.sh
@@ -61,7 +61,22 @@ fi
 chmod 0600 "${image}"
 
 ensure_loop_devices() {
-  if losetup -f >/dev/null 2>&1; then
+  if free_loop_device="$(losetup -f 2>/dev/null)"; then
+    loop_name="${free_loop_device##*/}"
+    loop_index="${loop_name#loop}"
+    case "${loop_name}" in
+      loop*) ;;
+      *) fail "invalid free loop device reported by the kernel" ;;
+    esac
+    case "${loop_index}" in
+      ''|*[!0-9]*) fail "invalid free loop device reported by the kernel" ;;
+    esac
+    if [ ! -e "${device_dir}/${loop_name}" ]; then
+      mkdir -p "${device_dir}"
+      mknod "${device_dir}/${loop_name}" b 7 "${loop_index}" ||
+        fail "could not recreate the discovered loop device inside the guest"
+    fi
+    losetup -f >/dev/null 2>&1 || fail "the discovered loop device is unusable inside the guest"
     return
   fi
   mkdir -p "${device_dir}"

--- a/dind/test.sh
+++ b/dind/test.sh
@@ -60,6 +60,9 @@ case "${1:-}" in
     fi
     ;;
   --find)
+    if [[ "${FAKE_REQUIRE_DISCOVERED_LOOP_NODE:-0}" == 1 && ! -f "${FAKE_DEVICE_DIR}/loop0" ]]; then
+      exit 1
+    fi
     : >"${FAKE_ASSOCIATED_MARKER}"
     printf '/dev/loop0\n'
     ;;
@@ -132,6 +135,7 @@ new_fixture() {
   export FAKE_DEVICE_DIR="${FIXTURE}/dev"
   : >"${FAKE_LOG}"
   unset FAKE_FINDMNT_FAIL FAKE_MKFS_FAIL FAKE_MOUNT_FAIL FAKE_FSCK_STATUS FAKE_FSCK_DELAY FAKE_NEED_LOOP_NODES FAKE_DOCKER_DRIVER
+  unset FAKE_REQUIRE_DISCOVERED_LOOP_NODE
   unset FAKE_LOOP_DETACH_FAIL
   unset FAKE_PERSISTENT_STORAGE
 }
@@ -211,6 +215,14 @@ detach_line="$(grep -n '^losetup -d /dev/loop0$' "${FAKE_LOG}" | cut -d: -f1)"
 [[ "${mount_line}" -lt "${detach_line}" ]]
 grep -q '^dockerd --host=tcp://127.0.0.1:2375 --tls=false --storage-driver=overlay2$' "${FAKE_LOG}"
 grep -qx overlay2 "${FIXTURE}/run/required-storage-driver"
+
+new_fixture missing-discovered-loop-node
+export FAKE_FS_TYPE=virtiofs
+export FAKE_REQUIRE_DISCOVERED_LOOP_NODE=1
+run_entrypoint
+grep -q '^mknod .*/loop0 b 7 0$' "${FAKE_LOG}"
+grep -q '^losetup --find --show .*/docker-data\.ext4$' "${FAKE_LOG}"
+grep -q '^dockerd .*--storage-driver=overlay2$' "${FAKE_LOG}"
 
 new_fixture existing-image
 export FAKE_FS_TYPE=virtiofs

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.16" || "${CHART_APP_VERSION}" != "0.8.16" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.16, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.17" || "${CHART_APP_VERSION}" != "0.8.17" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.17, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.16' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.17' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- recreate a kernel-discovered loop device node when Kata omits it from `/dev`
- preserve the existing fallback for guests without loop-control or loop devices
- add a regression test for successful discovery with a missing device node
- bump the coordinated chart release to 0.8.17

## Tests
- `bash dind/test.sh`
- `bash tests/operator/helm/test.sh`
- `sh -n dind/nvt-dind-entrypoint.sh`
- `bash -n dind/test.sh`
- `git diff --check`