### PR TITLE
fix: clarify credential enrollment options

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.56
-appVersion: "0.8.56"
+version: 0.8.57
+appVersion: "0.8.57"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.56`; otherwise the API server may prune the
+of, upgrading to chart `0.8.57`; otherwise the API server may prune the
 operator-owned native guest routing status or reject new AgentRun and schedule
 fields such as container capabilities, required Docker networks, the Docker
 kernel-log device control, dedicated Docker storage size, broker grant
@@ -45,11 +45,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.56 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.57 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.56 --namespace nvt --create-namespace
+  --version 0.8.57 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being
@@ -421,7 +421,7 @@ may spell that selection explicitly as `execution: {kind: pod, driver:
 kubernetes}`. External drivers select one exact entry from
 `agentSchedule.executionClasses` by `kind`, logical `driver`, and `classRef`;
 the class's bounded opaque configuration is snapshotted into the AgentRun.
-Unknown/mismatched selections fail without Pod fallback. Chart `0.8.56`
+Unknown/mismatched selections fail without Pod fallback. Chart `0.8.57`
 reconciles external AgentRuns only through the exact matching registered host.
 Defaults remain Kubernetes-only and need no source access, cloud SDK, cloud
 credentials, or extra workload.

--- a/credentialportal/internal/portal/server.go
+++ b/credentialportal/internal/portal/server.go
@@ -372,7 +372,67 @@ var portalTemplate = template.Must(template.New("portal").Parse(`<!doctype html>
 <body><header><h1>Manage credentials</h1>{{if .PrincipalName}}<p>Signed in as {{.PrincipalName}}</p>{{end}}</header>
 <p>Connect or reconnect a configured provider account. The portal never reads or displays the current value and does not report provider health.</p>
 {{if gt (len .Slots) 1}}<label for="slot">Enrollment slot</label><select id="slot"><option value="">Select a slot</option>{{range .Slots}}<option value="{{.Name}}">{{.Label}}{{if eq .Adapter "codex-oauth-file"}} (experimental device login){{end}}</option>{{end}}</select>{{else if eq (len .Slots) 1}}<input id="slot" type="hidden" value="{{(index .Slots 0).Name}}"><h2>{{(index .Slots 0).Label}}{{if eq (index .Slots 0).Adapter "codex-oauth-file"}} (experimental device login){{end}}</h2>{{end}}
-<fieldset><legend>Provider login</legend><button id="connect" type="button">Connect / reconnect</button><div id="action" class="action hidden"><a id="provider" href="#" target="_blank" rel="noopener noreferrer">Continue with provider</a><p id="device"></p><div id="paste" class="hidden"><label for="code">Authorization code</label><br><input id="code" type="password" autocomplete="off"><button id="submit-code" type="button">Submit code</button></div><button id="cancel" type="button">Cancel</button></div><p class="status" id="status" role="status"></p></fieldset>
-{{if .RecoveryUpload}}<fieldset><legend>Administrator recovery upload</legend><p>This secondary recovery path replaces the configured seed with a credential file.</p><input id="credential" type="file" accept="application/json,.json"><br><label><input id="confirm" type="checkbox"> I understand this replaces the configured enrollment seed.</label><br><button id="upload" type="button">Upload recovery file</button><p class="status" id="upload-status" role="status"></p></fieldset>{{end}}
+<fieldset><legend>Option 1: Sign in with provider</legend><button id="connect" type="button">Connect / reconnect</button><div id="action" class="action hidden"><a id="provider" href="#" target="_blank" rel="noopener noreferrer">Continue with provider</a><p id="device"></p><div id="paste" class="hidden"><label for="code">Authorization code</label><br><input id="code" type="password" autocomplete="off"><button id="submit-code" type="button">Submit code</button></div><button id="cancel" type="button">Cancel</button></div><p class="status" id="status" role="status"></p></fieldset>
+{{if .RecoveryUpload}}<fieldset><legend>Option 2: Upload an existing credential file</legend><p>Use this instead of provider sign-in when you already have a valid credential file. Uploading replaces the credential currently stored for the selected account.</p><input id="credential" type="file" accept="application/json,.json"><br><label><input id="confirm" type="checkbox"> I understand this replaces the credential currently stored for this account.</label><br><button id="upload" type="button">Upload credential file</button><p class="status" id="upload-status" role="status"></p></fieldset>{{end}}
 <button id="logout" type="button">Log out</button>
-<script>const csrf={{.CSRF}},base={{.BasePath}},status=document.getElementById('status');let enrollment='';const headers={'X-CSRF-Token':csrf};async function poll(){if(!enrollment)return;const r=await fetch(base+'/enrollments/'+encodeURIComponent(enrollment),{credentials:'same-origin'});if(!r.ok){status.textContent='Enrollment failed.';return}const value=await r.json();if(value.status==='starting'){setTimeout(poll,500);return}if(value.status==='action-required'){document.getElementById('action').classList.remove('hidden');const link=document.getElementById('provider');link.href=value.authorizationURL;document.getElementById('device').textContent=value.userCode?'One-time code: '+value.userCode:'';document.getElementById('paste').classList.toggle('hidden',!value.needsCode);status.textContent='Complete sign-in with the provider.';setTimeout(poll,1000);return}document.getElementById('action').classList.add('hidden');status.textContent=value.status==='success'?'Credential seed updated. Broker import occurs independently.':'Enrollment failed.'}document.getElementById('connect').onclick=async()=>{const slot=document.getElementById('slot').value;if(!slot||!confirm('Continue and replace this slot after provider sign-in succeeds?'))return;status.textContent='Starting provider login…';const r=await fetch(base+'/slots/'+encodeURIComponent(slot)+'/connect',{method:'POST',credentials:'same-origin',headers:{...headers,'X-NVT-Confirm':'replace'}});if(!r.ok){status.textContent='Enrollment failed.';return}const value=await r.json();enrollment=value.id;poll()};document.getElementById('submit-code').onclick=async()=>{const input=document.getElementById('code'),code=input.value;input.value='';if(!enrollment||!code)return;const r=await fetch(base+'/enrollments/'+encodeURIComponent(enrollment)+'/code',{method:'POST',credentials:'same-origin',headers:{...headers,'Content-Type':'application/json'},body:JSON.stringify({code})});status.textContent=r.ok?'Completing provider login…':'Enrollment failed.'};document.getElementById('cancel').onclick=async()=>{if(enrollment)await fetch(base+'/enrollments/'+encodeURIComponent(enrollment),{method:'DELETE',credentials:'same-origin',headers});enrollment='';document.getElementById('action').classList.add('hidden');status.textContent='Enrollment cancelled.'};{{if .RecoveryUpload}}document.getElementById('upload').onclick=async()=>{const uploadStatus=document.getElementById('upload-status'),slot=document.getElementById('slot').value,file=document.getElementById('credential').files[0];if(!slot||!file||!document.getElementById('confirm').checked){uploadStatus.textContent='Select a slot and file, then confirm replacement.';return}uploadStatus.textContent='Uploading…';try{const r=await fetch(base+'/slots/'+encodeURIComponent(slot)+'/credential',{method:'PUT',credentials:'same-origin',headers:{...headers,'Content-Type':'application/json','X-NVT-Confirm':'replace'},body:file});uploadStatus.textContent=r.ok?'Credential seed updated. Broker import occurs independently.':'Enrollment failed.'}catch(_){uploadStatus.textContent='Enrollment failed.'}};{{end}}document.getElementById('logout').onclick=async()=>{await fetch(base+'/logout',{method:'POST',credentials:'same-origin',headers});location.href=base+'/'};</script></body></html>`))
+<script>
+const csrf={{.CSRF}},base={{.BasePath}},status=document.getElementById('status');
+let enrollment='';
+const headers={'X-CSRF-Token':csrf};
+function setText(element,value){if(element.textContent!==value)element.textContent=value}
+async function poll(){
+if(!enrollment)return;
+const r=await fetch(base+'/enrollments/'+encodeURIComponent(enrollment),{credentials:'same-origin'});
+if(!r.ok){setText(status,'Enrollment failed.');return}
+const value=await r.json();
+if(value.status==='starting'){setTimeout(poll,500);return}
+if(value.status==='action-required'){
+document.getElementById('action').classList.remove('hidden');
+const link=document.getElementById('provider');
+if(link.getAttribute('href')!==value.authorizationURL)link.setAttribute('href',value.authorizationURL);
+setText(document.getElementById('device'),value.userCode?'One-time code: '+value.userCode:'');
+document.getElementById('paste').classList.toggle('hidden',!value.needsCode);
+setText(status,'Complete sign-in with the provider.');
+setTimeout(poll,1000);
+return
+}
+document.getElementById('action').classList.add('hidden');
+setText(status,value.status==='success'?'Credential seed updated. Broker import occurs independently.':'Enrollment failed.')
+}
+document.getElementById('connect').onclick=async()=>{
+const slot=document.getElementById('slot').value;
+if(!slot||!confirm('Continue and replace this slot after provider sign-in succeeds?'))return;
+setText(status,'Starting provider login…');
+const r=await fetch(base+'/slots/'+encodeURIComponent(slot)+'/connect',{method:'POST',credentials:'same-origin',headers:{...headers,'X-NVT-Confirm':'replace'}});
+if(!r.ok){setText(status,'Enrollment failed.');return}
+const value=await r.json();
+enrollment=value.id;
+poll()
+};
+document.getElementById('submit-code').onclick=async()=>{
+const input=document.getElementById('code'),code=input.value;
+input.value='';
+if(!enrollment||!code)return;
+const r=await fetch(base+'/enrollments/'+encodeURIComponent(enrollment)+'/code',{method:'POST',credentials:'same-origin',headers:{...headers,'Content-Type':'application/json'},body:JSON.stringify({code})});
+setText(status,r.ok?'Completing provider login…':'Enrollment failed.')
+};
+document.getElementById('cancel').onclick=async()=>{
+if(enrollment)await fetch(base+'/enrollments/'+encodeURIComponent(enrollment),{method:'DELETE',credentials:'same-origin',headers});
+enrollment='';
+document.getElementById('action').classList.add('hidden');
+setText(status,'Enrollment cancelled.')
+};
+{{if .RecoveryUpload}}document.getElementById('upload').onclick=async()=>{
+const uploadStatus=document.getElementById('upload-status'),slot=document.getElementById('slot').value,file=document.getElementById('credential').files[0];
+if(!slot||!file||!document.getElementById('confirm').checked){setText(uploadStatus,'Select a slot and file, then confirm replacement.');return}
+setText(uploadStatus,'Uploading…');
+try{
+const r=await fetch(base+'/slots/'+encodeURIComponent(slot)+'/credential',{method:'PUT',credentials:'same-origin',headers:{...headers,'Content-Type':'application/json','X-NVT-Confirm':'replace'},body:file});
+setText(uploadStatus,r.ok?'Credential seed updated. Broker import occurs independently.':'Enrollment failed.')
+}catch(_){setText(uploadStatus,'Enrollment failed.')}
+};{{end}}
+document.getElementById('logout').onclick=async()=>{
+await fetch(base+'/logout',{method:'POST',credentials:'same-origin',headers});
+location.href=base+'/'
+};
+</script></body></html>`))

--- a/credentialportal/internal/portal/server_test.go
+++ b/credentialportal/internal/portal/server_test.go
@@ -231,6 +231,11 @@ func TestDashboardListsOnlyOwnedSlotsAndNeverExistingValueOrHealth(t *testing.T)
 		!strings.Contains(response.Header().Get("Content-Security-Policy"), "connect-src 'self'") ||
 		!strings.Contains(body, `const csrf="`+csrf+`",base="/agents/credentials"`) ||
 		strings.Contains(body, `base="\"/agents/credentials\""`) ||
+		!strings.Contains(body, "Option 1: Sign in with provider") ||
+		!strings.Contains(body, "Option 2: Upload an existing credential file") ||
+		!strings.Contains(body, "Use this instead of provider sign-in") ||
+		!strings.Contains(body, "function setText(element,value)") ||
+		!strings.Contains(body, "setText(document.getElementById('device')") ||
 		!strings.Contains(body, "Connect / reconnect") ||
 		!strings.Contains(body, "experimental device login") ||
 		strings.Contains(body, "Bob") ||
@@ -273,7 +278,7 @@ func TestRecoveryUploadIsDisabledAndHiddenUnlessExplicitlyEnabled(t *testing.T) 
 	)
 	server.cfg.RecoveryUpload.Enabled = false
 	dashboard := request(t, server, cookie, "", http.MethodGet, "/agents/credentials/", "", nil)
-	if strings.Contains(dashboard.Body.String(), "Administrator recovery upload") ||
+	if strings.Contains(dashboard.Body.String(), "Option 2: Upload an existing credential file") ||
 		strings.Contains(dashboard.Body.String(), `id="credential"`) {
 		t.Fatal("disabled recovery upload appeared on the dashboard")
 	}

--- a/tests/operator/helm/credential-portal-test.sh
+++ b/tests/operator/helm/credential-portal-test.sh
@@ -22,7 +22,7 @@ if grep -Eq 'verbs:.*(get|list|create|delete)' "${PORTAL_ROLE}"; then
 fi
 grep -Fq 'resourceNames:' "${RENDER}"
 grep -Fq -- '- "nvt-portal-seed"' "${RENDER}"
-grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.56"' "${RENDER}"
+grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.57"' "${RENDER}"
 grep -Fq -- '--credential-portal-url=/agents/credentials' "${RENDER}"
 grep -Fq 'readOnlyRootFilesystem: true' "${RENDER}"
 grep -Fq 'automountServiceAccountToken: false' "${RENDER}"

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.56" || "${CHART_APP_VERSION}" != "0.8.56" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.56, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.57" || "${CHART_APP_VERSION}" != "0.8.57" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.57, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.56' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.57' "${CHART}/README.md"
 grep -Fq 'ghcr.io/mirkosekulic/nvt-host-bundle:<appVersion>' "${CHART}/README.md"
 grep -Fq 'repository: https://ghcr.io/mirkosekulic/nvt-host-bundle' "${CHART}/README.md"
 grep -Fq 'digest: sha256:<64-hex>' "${CHART}/README.md"


### PR DESCRIPTION
## Summary
- preserve device-code text nodes while enrollment polling continues so browser selection remains stable
- present provider sign-in and credential-file upload as two explicit alternatives
- replace internal seed/recovery terminology with account-oriented UI copy
- bump the coordinated chart to 0.8.57

## Tests
- `cd credentialportal && go test ./...`
- `helm lint charts/nvt`
- `bash tests/operator/helm/credential-portal-test.sh`
- `git diff --check`