### PR TITLE
feat(operator): add per-principal parallelism

### DIFF
--- a/charts/nvt/Chart.yaml
+++ b/charts/nvt/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nvt
 description: Core nvt Kubernetes stack
 type: application
-version: 0.8.63
-appVersion: "0.8.63"
+version: 0.8.64
+appVersion: "0.8.64"

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -24,7 +24,7 @@ chart values.
 Helm installs files from a chart's `crds/` directory on first install but does
 not upgrade them during a normal `helm upgrade`. Existing installations must
 therefore update both the AgentRun and AgentSchedule CRDs before, or as part
-of, upgrading to chart `0.8.63`; otherwise the API server may prune the
+of, upgrading to chart `0.8.64`; otherwise the API server may prune the
 operator-owned native guest routing status or reject new AgentRun and schedule
 fields such as container capabilities, required Docker networks, the Docker
 kernel-log device control, dedicated Docker storage size, broker grant
@@ -45,11 +45,11 @@ For the Helm CLI, apply the CRDs from the same immutable chart version before
 upgrading the release:
 
 ```sh
-helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.63 \
+helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.64 \
   | kubectl apply --server-side -f -
 
 helm upgrade --install nvt oci://ghcr.io/mirkosekulic/helm/nvt \
-  --version 0.8.63 --namespace nvt --create-namespace
+  --version 0.8.64 --namespace nvt --create-namespace
 ```
 
 Do not apply CRDs from a different chart version than the release being
@@ -461,6 +461,12 @@ admission. Empty values
 preserve legacy full-`AgentRun` admission. Profiled admission requires a
 projected ServiceAccount token with audience `nvt-operator`; see the
 [AgentSchedule contract](../../operator/docs/agentschedule.md).
+
+`agentSchedule.maxParallelism` is always the schedule-wide ceiling. Optional
+`agentSchedule.principalParallelism` adds a positive default per exact
+`issuer` + `subject` and up to 256 exact-principal overrides. Omit the object to
+preserve global-only admission. Overrides never bypass the global ceiling and
+do not use mutable display names or provider-specific usernames.
 
 Dynamic principal-owned schedule resolution is disabled by default. Enable
 `operator.principalAccounts` and map public broker credential templates only to

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -467,6 +467,9 @@ projected ServiceAccount token with audience `nvt-operator`; see the
 `issuer` + `subject` and up to 256 exact-principal overrides. Omit the object to
 preserve global-only admission. Overrides never bypass the global ceiling and
 do not use mutable display names or provider-specific usernames.
+The chart fixes the operator at one replica and uses `Recreate` unconditionally
+because schedule admission locking is process-local. An upgrade can briefly
+pause admission, but old and new operator binaries never admit concurrently.
 
 Dynamic principal-owned schedule resolution is disabled by default. Enable
 `operator.principalAccounts` and map public broker credential templates only to

--- a/charts/nvt/crds/nvt.dev_agentschedules.yaml
+++ b/charts/nvt/crds/nvt.dev_agentschedules.yaml
@@ -38,12 +38,48 @@ spec:
                   message: dynamic principal credential selection requires producerPolicies
                 - rule: "!has(self.principalCredentialSelection) || !self.principalCredentialSelection.enabled || self.producerPolicies.all(p, has(p.allowedPrincipalIssuers) && size(p.allowedPrincipalIssuers) > 0)"
                   message: dynamic principal credential selection requires issuer eligibility on every producer policy
+                - rule: "!has(self.principalParallelism) || (has(self.profiles) && size(self.profiles) > 0)"
+                  message: principalParallelism requires a profiled schedule
               properties:
                 suspend:
                   type: boolean
                 maxParallelism:
                   type: integer
                   minimum: 0
+                principalParallelism:
+                  description: Per-principal active-run capacity with exact issuer and subject overrides.
+                  type: object
+                  required:
+                    - defaultMaxParallelism
+                  properties:
+                    defaultMaxParallelism:
+                      type: integer
+                      minimum: 1
+                    overrides:
+                      type: array
+                      maxItems: 256
+                      x-kubernetes-list-type: map
+                      x-kubernetes-list-map-keys:
+                        - issuer
+                        - subject
+                      items:
+                        type: object
+                        required:
+                          - issuer
+                          - subject
+                          - maxParallelism
+                        properties:
+                          issuer:
+                            type: string
+                            minLength: 1
+                            maxLength: 2048
+                          subject:
+                            type: string
+                            minLength: 1
+                            maxLength: 512
+                          maxParallelism:
+                            type: integer
+                            minimum: 1
                 allowedProducers:
                   type: array
                   minItems: 1

--- a/charts/nvt/templates/agentschedule.yaml
+++ b/charts/nvt/templates/agentschedule.yaml
@@ -53,6 +53,10 @@ metadata:
     {{- include "nvt.labels" . | nindent 4 }}
 spec:
   maxParallelism: {{ .Values.agentSchedule.maxParallelism }}
+  {{- with .Values.agentSchedule.principalParallelism }}
+  principalParallelism:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   suspend: {{ .Values.agentSchedule.suspend }}
   {{- with .Values.agentSchedule.template }}
   {{- $template := deepCopy . }}

--- a/charts/nvt/templates/operator-deployment.yaml
+++ b/charts/nvt/templates/operator-deployment.yaml
@@ -83,10 +83,10 @@ metadata:
     {{- include "nvt.operatorLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.operator.replicas }}
-  {{- if .Values.nativeEgressRelay.enabled }}
+  # Schedule admission locking is process-local. Recreate prevents old and
+  # new operator binaries from admitting concurrently during an upgrade.
   strategy:
     type: Recreate
-  {{- end }}
   selector:
     matchLabels:
       {{- include "nvt.operatorSelectorLabels" . | nindent 6 }}

--- a/charts/nvt/values.yaml
+++ b/charts/nvt/values.yaml
@@ -476,6 +476,9 @@ agentSchedule:
   enabled: true
   name: default
   maxParallelism: 1
+  # Optional active-run limit applied independently to every exact principal
+  # issuer+subject pair, with bounded administrator-owned exceptions.
+  principalParallelism: {}
   suspend: false
   # Empty profile fields preserve the legacy full-AgentRun admission contract.
   # See operator/docs/agentschedule.md for a complete profiled example.

--- a/operator/api/v1alpha1/agentschedule_types.go
+++ b/operator/api/v1alpha1/agentschedule_types.go
@@ -20,9 +20,12 @@ type AgentSchedule struct {
 
 // AgentScheduleSpec defines generic scheduling controls.
 type AgentScheduleSpec struct {
-	Suspend        bool                   `json:"suspend,omitempty"`
-	MaxParallelism int32                  `json:"maxParallelism,omitempty"`
-	Template       *AgentScheduleTemplate `json:"template,omitempty"`
+	Suspend        bool  `json:"suspend,omitempty"`
+	MaxParallelism int32 `json:"maxParallelism,omitempty"`
+	// PrincipalParallelism optionally bounds active runs independently for each
+	// exact immutable issuer+subject identity.
+	PrincipalParallelism *AgentSchedulePrincipalParallelism `json:"principalParallelism,omitempty"`
+	Template             *AgentScheduleTemplate             `json:"template,omitempty"`
 	// ExecutionClasses are administrator-owned, bounded driver configurations.
 	// +listType=map
 	// +listMapKey=name
@@ -135,6 +138,32 @@ type AgentScheduleProducerPolicy struct {
 	AllowedPrincipalIssuers []string `json:"allowedPrincipalIssuers,omitempty"`
 }
 
+// AgentSchedulePrincipalParallelism defines a default per-principal capacity
+// and bounded exact-principal exceptions. Global MaxParallelism remains the
+// absolute schedule ceiling.
+type AgentSchedulePrincipalParallelism struct {
+	// +kubebuilder:validation:Minimum=1
+	DefaultMaxParallelism int32 `json:"defaultMaxParallelism"`
+	// +kubebuilder:validation:MaxItems=256
+	// +listType=map
+	// +listMapKey=issuer
+	// +listMapKey=subject
+	Overrides []AgentSchedulePrincipalParallelismOverride `json:"overrides,omitempty"`
+}
+
+// AgentSchedulePrincipalParallelismOverride replaces the default capacity for
+// one exact immutable principal.
+type AgentSchedulePrincipalParallelismOverride struct {
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=2048
+	Issuer string `json:"issuer"`
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	Subject string `json:"subject"`
+	// +kubebuilder:validation:Minimum=1
+	MaxParallelism int32 `json:"maxParallelism"`
+}
+
 // AgentSchedulePrincipalCredentialSelection maps broker-owned public
 // credential templates to administrator-owned execution profiles.
 type AgentSchedulePrincipalCredentialSelection struct {
@@ -236,6 +265,9 @@ func (in *AgentScheduleSpec) DeepCopy() *AgentScheduleSpec {
 	if in.Template != nil {
 		out.Template = in.Template.DeepCopy()
 	}
+	if in.PrincipalParallelism != nil {
+		out.PrincipalParallelism = in.PrincipalParallelism.DeepCopy()
+	}
 	if in.ExecutionClasses != nil {
 		out.ExecutionClasses = make([]AgentScheduleExecutionClass, len(in.ExecutionClasses))
 		for i := range in.ExecutionClasses {
@@ -272,6 +304,19 @@ func (in *AgentScheduleSpec) DeepCopy() *AgentScheduleSpec {
 		}
 	}
 	out.AllowedProducers = append([]string(nil), in.AllowedProducers...)
+	return out
+}
+
+// DeepCopy returns a copy of principal parallelism configuration.
+func (in *AgentSchedulePrincipalParallelism) DeepCopy() *AgentSchedulePrincipalParallelism {
+	if in == nil {
+		return nil
+	}
+	out := new(AgentSchedulePrincipalParallelism)
+	*out = *in
+	if in.Overrides != nil {
+		out.Overrides = append([]AgentSchedulePrincipalParallelismOverride{}, in.Overrides...)
+	}
 	return out
 }
 

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -191,7 +191,9 @@ func operatorHTTPHandler(mgr manager.Manager, accounts principalaccounts.Resolve
 	mux.Handle("/v1/agentruns/", controller.NewAgentRunCallbackHandler(mgr.GetClient()))
 	mux.Handle(
 		"/v1/schedules/",
-		controller.NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(mgr.GetClient(), mgr.GetScheme(), accounts),
+		controller.NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(
+			mgr.GetClient(), mgr.GetAPIReader(), mgr.GetScheme(), accounts,
+		),
 	)
 	if coordinator, ok := accounts.(interface {
 		principalaccounts.Coordinator

--- a/operator/config/crd/bases/nvt.dev_agentschedules.yaml
+++ b/operator/config/crd/bases/nvt.dev_agentschedules.yaml
@@ -38,12 +38,48 @@ spec:
                   message: dynamic principal credential selection requires producerPolicies
                 - rule: "!has(self.principalCredentialSelection) || !self.principalCredentialSelection.enabled || self.producerPolicies.all(p, has(p.allowedPrincipalIssuers) && size(p.allowedPrincipalIssuers) > 0)"
                   message: dynamic principal credential selection requires issuer eligibility on every producer policy
+                - rule: "!has(self.principalParallelism) || (has(self.profiles) && size(self.profiles) > 0)"
+                  message: principalParallelism requires a profiled schedule
               properties:
                 suspend:
                   type: boolean
                 maxParallelism:
                   type: integer
                   minimum: 0
+                principalParallelism:
+                  description: Per-principal active-run capacity with exact issuer and subject overrides.
+                  type: object
+                  required:
+                    - defaultMaxParallelism
+                  properties:
+                    defaultMaxParallelism:
+                      type: integer
+                      minimum: 1
+                    overrides:
+                      type: array
+                      maxItems: 256
+                      x-kubernetes-list-type: map
+                      x-kubernetes-list-map-keys:
+                        - issuer
+                        - subject
+                      items:
+                        type: object
+                        required:
+                          - issuer
+                          - subject
+                          - maxParallelism
+                        properties:
+                          issuer:
+                            type: string
+                            minLength: 1
+                            maxLength: 2048
+                          subject:
+                            type: string
+                            minLength: 1
+                            maxLength: 512
+                          maxParallelism:
+                            type: integer
+                            minimum: 1
                 allowedProducers:
                   type: array
                   minItems: 1

--- a/operator/docs/agentschedule.md
+++ b/operator/docs/agentschedule.md
@@ -372,11 +372,31 @@ Kubernetes producer workload identity, not an end-user identity.
 
 ## Generic admission controls
 
-Both modes enforce suspend, max parallelism, and retained work-ID
-deduplication. The parallelism default is `1`. Admissions are serialized per
-schedule within the active operator process. The operator forces namespace and
-ownership and records work/gateway metadata; `work.repository` is stored in
-`nvt.dev/work-repository` when present.
+Both modes enforce suspend, global max parallelism, and retained work-ID
+deduplication. The global parallelism default is `1`. Profiled schedules may
+also set `principalParallelism.defaultMaxParallelism` to limit active runs
+independently for every exact immutable `issuer` + `subject` pair. Up to 256
+administrator-owned `overrides` may replace that default for exact principals:
+
+```yaml
+maxParallelism: 20
+principalParallelism:
+  defaultMaxParallelism: 2
+  overrides:
+    - issuer: https://identity.example/tenant
+      subject: immutable-user-42
+      maxParallelism: 5
+```
+
+The global value remains the absolute ceiling. Omitting `principalParallelism`
+preserves global-only behavior. Requests must carry a canonical principal when
+the object is configured. Display names, selected profiles, credential
+providers, and producer identities do not affect the capacity key. Duplicate
+override keys are invalid, and terminal runs release both limits.
+
+Admissions are serialized per schedule within the active operator process.
+The operator forces namespace and ownership and records work/gateway metadata;
+`work.repository` is stored in `nvt.dev/work-repository` when present.
 
 Responses use `201` for creation, `202` for suspended/duplicate work, `429` for
 capacity, `401` for failed profiled authentication, `403` for unauthorized

--- a/operator/docs/agentschedule.md
+++ b/operator/docs/agentschedule.md
@@ -395,6 +395,9 @@ providers, and producer identities do not affect the capacity key. Duplicate
 override keys are invalid, and terminal runs release both limits.
 
 Admissions are serialized per schedule within the active operator process.
+The chart therefore requires one operator replica and an unconditional
+`Recreate` Deployment strategy. Upgrades may briefly pause admission, but an
+old and new binary cannot overlap and make independent capacity decisions.
 The operator forces namespace and ownership and records work/gateway metadata;
 `work.repository` is stored in `nvt.dev/work-repository` when present.
 

--- a/operator/examples/agentschedule-profiled.yaml
+++ b/operator/examples/agentschedule-profiled.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: nvt
 spec:
   maxParallelism: 5
+  principalParallelism:
+    defaultMaxParallelism: 2
+    overrides:
+      - issuer: https://github.com
+        subject: "23359247"
+        maxParallelism: 4
   template:
     image: nvt-agent-runtime:latest
     runtimeClassName: kata-vm-isolation

--- a/operator/internal/controller/agentschedule_admission.go
+++ b/operator/internal/controller/agentschedule_admission.go
@@ -25,10 +25,16 @@ import (
 	"github.com/mirkoSekulic/nvt-agent/operator/principalaccounts"
 )
 
-const scheduleAdmissionPathPrefix = "/v1/schedules/"
+const (
+	scheduleAdmissionPathPrefix                = "/v1/schedules/"
+	invalidExecutionProfileConfigurationReason = "invalid-execution-profile-configuration"
+	maxParallelismReachedReason                = "max-parallelism-reached"
+	principalMaxParallelismReachedReason       = "principal-max-parallelism-reached"
+)
 
 type agentScheduleAdmissionHandler struct {
 	client                client.Client
+	reader                client.Reader
 	scheme                *runtime.Scheme
 	authenticator         ScheduleProducerAuthenticator
 	profileResolver       ExecutionProfileResolver
@@ -76,13 +82,14 @@ type scheduleAdmissionAgentRun struct {
 
 // NewAgentScheduleAdmissionHandler returns the cluster-internal schedule admission handler.
 func NewAgentScheduleAdmissionHandler(k8sClient client.Client, scheme *runtime.Scheme) http.Handler {
-	return NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(k8sClient, scheme, nil)
+	return NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(k8sClient, k8sClient, scheme, nil)
 }
 
 // NewAgentScheduleAdmissionHandlerWithPrincipalAccounts adds the optional
 // trusted dynamic principal-account resolver without changing static admission.
 func NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(
 	k8sClient client.Client,
+	reader client.Reader,
 	scheme *runtime.Scheme,
 	accounts principalaccounts.Resolver,
 ) http.Handler {
@@ -92,6 +99,7 @@ func NewAgentScheduleAdmissionHandlerWithPrincipalAccounts(
 	}
 	return &agentScheduleAdmissionHandler{
 		client:                k8sClient,
+		reader:                reader,
 		scheme:                scheme,
 		authenticator:         NewKubernetesTokenReviewProducerAuthenticator(k8sClient),
 		profileResolver:       StaticExecutionProfileResolver{},
@@ -139,9 +147,13 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	unlock := h.lockScheduleAdmission(namespace, name)
 	defer unlock()
 
+	reader := h.reader
+	if reader == nil {
+		reader = h.client
+	}
 	schedule := &nvtv1alpha1.AgentSchedule{}
-	if err := h.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, schedule); err != nil {
-		if apierrors.IsNotFound(err) {
+	if getErr := reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, schedule); getErr != nil {
+		if apierrors.IsNotFound(getErr) {
 			http.Error(response, "AgentSchedule not found\n", http.StatusNotFound)
 			return
 		}
@@ -185,9 +197,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 			})
 			return
 		case err != nil:
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -215,18 +227,52 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 		})
 		return
 	}
+	principalLimit := int32(0)
+	if schedule.Spec.PrincipalParallelism != nil {
+		if !profiled {
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
+			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
+			})
+			return
+		}
+		var limitErr error
+		principalLimit, limitErr = principalParallelismLimit(schedule.Spec.PrincipalParallelism, principal)
+		if errors.Is(limitErr, errPrincipalRequired) {
+			h.recordRejected(ctx, schedule, "principal-required")
+			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
+				Scheduled: false, Reason: "principal-required",
+			})
+			return
+		}
+		if limitErr != nil {
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
+			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
+			})
+			return
+		}
+	}
 
-	runs, err := ListScheduledRuns(ctx, h.client, schedule)
+	runs, err := ListScheduledRuns(ctx, reader, schedule)
 	if err != nil {
 		http.Error(response, "list scheduled AgentRuns failed\n", http.StatusInternalServerError)
 		return
 	}
 	activeRuns := countActiveScheduledRuns(runs)
 	if activeRuns >= EffectiveMaxParallelism(schedule) {
-		h.recordRejected(ctx, schedule, "max-parallelism-reached")
+		h.recordRejected(ctx, schedule, maxParallelismReachedReason)
 		writeScheduleAdmissionJSON(response, http.StatusTooManyRequests, scheduleAdmissionResponse{
 			Scheduled: false,
-			Reason:    "max-parallelism-reached",
+			Reason:    maxParallelismReachedReason,
+		})
+		return
+	}
+	if principalLimit > 0 && countActiveScheduledRunsForPrincipal(runs, principal) >= principalLimit {
+		h.recordRejected(ctx, schedule, principalMaxParallelismReachedReason)
+		writeScheduleAdmissionJSON(response, http.StatusTooManyRequests, scheduleAdmissionResponse{
+			Scheduled: false,
+			Reason:    principalMaxParallelismReachedReason,
 		})
 		return
 	}
@@ -323,9 +369,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 				})
 				return
 			}
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -335,9 +381,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 		}
 		profiledRun, buildErr := buildProfiledAgentRun(schedule, resolved, producer, principal, resolvedWorkflow, prompt)
 		if buildErr != nil {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -360,9 +406,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	ApplyDefaultEgressMode(&run)
 	if err := ValidateAgentRunExecution(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -375,9 +421,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if err := ValidateAgentRunRuntimeCapabilities(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -390,9 +436,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if err := ValidateAgentRunDockerNetworks(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -405,9 +451,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if err := ValidateAgentRunEgressMode(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -421,9 +467,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if err := ValidateAgentRunWorkspace(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -437,9 +483,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if err := ValidateAgentRunWorkspaceInstructions(&run); err != nil {
 		if profiled {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -462,9 +508,9 @@ func (h *agentScheduleAdmissionHandler) ServeHTTP(response http.ResponseWriter, 
 	}
 	if profiled {
 		if err := injectProfiledLifecycleCallback(&run); err != nil {
-			h.recordRejected(ctx, schedule, "invalid-execution-profile-configuration")
+			h.recordRejected(ctx, schedule, invalidExecutionProfileConfigurationReason)
 			writeScheduleAdmissionJSON(response, http.StatusBadRequest, scheduleAdmissionResponse{
-				Scheduled: false, Reason: "invalid-execution-profile-configuration",
+				Scheduled: false, Reason: invalidExecutionProfileConfigurationReason,
 			})
 			return
 		}
@@ -634,6 +680,71 @@ func countActiveScheduledRuns(runs *nvtv1alpha1.AgentRunList) int32 {
 		}
 	}
 	return active
+}
+
+func countActiveScheduledRunsForPrincipal(
+	runs *nvtv1alpha1.AgentRunList,
+	principal *nvtv1alpha1.AgentRunPrincipal,
+) int32 {
+	if !validPrincipalIdentity(principal) {
+		return 0
+	}
+	var active int32
+	for i := range runs.Items {
+		run := &runs.Items[i]
+		if !IsActiveScheduledRun(run) || run.Spec.ProfileProvenance == nil ||
+			run.Spec.ProfileProvenance.Principal == nil {
+			continue
+		}
+		owner := run.Spec.ProfileProvenance.Principal
+		if owner.Issuer == principal.Issuer && owner.Subject == principal.Subject {
+			active++
+		}
+	}
+	return active
+}
+
+func validPrincipalIdentity(principal *nvtv1alpha1.AgentRunPrincipal) bool {
+	return principal != nil && canonicalPrincipalIssuer(principal.Issuer) && validPrincipalSubject(principal.Subject)
+}
+
+var errPrincipalRequired = errors.New("principal required")
+
+func principalParallelismLimit(
+	configuration *nvtv1alpha1.AgentSchedulePrincipalParallelism,
+	principal *nvtv1alpha1.AgentRunPrincipal,
+) (int32, error) {
+	if configuration == nil {
+		return 0, nil
+	}
+	if configuration.DefaultMaxParallelism < 1 || len(configuration.Overrides) > 256 {
+		return 0, errInvalidExecutionProfileConfiguration
+	}
+
+	type principalKey struct {
+		issuer  string
+		subject string
+	}
+	overrides := make(map[principalKey]int32, len(configuration.Overrides))
+	for _, override := range configuration.Overrides {
+		if !canonicalPrincipalIssuer(override.Issuer) || !validPrincipalSubject(override.Subject) ||
+			override.MaxParallelism < 1 {
+			return 0, errInvalidExecutionProfileConfiguration
+		}
+		key := principalKey{issuer: override.Issuer, subject: override.Subject}
+		if _, duplicate := overrides[key]; duplicate {
+			return 0, errInvalidExecutionProfileConfiguration
+		}
+		overrides[key] = override.MaxParallelism
+	}
+
+	if !validPrincipalIdentity(principal) {
+		return 0, errPrincipalRequired
+	}
+	if limit, overridden := overrides[principalKey{issuer: principal.Issuer, subject: principal.Subject}]; overridden {
+		return limit, nil
+	}
+	return configuration.DefaultMaxParallelism, nil
 }
 
 type scheduleAdmissionLocks struct {

--- a/operator/internal/controller/agentschedule_controller_test.go
+++ b/operator/internal/controller/agentschedule_controller_test.go
@@ -26,6 +26,8 @@ import (
 	nvtv1alpha1 "github.com/mirkoSekulic/nvt-agent/operator/api/v1alpha1"
 )
 
+const testPrincipalSubject = "subject"
+
 func TestAgentScheduleAPIDeepCopyAndScheme(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := nvtv1alpha1.AddToScheme(scheme); err != nil {
@@ -33,6 +35,12 @@ func TestAgentScheduleAPIDeepCopyAndScheme(t *testing.T) {
 	}
 
 	schedule := testAgentSchedule()
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{
+		DefaultMaxParallelism: 1,
+		Overrides: []nvtv1alpha1.AgentSchedulePrincipalParallelismOverride{{
+			Issuer: "https://identity.example", Subject: "principal", MaxParallelism: 2,
+		}},
+	}
 	now := metav1.Now()
 	schedule.Status.LastAcceptedAt = &now
 	copyObject := schedule.DeepCopyObject()
@@ -43,6 +51,10 @@ func TestAgentScheduleAPIDeepCopyAndScheme(t *testing.T) {
 	copied.Status.LastAcceptedAt.Time = copied.Status.LastAcceptedAt.Time.Add(1)
 	if schedule.Status.LastAcceptedAt.Equal(copied.Status.LastAcceptedAt) {
 		t.Fatal("expected status timestamp to be deep-copied")
+	}
+	copied.Spec.PrincipalParallelism.Overrides[0].MaxParallelism = 9
+	if schedule.Spec.PrincipalParallelism.Overrides[0].MaxParallelism != 2 {
+		t.Fatal("expected principal parallelism overrides to be deep-copied")
 	}
 	workspaceSize := resource.MustParse("5Gi")
 	dockerSize := resource.MustParse("20Gi")
@@ -120,6 +132,17 @@ func TestAgentScheduleCRDSchemaIncludesSpecAndStatus(t *testing.T) {
 	).(map[string]any)
 	if crdPath(t, properties, "maxParallelism", "type") != "integer" {
 		t.Fatalf("expected spec.maxParallelism integer schema, got %#v", properties["maxParallelism"])
+	}
+	principalParallelismValue := crdPath(t, properties, "principalParallelism")
+	principalParallelism, ok := principalParallelismValue.(map[string]any)
+	if !ok {
+		t.Fatalf("expected principalParallelism object schema, got %#v", principalParallelismValue)
+	}
+	if fmt.Sprint(crdPath(t, principalParallelism, "properties", "defaultMaxParallelism", "minimum")) != "1" ||
+		fmt.Sprint(crdPath(t, principalParallelism, "properties", "overrides", "maxItems")) != "256" ||
+		!reflect.DeepEqual(crdPath(t, principalParallelism, "properties", "overrides", "x-kubernetes-list-map-keys"),
+			[]any{"issuer", testPrincipalSubject}) {
+		t.Fatalf("expected bounded exact-key principal parallelism schema, got %#v", principalParallelism)
 	}
 	if crdPath(t, properties, "profiles", "items", "properties", "agentRuntimeConfig", "x-kubernetes-preserve-unknown-fields") != true {
 		t.Fatalf("expected profile runtime config preservation schema, got %#v", properties["profiles"])
@@ -351,6 +374,64 @@ func TestScheduleAdmissionMaxParallelismCreatesNoRun(t *testing.T) {
 		t.Fatalf("unexpected response: %#v", decoded)
 	}
 	assertScheduledRunCount(t, k8sClient, schedule, 1)
+}
+
+func TestScheduleAdmissionUsesAuthoritativeReaderForCapacity(t *testing.T) {
+	schedule := testAgentSchedule()
+	schedule.Spec.MaxParallelism = 1
+	scheme := testScheme(t)
+	writerScheduleObject := schedule.DeepCopyObject()
+	writerSchedule, ok := writerScheduleObject.(*nvtv1alpha1.AgentSchedule)
+	if !ok {
+		t.Fatalf("copy schedule for writer: %T", writerScheduleObject)
+	}
+	readerScheduleObject := schedule.DeepCopyObject()
+	readerSchedule, ok := readerScheduleObject.(*nvtv1alpha1.AgentSchedule)
+	if !ok {
+		t.Fatalf("copy schedule for reader: %T", readerScheduleObject)
+	}
+	writer := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentSchedule{}, &nvtv1alpha1.AgentRun{}).
+		WithObjects(writerSchedule).
+		Build()
+	reader := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&nvtv1alpha1.AgentSchedule{}, &nvtv1alpha1.AgentRun{}).
+		WithObjects(readerSchedule, scheduledRun("authoritative-active", schedule, "existing", nvtv1alpha1.AgentRunPhaseRunning)).
+		Build()
+	handler := &agentScheduleAdmissionHandler{
+		client: writer, reader: reader, scheme: scheme, now: metav1.Now,
+		admissionLocks: newScheduleAdmissionLocks(),
+	}
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/v1/schedules/"+schedule.Namespace+"/"+schedule.Name+"/admissions",
+		strings.NewReader(scheduleAdmissionBody(t, "new-work", "", nil)),
+	)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, response, http.StatusTooManyRequests, &decoded)
+	if decoded.Reason != maxParallelismReachedReason {
+		t.Fatalf("authoritative capacity was ignored: %#v", decoded)
+	}
+	assertScheduledRunCount(t, writer, schedule, 0)
+}
+
+func TestLegacyScheduleRejectsPerPrincipalParallelism(t *testing.T) {
+	schedule := testAgentSchedule()
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{DefaultMaxParallelism: 1}
+	fixture := scheduleAdmissionFixture(t, schedule)
+
+	response, k8sClient := serveScheduleAdmission(t, fixture, scheduleAdmissionBody(t, "new-work", "", nil))
+
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, response, http.StatusBadRequest, &decoded)
+	if decoded.Scheduled || decoded.Reason != invalidExecutionProfileConfigurationReason {
+		t.Fatalf("unexpected response: %#v", decoded)
+	}
+	assertScheduledRunCount(t, k8sClient, schedule, 0)
 }
 
 func TestScheduleAdmissionDuplicateActiveWorkCreatesNoRun(t *testing.T) {

--- a/operator/internal/controller/execution_profile.go
+++ b/operator/internal/controller/execution_profile.go
@@ -443,8 +443,7 @@ func producerAllowsDynamicPrincipal(
 	principal *nvtv1alpha1.AgentRunPrincipal,
 ) bool {
 	if !ScheduleUsesPrincipalCredentials(schedule) || principal == nil ||
-		!canonicalPrincipalIssuer(principal.Issuer) || principal.Subject == "" || len(principal.Subject) > 512 ||
-		strings.TrimSpace(principal.Subject) != principal.Subject || strings.ContainsAny(principal.Subject, "\x00\r\n") {
+		!canonicalPrincipalIssuer(principal.Issuer) || !validPrincipalSubject(principal.Subject) {
 		return false
 	}
 	for _, policy := range schedule.Spec.ProducerPolicies {
@@ -459,6 +458,11 @@ func producerAllowsDynamicPrincipal(
 		return false
 	}
 	return false
+}
+
+func validPrincipalSubject(value string) bool {
+	return value != "" && len(value) <= 512 && strings.TrimSpace(value) == value &&
+		!strings.ContainsAny(value, "\x00\r\n")
 }
 
 func canonicalPrincipalIssuer(value string) bool {

--- a/operator/internal/controller/execution_profile_test.go
+++ b/operator/internal/controller/execution_profile_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -241,6 +242,158 @@ func TestProfiledScheduleNoMatchPolicies(t *testing.T) {
 	decodeAdmissionResponse(t, denied, http.StatusForbidden, &decoded)
 	if decoded.Reason != "profile-selection-denied" || strings.Contains(denied.Body.String(), "canary") {
 		t.Fatalf("unsafe or unexpected denial: %q", denied.Body.String())
+	}
+}
+
+func TestProfiledSchedulePrincipalParallelism(t *testing.T) {
+	schedule := testProfiledAgentSchedule()
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{
+		DefaultMaxParallelism: 1,
+		Overrides: []nvtv1alpha1.AgentSchedulePrincipalParallelismOverride{{
+			Issuer: "https://github.com", Subject: "immutable-user-42", MaxParallelism: 2,
+		}},
+	}
+	fixture := newProfileAdmissionFixture(t, schedule)
+
+	principal := &scheduleAdmissionPrincipal{
+		Issuer: "https://github.com", Subject: "immutable-user-42", DisplayName: "original-login",
+	}
+	first := fixture.serve(t, profiledAdmissionBody(t, "principal-first", principal, nil), "Bearer projected-token")
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, first, http.StatusCreated, &decoded)
+	firstRun := fixture.run(t, decoded.AgentRun.Name)
+
+	renamed := *principal
+	renamed.DisplayName = "renamed-login"
+	second := fixture.serve(t, profiledAdmissionBody(t, "principal-second", &renamed, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, second, http.StatusCreated, &decoded)
+	denied := fixture.serve(t, profiledAdmissionBody(t, "principal-third", &renamed, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, denied, http.StatusTooManyRequests, &decoded)
+	if decoded.Scheduled || decoded.Reason != principalMaxParallelismReachedReason {
+		t.Fatalf("unexpected same-principal response: %#v", decoded)
+	}
+
+	otherSubject := *principal
+	otherSubject.Subject = "immutable-user-43"
+	otherSubjectResponse := fixture.serve(t,
+		profiledAdmissionBody(t, "other-subject", &otherSubject, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, otherSubjectResponse, http.StatusCreated, &decoded)
+	otherSubjectDenied := fixture.serve(t,
+		profiledAdmissionBody(t, "other-subject-second", &otherSubject, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, otherSubjectDenied, http.StatusTooManyRequests, &decoded)
+	if decoded.Reason != principalMaxParallelismReachedReason {
+		t.Fatalf("unexpected default-limit response: %#v", decoded)
+	}
+
+	otherIssuer := *principal
+	otherIssuer.Issuer = "https://idp.example.test"
+	otherIssuerResponse := fixture.serve(t,
+		profiledAdmissionBody(t, "other-issuer", &otherIssuer, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, otherIssuerResponse, http.StatusCreated, &decoded)
+
+	firstRun.Status.Phase = nvtv1alpha1.AgentRunPhaseCompleted
+	if err := fixture.client.Status().Update(context.Background(), &firstRun); err != nil {
+		t.Fatalf("mark first principal run terminal: %v", err)
+	}
+	released := fixture.serve(t,
+		profiledAdmissionBody(t, "principal-after-terminal", principal, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, released, http.StatusCreated, &decoded)
+}
+
+func TestProfiledSchedulePerPrincipalLimitRequiresPrincipal(t *testing.T) {
+	schedule := testProfiledAgentSchedule()
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{DefaultMaxParallelism: 1}
+	fixture := newProfileAdmissionFixture(t, schedule)
+
+	response := fixture.serve(t, profiledAdmissionBody(t, "missing-principal", nil, nil), "Bearer projected-token")
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, response, http.StatusBadRequest, &decoded)
+	if decoded.Scheduled || decoded.Reason != "principal-required" {
+		t.Fatalf("unexpected missing-principal response: %#v", decoded)
+	}
+}
+
+func TestProfiledScheduleGlobalParallelismRemainsAbsoluteCeiling(t *testing.T) {
+	schedule := testProfiledAgentSchedule()
+	schedule.Spec.MaxParallelism = 1
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{
+		DefaultMaxParallelism: 5,
+		Overrides: []nvtv1alpha1.AgentSchedulePrincipalParallelismOverride{{
+			Issuer: "https://github.com", Subject: "privileged-user", MaxParallelism: 10,
+		}},
+	}
+	fixture := newProfileAdmissionFixture(t, schedule)
+
+	firstPrincipal := &scheduleAdmissionPrincipal{Issuer: "https://github.com", Subject: "privileged-user"}
+	first := fixture.serve(t, profiledAdmissionBody(t, "global-first", firstPrincipal, nil), "Bearer projected-token")
+	var decoded scheduleAdmissionResponse
+	decodeAdmissionResponse(t, first, http.StatusCreated, &decoded)
+
+	secondPrincipal := &scheduleAdmissionPrincipal{Issuer: "https://github.com", Subject: "other-user"}
+	second := fixture.serve(t,
+		profiledAdmissionBody(t, "global-second", secondPrincipal, nil), "Bearer projected-token")
+	decodeAdmissionResponse(t, second, http.StatusTooManyRequests, &decoded)
+	if decoded.Reason != maxParallelismReachedReason {
+		t.Fatalf("global ceiling did not win: %#v", decoded)
+	}
+}
+
+func TestProfiledScheduleRejectsInvalidPrincipalParallelism(t *testing.T) {
+	invalidConfigurations := []nvtv1alpha1.AgentSchedulePrincipalParallelism{
+		{},
+		{DefaultMaxParallelism: 1, Overrides: []nvtv1alpha1.AgentSchedulePrincipalParallelismOverride{
+			{Issuer: "https://github.com", Subject: "same", MaxParallelism: 1},
+			{Issuer: "https://github.com", Subject: "same", MaxParallelism: 2},
+		}},
+		{DefaultMaxParallelism: 1, Overrides: []nvtv1alpha1.AgentSchedulePrincipalParallelismOverride{{
+			Issuer: "http://insecure.example", Subject: testPrincipalSubject, MaxParallelism: 1,
+		}}},
+	}
+	principal := &scheduleAdmissionPrincipal{Issuer: "https://github.com", Subject: testPrincipalSubject}
+	for index := range invalidConfigurations {
+		schedule := testProfiledAgentSchedule()
+		schedule.Spec.PrincipalParallelism = invalidConfigurations[index].DeepCopy()
+		fixture := newProfileAdmissionFixture(t, schedule)
+		body := profiledAdmissionBody(t, fmt.Sprintf("invalid-capacity-%d", index), principal, nil)
+		response := fixture.serve(t, body, "Bearer projected-token")
+		var decoded scheduleAdmissionResponse
+		decodeAdmissionResponse(t, response, http.StatusBadRequest, &decoded)
+		if decoded.Scheduled || decoded.Reason != invalidExecutionProfileConfigurationReason {
+			t.Fatalf("configuration %d was accepted: %#v", index, decoded)
+		}
+	}
+}
+
+func TestProfiledScheduleConcurrentAdmissionsRespectPrincipalParallelism(t *testing.T) {
+	schedule := testProfiledAgentSchedule()
+	schedule.Spec.PrincipalParallelism = &nvtv1alpha1.AgentSchedulePrincipalParallelism{DefaultMaxParallelism: 1}
+	fixture := newProfileAdmissionFixture(t, schedule)
+	principal := &scheduleAdmissionPrincipal{Issuer: "https://github.com", Subject: "concurrent-user"}
+	bodies := make([]string, 8)
+	for index := range bodies {
+		bodies[index] = profiledAdmissionBody(t, fmt.Sprintf("principal-concurrent-%d", index), principal, nil)
+	}
+
+	responses := make([]*httptest.ResponseRecorder, len(bodies))
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	for index := range bodies {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			<-start
+			responses[index] = fixture.serve(t, bodies[index], "Bearer projected-token")
+		}(index)
+	}
+	close(start)
+	wait.Wait()
+
+	statusCounts := map[int]int{}
+	for _, response := range responses {
+		statusCounts[response.Code]++
+	}
+	if statusCounts[http.StatusCreated] != 1 || statusCounts[http.StatusTooManyRequests] != len(bodies)-1 {
+		t.Fatalf("principal capacity was oversubscribed: %#v", statusCounts)
 	}
 }
 
@@ -1021,6 +1174,7 @@ type profileAdmissionFixture struct {
 	principalAccounts     principalaccounts.Resolver
 	principalCoordination principalaccounts.Coordinator
 	scheme                *runtime.Scheme
+	admissionLocks        *scheduleAdmissionLocks
 }
 
 func newProfileAdmissionFixture(t *testing.T, schedule *nvtv1alpha1.AgentSchedule) *profileAdmissionFixture {
@@ -1039,7 +1193,8 @@ func newProfileAdmissionFixture(t *testing.T, schedule *nvtv1alpha1.AgentSchedul
 	}
 	return &profileAdmissionFixture{
 		client: k8sClient, schedule: schedule, scheme: scheme,
-		authenticator: fakeScheduleProducerAuthenticator{identity: identity},
+		authenticator:  fakeScheduleProducerAuthenticator{identity: identity},
+		admissionLocks: newScheduleAdmissionLocks(),
 	}
 }
 
@@ -1068,6 +1223,7 @@ func (f *profileAdmissionFixture) serve(t *testing.T, body, authorization string
 		client: f.client, scheme: f.scheme, authenticator: f.authenticator,
 		profileResolver: StaticExecutionProfileResolver{}, principalAccounts: f.principalAccounts, now: metav1.Now,
 		principalCoordination: f.principalCoordination,
+		admissionLocks:        f.admissionLocks,
 	}
 	request := httptest.NewRequest(http.MethodPost,
 		"/v1/schedules/"+f.schedule.Namespace+"/"+f.schedule.Name+"/admissions",

--- a/tests/operator/helm/credential-portal-test.sh
+++ b/tests/operator/helm/credential-portal-test.sh
@@ -24,7 +24,7 @@ if grep -Eq 'verbs:.*(get|list|create|delete)' "${PORTAL_ROLE}"; then
 fi
 grep -Fq 'resourceNames:' "${RENDER}"
 grep -Fq -- '- "nvt-portal-seed"' "${RENDER}"
-grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.63"' "${RENDER}"
+grep -Fq 'image: "ghcr.io/mirkosekulic/nvt-credential-portal:0.8.64"' "${RENDER}"
 grep -Fq -- '--credential-portal-url=/agents/credentials' "${RENDER}"
 grep -Fq 'readOnlyRootFilesystem: true' "${RENDER}"
 grep -Fq 'automountServiceAccountToken: false' "${RENDER}"

--- a/tests/operator/helm/profile-values.yaml
+++ b/tests/operator/helm/profile-values.yaml
@@ -1,4 +1,10 @@
 agentSchedule:
+  principalParallelism:
+    defaultMaxParallelism: 2
+    overrides:
+      - issuer: https://github.com
+        subject: "23359247"
+        maxParallelism: 4
   executionClasses:
     - name: vm-standard
       kind: vm

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CHART="${ROOT}/charts/nvt"
 CHART_VERSION="$(awk -F ': *' '/^version:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
 CHART_APP_VERSION="$(awk -F ': *' '/^appVersion:/ { gsub(/"/, "", $2); print $2; exit }' "${CHART}/Chart.yaml")"
-if [[ "${CHART_VERSION}" != "0.8.63" || "${CHART_APP_VERSION}" != "0.8.63" ]]; then
-  echo "expected coordinated chart version and appVersion 0.8.63, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
+if [[ "${CHART_VERSION}" != "0.8.64" || "${CHART_APP_VERSION}" != "0.8.64" ]]; then
+  echo "expected coordinated chart version and appVersion 0.8.64, got ${CHART_VERSION}/${CHART_APP_VERSION}" >&2
   exit 1
 fi
 if [[ "$(grep -Fc 'crds: CreateReplace' "${CHART}/README.md")" -lt 2 ]]; then
   echo "expected Flux install and upgrade CRD CreateReplace guidance" >&2
   exit 1
 fi
-grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.63' "${CHART}/README.md"
+grep -Fq 'helm show crds oci://ghcr.io/mirkosekulic/helm/nvt --version 0.8.64' "${CHART}/README.md"
 grep -Fq 'ghcr.io/mirkosekulic/nvt-host-bundle:<appVersion>' "${CHART}/README.md"
 grep -Fq 'repository: https://ghcr.io/mirkosekulic/nvt-host-bundle' "${CHART}/README.md"
 grep -Fq 'digest: sha256:<64-hex>' "${CHART}/README.md"
@@ -1356,6 +1356,13 @@ fi
 grep -q 'operator.image must use the 0.2 repository/tag/pullPolicy map; migrate 0.1 scalar image values before upgrading' "${LEGACY_IMAGE_FAILURE}"
 
 grep -q 'name: default-codex' "${PROFILE_RENDER}"
+grep -q 'principalParallelism:' "${PROFILE_RENDER}"
+grep -q 'defaultMaxParallelism: 2' "${PROFILE_RENDER}"
+grep -A8 'principalParallelism:' "${PROFILE_RENDER}" | grep -q 'maxParallelism: 4'
+if grep -q 'principalParallelism:' "${SCHEDULE_LEGACY_RENDER}"; then
+  echo "default schedule unexpectedly enabled per-principal capacity" >&2
+  exit 1
+fi
 grep -A10 'executionClasses:' "${PROFILE_RENDER}" | grep -q 'name: vm-standard'
 grep -A10 'executionClasses:' "${PROFILE_RENDER}" | grep -q 'driver: example-vm'
 grep -A10 'executionClasses:' "${PROFILE_RENDER}" | grep -q 'isolation: required'

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -947,7 +947,7 @@ accounts = resources("ServiceAccount")
 configmaps = resources("ConfigMap")
 default_operator = next(item for item in default_documents if item.get("kind") == "Deployment" and item["metadata"]["name"] == "nvt-operator")
 assert "securityContext" not in default_operator["spec"]["template"]["spec"]
-assert "strategy" not in default_operator["spec"]
+assert default_operator["spec"]["strategy"] == {"type": "Recreate"}
 assert "nvt.dev/native-egress-rollout-revision" not in default_operator["spec"]["template"].get("metadata", {}).get("annotations", {})
 expected = {"fake-east", "fake-west"}
 driver_names = {f"nvt-execution-driver-{name}" for name in expected}

--- a/tests/operator/helm/test.sh
+++ b/tests/operator/helm/test.sh
@@ -824,6 +824,7 @@ require_resource_namespace "${DEFAULT_RENDER}" ServiceAccount nvt-operator custo
 require_resource_namespace "${DEFAULT_RENDER}" Role nvt-operator custom-ns
 require_resource_namespace "${DEFAULT_RENDER}" RoleBinding nvt-operator custom-ns
 require_resource_namespace "${DEFAULT_RENDER}" Service nvt-operator custom-ns
+require_deployment_strategy "${DEFAULT_RENDER}" nvt-operator Recreate
 grep -q 'resources: \["persistentvolumeclaims"\]' "${DEFAULT_RENDER}"
 require_resource_namespace "${DEFAULT_RENDER}" AgentSchedule default custom-ns
 missing_resource "${DEFAULT_RENDER}" Namespace nvt


### PR DESCRIPTION
## Summary

- add optional, generic AgentSchedule principal capacity with a default and bounded exact issuer+subject overrides
- keep maxParallelism as the absolute schedule-wide ceiling and release capacity only for terminal runs
- require canonical immutable principals, reject malformed or duplicate override configuration, and keep display names/providers out of the capacity key
- use the authoritative Kubernetes API reader for admission capacity checks so cached reads cannot oversubscribe global or principal limits
- force the single-replica operator Deployment to use `Recreate`, preventing mixed-version admission during upgrades while locking remains process-local
- expose the disabled-by-default contract through the CRD and Helm chart 0.8.64

## Tests

- `go test ./internal/controller ./cmd/manager -count=1`
- `go test -race ./internal/controller -run 'PrincipalParallelism|AuthoritativeReader|GlobalParallelismRemainsAbsoluteCeiling' -count=1`
- `golangci-lint run --new-from-rev=origin/main ./internal/controller/... ./cmd/manager/...`
- `helm lint charts/nvt`
- profiled/default AgentSchedule render checks, including unconditional operator `Recreate` in default and native-relay configurations
- `bash tests/operator/helm/credential-portal-test.sh`
- generated/chart CRD byte parity and `git diff --check`

The full `go test ./...` was also attempted locally; unrelated existing macOS execution-driver process/socket tests fail, while the changed controller packages pass.
