### PR TITLE
fix: parse colored Codex device codes

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.55
-appVersion: "0.8.55"
+version: 0.8.56
+appVersion: "0.8.56"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.55`; otherwise the API server may prune the
+of, upgrading to chart `0.8.56`; otherwise the API server may prune the
 operator-owned native guest routing status or reject new AgentRun and schedule
 fields such as container capabilities, required Docker networks, the Docker
 kernel-log device control, dedicated Docker storage size, broker grant
@@ -45,11 +45,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.55 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.56 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.55 --namespace nvt --create-namespace
+  --version 0.8.56 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being
@@ -421,7 +421,7 @@ may spell that selection explicitly as `execution: {kind: pod, driver:
 kubernetes}`. External drivers select one exact entry from
 `agentSchedule.executionClasses` by `kind`, logical `driver`, and `classRef`;
 the class's bounded opaque configuration is snapshotted into the AgentRun.
-Unknown/mismatched selections fail without Pod fallback. Chart `0.8.55`
+Unknown/mismatched selections fail without Pod fallback. Chart `0.8.56`
 reconciles external AgentRuns only through the exact matching registered host.
 Defaults remain Kubernetes-only and need no source access, cloud SDK, cloud
 credentials, or extra workload.

--- a/credentialportal/internal/portal/enrollment.go
+++ b/credentialportal/internal/portal/enrollment.go
@@ -47,6 +47,7 @@ var (
 
 	outputURLPattern  = regexp.MustCompile(`https://[^\s\x00-\x20\x7f]+`)
 	deviceCodePattern = regexp.MustCompile(`\b[A-Z0-9]{3,12}(?:-[A-Z0-9]{3,12})+\b`)
+	terminalCSI       = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
 )
 
 type EnrollmentStatus struct {
@@ -559,7 +560,9 @@ func codexDeviceAction(output []byte, urls []*url.URL) (providerAction, bool, er
 		if parsed.Hostname() != "auth.openai.com" || parsed.Path != "/codex/device" || parsed.RawQuery != "" {
 			continue
 		}
-		code := deviceCodePattern.FindString(string(output))
+		plainOutput := terminalCSI.ReplaceAll(output, nil)
+		code := deviceCodePattern.FindString(string(plainOutput))
+		clearBytes(plainOutput)
 		if code == "" {
 			return providerAction{}, false, nil
 		}

--- a/credentialportal/internal/portal/enrollment_test.go
+++ b/credentialportal/internal/portal/enrollment_test.go
@@ -202,6 +202,18 @@ func TestDefaultCommandAdaptersPinOfficialInvocationAndCredentialDiscovery(t *te
 	}
 }
 
+func TestCodexDeviceActionRecognizesANSIColoredHandoff(t *testing.T) {
+	output := []byte(
+		"Open \x1b[94mhttps://auth.openai.com/codex/device\x1b[0m and enter " +
+			"\x1b[94mABCD-EFGHI\x1b[0m",
+	)
+	action, found, err := defaultEnrollmentAdapters()[AdapterCodexOAuthFile].action(output)
+	if err != nil || !found || action.AuthorizationURL != fakeCodexDeviceURL ||
+		action.UserCode != "ABCD-EFGHI" || action.NeedsCode {
+		t.Fatal("ANSI-colored Codex handoff was not recognized")
+	}
+}
+
 //nolint:gocyclo // This conformance test covers initial Connect and unconditional Reconnect in one lifecycle.
 func TestCodexConnectBindsSlotPatchesValidatedFileAndCleansUp(t *testing.T) {
 	t.Setenv("NVT_CREDENTIAL_PORTAL_SESSION_SECRET", "portal-session-secret-canary")

--- a/tests/operator/helm/credential-portal-test.sh
+++ b/tests/operator/helm/credential-portal-test.sh
@@ -22,7 +22,7 @@ if grep -Eq 'verbs:.*(get|list|create|delete)' "${PORTAL_ROLE}"; then
 fi
 grep -Fq 'resourceNames:' "${RENDER}"
 grep -Fq -- '- "nvt-portal-seed"' "${RENDER}"
-grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.55"' "${RENDER}"
+grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.56"' "${RENDER}"
 grep -Fq -- '--credential-portal-url=/agents/credentials' "${RENDER}"
 grep -Fq 'readOnlyRootFilesystem: true' "${RENDER}"
 grep -Fq 'automountServiceAccountToken: false' "${RENDER}"

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.55" || "${CHART_APP_VERSION}" != "0.8.55" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.55, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.56" || "${CHART_APP_VERSION}" != "0.8.56" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.56, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.55' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.56' "${CHART}/README.md"
 grep -Fq 'ghcr.io/mirkosekulic/nvt-host-bundle:<appVersion>' "${CHART}/README.md"
 grep -Fq 'repository: https://ghcr.io/mirkosekulic/nvt-host-bundle' "${CHART}/README.md"
 grep -Fq 'digest: sha256:<64-hex>' "${CHART}/README.md"


### PR DESCRIPTION
## Summary
- strip ANSI CSI sequences before extracting Codex device codes
- pin the real colored CLI output shape with a regression test
- bump the coordinated chart to 0.8.56

## Tests
- `cd credentialportal && go test ./...`
- live PTY probe with Codex CLI 0.147.0
- `helm lint charts/nvt`
- `bash tests/operator/helm/credential-portal-test.sh`
- `git diff --check`