### PR TITLE
fix: harden native local workstation startup

### DIFF
--- a/compose.infra.yaml
+++ b/compose.infra.yaml
@@ -30,6 +30,44 @@ services:
       - agents-proxy
     restart: unless-stopped
 
+  local-controller-private-init:
+    image: nvt-local-controller:latest
+    user: "0:0"
+    network_mode: none
+    environment:
+      NVT_LOCAL_GATEWAY_UID: ${NVT_LOCAL_GATEWAY_UID:-65532}
+      NVT_LOCAL_GATEWAY_GID: ${NVT_LOCAL_GATEWAY_GID:-65532}
+    entrypoint:
+      - /bin/sh
+      - -euc
+    command:
+      - |
+        umask 077
+        test -s /source/local-controller.key
+        test -s /source/local-controller-admin-token
+        test -s /source/local-controller-route-token
+        cp /source/local-controller.key /private/local-controller.key.next
+        chown 0:0 /private/local-controller.key.next
+        chmod 0600 /private/local-controller.key.next
+        mv -f /private/local-controller.key.next /private/local-controller.key
+        cp /source/local-controller-admin-token /private/local-controller-admin-token.next
+        chown 0:0 /private/local-controller-admin-token.next
+        chmod 0600 /private/local-controller-admin-token.next
+        mv -f /private/local-controller-admin-token.next /private/local-controller-admin-token
+        cp /source/local-controller-route-token /private/local-controller-route-token.next
+        chown 0:0 /private/local-controller-route-token.next
+        chmod 0600 /private/local-controller-route-token.next
+        mv -f /private/local-controller-route-token.next /private/local-controller-route-token
+        cp /source/local-controller-route-token /gateway-private/local-controller-route-token.next
+        chown "$${NVT_LOCAL_GATEWAY_UID}:$${NVT_LOCAL_GATEWAY_GID}" /gateway-private/local-controller-route-token.next
+        chmod 0400 /gateway-private/local-controller-route-token.next
+        mv -f /gateway-private/local-controller-route-token.next /gateway-private/local-controller-route-token
+    volumes:
+      - ./.broker:/source:ro
+      - local-controller-private:/private
+      - local-gateway-private:/gateway-private
+    restart: "no"
+
   gateway:
     image: nvt-agent-gateway:latest
     container_name: nvt-local-gateway
@@ -48,8 +86,11 @@ services:
     networks:
       - agents-proxy
       - local-control-plane
+    depends_on:
+      local-controller-private-init:
+        condition: service_completed_successfully
     volumes:
-      - ./.broker/local-controller-route-token:/run/secrets/local-controller-route-token:ro
+      - local-gateway-private:/run/secrets:ro
     labels:
       - traefik.enable=true
       - traefik.docker.network=agents-proxy
@@ -85,14 +126,14 @@ services:
       NVT_LOCAL_CONTROLLER_RUNS_DIR: /state/controller/runs
       NVT_LOCAL_CONTROLLER_BROKER_URL: http://broker:7347
       NVT_LOCAL_CONTROLLER_BROKER_AGENTS: /broker-state/agents.yaml
-      NVT_LOCAL_CONTROLLER_IDENTITY_KEY_FILE: /broker-state/local-controller.key
+      NVT_LOCAL_CONTROLLER_IDENTITY_KEY_FILE: /controller-private/local-controller.key
       NVT_LOCAL_CONTROLLER_EXTERNAL_NETWORK: agents-proxy
       NVT_LOCAL_CONTROLLER_ROUTE_BASE_DOMAIN: agent.localhost
       NVT_LOCAL_CONTROLLER_ROUTE_PATH_PREFIX: /agents
       NVT_LOCAL_CONTROLLER_GATEWAY_CONTAINER: nvt-local-gateway
       NVT_LOCAL_CONTROLLER_CONFIG: ${NVT_LOCAL_CONTROLLER_CONFIG:-}
-      NVT_LOCAL_CONTROLLER_ADMIN_TOKEN_FILE: /broker-state/local-controller-admin-token
-      NVT_LOCAL_CONTROLLER_ROUTE_TOKEN_FILE: /broker-state/local-controller-route-token
+      NVT_LOCAL_CONTROLLER_ADMIN_TOKEN_FILE: /controller-private/local-controller-admin-token
+      NVT_LOCAL_CONTROLLER_ROUTE_TOKEN_FILE: /controller-private/local-controller-route-token
       NVT_LOCAL_CONTROLLER_RUN_NETWORK_POOL: ${NVT_LOCAL_CONTROLLER_RUN_NETWORK_POOL:-100.64.0.0/10}
       NVT_LOCAL_CONTROLLER_PROXY_PORT: ${NVT_PROXY_PORT:-4090}
       NVT_LOCAL_CONTROLLER_DIND_PROTECTED_CIDRS: ${NVT_DIND_PROTECTED_CIDRS:-127.0.0.0/8 169.254.0.0/16}
@@ -103,9 +144,13 @@ services:
     volumes:
       - local-controller-state:/state
       - ./.broker:/broker-state
+      - local-controller-private:/controller-private:ro
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - local-control-plane
+    depends_on:
+      local-controller-private-init:
+        condition: service_completed_successfully
     read_only: true
     tmpfs:
       - /tmp
@@ -119,3 +164,5 @@ networks:
 
 volumes:
   local-controller-state:
+  local-controller-private:
+  local-gateway-private:

--- a/docs/local-development-agent.md
+++ b/docs/local-development-agent.md
@@ -62,6 +62,9 @@ http://localhost:4090/agents/nvt/
 http://nvt.agent.localhost:4090/
 ```
 
+Every workstation uses `/workspace` inside the agent, matching the Kubernetes
+runtime contract; host-specific `.agents/...` paths are not exposed.
+
 Adding a workstation and restarting the controller creates it atomically.
 Unchanged entries replay idempotently. Workspace, runtime/session state, Docker
 data, and route identity survive controller, agent-container, and ordinary

--- a/localcontroller/internal/dockerbackend/backend_test.go
+++ b/localcontroller/internal/dockerbackend/backend_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mirkoSekulic/nvt-agent/localcontroller/internal/controller"
 	"github.com/mirkoSekulic/nvt-agent/protocol/resolvedrun"
+	"gopkg.in/yaml.v3"
 )
 
 type fakeDocker struct {
@@ -442,6 +443,24 @@ func TestConfinementGateIsLimitedToEnforcedTransparentRuns(t *testing.T) {
 		if bytes.Contains(direct, []byte(forbidden)) {
 			t.Fatalf("direct run received confinement gate %q:\n%s", forbidden, direct)
 		}
+	}
+}
+
+func TestAgentHealthcheckAllowsBoundedColdBootstrap(t *testing.T) {
+	run := testMediatedRun(t)
+	config := Config{Owner: "test-controller", ExternalNetwork: "agents-proxy", ProxyPort: 4090, ProtectedCIDRs: "127.0.0.0/8 169.254.0.0/16", DindImage: "nvt-dind:test", EgressdImage: "nvt-egressd:test", CapturedImage: "nvt-captured:test", SeedImage: "nvt-runtime:test"}
+	names := namesFor(Config{RunsDir: t.TempDir()}, run.RunID, strings.Repeat("3", 64))
+	plan, err := renderCompose(config, run, strings.Repeat("3", 64), names)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document composeDocument
+	if err := yaml.Unmarshal(plan, &document); err != nil {
+		t.Fatal(err)
+	}
+	healthcheck := document.Services["agent"].Healthcheck
+	if healthcheck == nil || !reflect.DeepEqual(healthcheck.Test, []string{"CMD-SHELL", "health"}) || healthcheck.Interval != "10s" || healthcheck.Timeout != "2s" || healthcheck.StartPeriod != "15m" || healthcheck.Retries != 3 {
+		t.Fatalf("agent healthcheck does not preserve the bounded bootstrap grace: %#v", healthcheck)
 	}
 }
 

--- a/localcontroller/internal/dockerbackend/render.go
+++ b/localcontroller/internal/dockerbackend/render.go
@@ -163,10 +163,11 @@ type composeDependency struct {
 }
 
 type composeHealthcheck struct {
-	Test     []string `yaml:"test"`
-	Interval string   `yaml:"interval"`
-	Timeout  string   `yaml:"timeout"`
-	Retries  int      `yaml:"retries"`
+	Test        []string `yaml:"test"`
+	Interval    string   `yaml:"interval"`
+	Timeout     string   `yaml:"timeout"`
+	StartPeriod string   `yaml:"start_period,omitempty"`
+	Retries     int      `yaml:"retries"`
 }
 
 type exposeRoute struct {
@@ -288,8 +289,9 @@ func renderCompose(config Config, run resolvedrun.ResolvedAgentRun, digest strin
 	services["agent"] = composeService{
 		Image: run.Image, User: user, WorkingDir: "/workspace", NetworkMode: "service:" + namespaceService, Restart: "unless-stopped", Labels: agentLabels,
 		Environment: agentEnvironment, DependsOn: agentDepends, CapAdd: append([]string(nil), runtimeCapabilities(run)...),
-		Volumes: []string{"workspace:/workspace", "agent-home:" + home, "agent-config:/nvt-config:ro"},
-		CPUs:    dockerCPU(run.Resources.CPULimit), MemLimit: dockerMemory(run.Resources.MemoryLimit),
+		Volumes:     []string{"workspace:/workspace", "agent-home:" + home, "agent-config:/nvt-config:ro"},
+		Healthcheck: &composeHealthcheck{Test: []string{"CMD-SHELL", "health"}, Interval: "10s", Timeout: "2s", StartPeriod: "15m", Retries: 3},
+		CPUs:        dockerCPU(run.Resources.CPULimit), MemLimit: dockerMemory(run.Resources.MemoryLimit),
 	}
 	if requiresConfinementProof(run) {
 		agent := services["agent"]

--- a/scripts/infra-up.sh
+++ b/scripts/infra-up.sh
@@ -31,8 +31,8 @@ for token_name in local-controller-admin-token local-controller-route-token; do
   chmod 600 "$broker_dir/$token_name"
 done
 
-# The gateway remains non-root while reading its mode-0600 bind-mounted route
-# credential on native Linux. Docker Desktop also accepts the numeric host UID.
+# The gateway remains non-root while reading the route credential copied into
+# the private controller volume. Numeric IDs keep ownership portable.
 export NVT_LOCAL_GATEWAY_UID="$(id -u)"
 export NVT_LOCAL_GATEWAY_GID="$(id -g)"
 

--- a/templates/local-controller.yaml
+++ b/templates/local-controller.yaml
@@ -22,7 +22,7 @@ defaults:
 
 execution_backends:
   - name: local-docker
-    kind: docker
+    kind: container
 
 retention_policies:
   - name: persistent

--- a/tests/runtime/local_controller_compose_test.go
+++ b/tests/runtime/local_controller_compose_test.go
@@ -60,16 +60,18 @@ func TestLocalControllerIsTheOnlyLocalRunComponentWithDockerAuthority(t *testing
 		"NVT_LOCAL_CONTROLLER_RUN_NETWORK_POOL: ${NVT_LOCAL_CONTROLLER_RUN_NETWORK_POOL:-100.64.0.0/10}",
 		"NVT_LOCAL_CONTROLLER_DOCKER_HOST: unix:///var/run/docker.sock",
 		"NVT_LOCAL_CONTROLLER_BROKER_AGENTS: /broker-state/agents.yaml",
+		"NVT_LOCAL_CONTROLLER_IDENTITY_KEY_FILE: /controller-private/local-controller.key",
 		"NVT_LOCAL_CONTROLLER_DIND_PROTECTED_CIDRS:",
 		"NVT_LOCAL_CONTROLLER_PROXY_PORT:",
 		"NVT_LOCAL_CONTROLLER_ROUTE_BASE_DOMAIN: agent.localhost",
 		"NVT_LOCAL_CONTROLLER_ROUTE_PATH_PREFIX: /agents",
 		"NVT_LOCAL_CONTROLLER_GATEWAY_CONTAINER: nvt-local-gateway",
 		"NVT_LOCAL_CONTROLLER_CONFIG:",
-		"NVT_LOCAL_CONTROLLER_ADMIN_TOKEN_FILE: /broker-state/local-controller-admin-token",
-		"NVT_LOCAL_CONTROLLER_ROUTE_TOKEN_FILE: /broker-state/local-controller-route-token",
+		"NVT_LOCAL_CONTROLLER_ADMIN_TOKEN_FILE: /controller-private/local-controller-admin-token",
+		"NVT_LOCAL_CONTROLLER_ROUTE_TOKEN_FILE: /controller-private/local-controller-route-token",
 		"local-controller-state:/state",
 		"./.broker:/broker-state",
+		"local-controller-private:/controller-private:ro",
 		"/var/run/docker.sock:/var/run/docker.sock",
 		"- local-control-plane",
 		"read_only: true",
@@ -99,7 +101,7 @@ func TestLocalControllerIsTheOnlyLocalRunComponentWithDockerAuthority(t *testing
 		`NVT_GATEWAY_LOCAL_RUNS_DISABLE_KUBERNETES: "true"`,
 		"NVT_GATEWAY_LOCAL_RUNS_CONTROLLER_URL: http://local-controller:7480",
 		"NVT_GATEWAY_LOCAL_RUNS_TOKEN_FILE: /run/secrets/local-controller-route-token",
-		"./.broker/local-controller-route-token:/run/secrets/local-controller-route-token:ro",
+		"local-gateway-private:/run/secrets:ro",
 		"nvt.dev/local-gateway=true",
 		"traefik.http.routers.nvt-local-gateway.rule=Host(`localhost`) && (PathPrefix(`/agents`) || PathPrefix(`/oauth2`))",
 		"traefik.http.routers.nvt-local-gateway-host.rule=HostRegexp(",
@@ -134,6 +136,32 @@ func TestLocalControllerIsTheOnlyLocalRunComponentWithDockerAuthority(t *testing
 	if !strings.Contains(compose, "\n  local-controller-state:\n") {
 		t.Fatalf("compose infrastructure has no durable controller state volume:\n%s", compose)
 	}
+	if !strings.Contains(compose, "\n  local-controller-private:\n") {
+		t.Fatalf("compose infrastructure has no private controller credential volume:\n%s", compose)
+	}
+	if !strings.Contains(compose, "\n  local-gateway-private:\n") {
+		t.Fatalf("compose infrastructure has no private gateway credential volume:\n%s", compose)
+	}
+	privateInitStart := strings.Index(compose, "\n  local-controller-private-init:\n")
+	if privateInitStart == -1 || privateInitStart >= gatewayStart {
+		t.Fatalf("compose infrastructure has no controller credential initializer:\n%s", compose)
+	}
+	privateInit := compose[privateInitStart:gatewayStart]
+	for _, required := range []string{
+		"image: nvt-local-controller:latest",
+		"network_mode: none",
+		"./.broker:/source:ro",
+		"local-controller-private:/private",
+		"local-gateway-private:/gateway-private",
+		"chmod 0600 /private/local-controller.key.next",
+		"chmod 0600 /private/local-controller-admin-token.next",
+		"chmod 0600 /private/local-controller-route-token.next",
+		"chmod 0400 /gateway-private/local-controller-route-token.next",
+	} {
+		if !strings.Contains(privateInit, required) {
+			t.Fatalf("controller credential initializer missing %q:\n%s", required, privateInit)
+		}
+	}
 
 	dockerfileBytes, err := os.ReadFile(filepath.Join(root, "localcontroller", "Dockerfile"))
 	if err != nil {
@@ -164,7 +192,7 @@ func TestNativeLocalConfigurationReplacesMigrationAuthoring(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(config)
-	for _, required := range []string{"api_version: nvt.local-platform/v1", "profiles:", "workflows:", "execution_backends:", "retention_policies:", "workstations:", "name: nvt", "name: studio", "name: infra"} {
+	for _, required := range []string{"api_version: nvt.local-platform/v1", "profiles:", "workflows:", "execution_backends:", "name: local-docker", "kind: container", "retention_policies:", "workstations:", "name: nvt", "name: studio", "name: infra"} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("native local config missing %q", required)
 		}
@@ -173,7 +201,7 @@ func TestNativeLocalConfigurationReplacesMigrationAuthoring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, forbidden := range []string{"local_runs", "source_agent", ".agents/", "local-agent-migrate", "local-controller-migration"} {
+	for _, forbidden := range []string{"local_runs", "source_agent", ".agents/", "local-agent-migrate", "local-controller-migration", "kind: docker"} {
 		if strings.Contains(text, forbidden) || strings.Contains(string(makefile), forbidden) {
 			t.Fatalf("legacy local authoring surface remains: %q", forbidden)
 		}


### PR DESCRIPTION
## Summary

- preserve strict controller and gateway credential-file modes on Docker Desktop through network-isolated private-volume initialization
- fix the shipped local execution backend kind and give cold workstation bootstrap a bounded health grace
- document and verify `/workspace` as the stable local and Kubernetes workspace contract

## Verification

- `cd localcontroller && go test -count=1 ./...`
- `cd tests/runtime && go test -count=1 -run "TestLocalControllerIsTheOnlyLocalRunComponentWithDockerAuthority|TestNativeLocalConfigurationReplacesMigrationAuthoring" ./...`
- `docker compose -f compose.infra.yaml config --quiet`
- live Docker smoke: `nvt`, `studio`, and `infra` reached healthy/running with mediated credentials and `/workspace` routes
- restart smoke: agent restart selected the generic resume command; shared-infrastructure restart recovered all three runs

The full runtime suite was also attempted with `TMPDIR=/tmp`; remaining failures are pre-existing tmux/session timing flakes, including `TestAfterAgentPluginsStartConcurrently`.