### PR TITLE
fix: handle lost Kata loop markers

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.17
-appVersion: "0.8.17"
+version: 0.8.18
+appVersion: "0.8.18"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.17`; otherwise the API server will prune or reject
+of, upgrading to chart `0.8.18`; otherwise the API server will prune or reject
 new AgentRun and schedule fields such as container capabilities, dedicated
 Docker storage size, broker grant preparations, profile workspace instructions,
 or workflow producer policies.
@@ -44,11 +44,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.17 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.18 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.17 --namespace nvt --create-namespace
+  --version 0.8.18 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being

--- a/dind/nvt-dind-entrypoint.sh
+++ b/dind/nvt-dind-entrypoint.sh
@@ -62,6 +62,9 @@ chmod 0600 "${image}"
 
 ensure_loop_devices() {
   if free_loop_device="$(losetup -f 2>/dev/null)"; then
+    case "${free_loop_device}" in
+      *' (lost)') free_loop_device="${free_loop_device% (lost)}" ;;
+    esac
     loop_name="${free_loop_device##*/}"
     loop_index="${loop_name#loop}"
     case "${loop_name}" in

--- a/dind/test.sh
+++ b/dind/test.sh
@@ -52,7 +52,11 @@ case "${1:-}" in
     if [[ "${FAKE_NEED_LOOP_NODES:-0}" == 1 && ! -f "${FAKE_DEVICE_DIR}/loop-control" ]]; then
       exit 1
     fi
-    printf '/dev/loop0\n'
+    if [[ "${FAKE_REPORT_LOST_LOOP:-0}" == 1 ]]; then
+      printf '/dev/loop0 (lost)\n'
+    else
+      printf '/dev/loop0\n'
+    fi
     ;;
   -j)
     if [[ -f "${FAKE_ASSOCIATED_MARKER}" ]]; then
@@ -136,6 +140,7 @@ new_fixture() {
   : >"${FAKE_LOG}"
   unset FAKE_FINDMNT_FAIL FAKE_MKFS_FAIL FAKE_MOUNT_FAIL FAKE_FSCK_STATUS FAKE_FSCK_DELAY FAKE_NEED_LOOP_NODES FAKE_DOCKER_DRIVER
   unset FAKE_REQUIRE_DISCOVERED_LOOP_NODE
+  unset FAKE_REPORT_LOST_LOOP
   unset FAKE_LOOP_DETACH_FAIL
   unset FAKE_PERSISTENT_STORAGE
 }
@@ -219,6 +224,7 @@ grep -qx overlay2 "${FIXTURE}/run/required-storage-driver"
 new_fixture missing-discovered-loop-node
 export FAKE_FS_TYPE=virtiofs
 export FAKE_REQUIRE_DISCOVERED_LOOP_NODE=1
+export FAKE_REPORT_LOST_LOOP=1
 run_entrypoint
 grep -q '^mknod .*/loop0 b 7 0$' "${FAKE_LOG}"
 grep -q '^losetup --find --show .*/docker-data\.ext4$' "${FAKE_LOG}"

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.17" || "${CHART_APP_VERSION}" != "0.8.17" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.17, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.18" || "${CHART_APP_VERSION}" != "0.8.18" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.18, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.17' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.18' "${CHART}/README.md"
 grep -Fq 'kubectl apply --server-side -f -' "${CHART}/README.md"
 TEST_RELEASE_TAG="${CHART_VERSION}-943d5ba"
 WORKDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- normalize the explicit ` (lost)` suffix emitted by `losetup -f` when Kata exposes a loop device in sysfs without its `/dev` node
- retain strict validation of the discovered loop-device name before recreating it
- model the exact AKS Kata output in the regression fixture
- bump the coordinated chart release to 0.8.18

## Tests
- `bash dind/test.sh`
- `bash tests/operator/helm/test.sh`
- `sh -n dind/nvt-dind-entrypoint.sh`
- `bash -n dind/test.sh`
- `git diff --check`
- privileged AKS Kata smoke: `overlay2`, `/dev/loop0 ext4`, `AUTOCLEAR=1`