### PR TITLE
fix(local): accept anchored schedule source URLs

### DIFF
--- a/localcontroller/internal/controller/scheduling.go
+++ b/localcontroller/internal/controller/scheduling.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/mirkoSekulic/nvt-agent/protocol/resolvedrun"
@@ -605,5 +606,7 @@ func validScheduleText(value string, maximum int, allowEmpty bool) bool {
 
 func validScheduleURL(raw string) bool {
 	parsed, err := url.Parse(raw)
-	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil && parsed.Fragment == "" && len(raw) <= 2048 && !strings.ContainsAny(raw, "\x00\r\n")
+	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil && len(raw) <= 2048 &&
+		!strings.ContainsAny(raw, "\x00\r\n") && utf8.ValidString(parsed.Fragment) &&
+		strings.IndexFunc(parsed.Fragment, unicode.IsControl) == -1
 }

--- a/localcontroller/internal/controller/scheduling_test.go
+++ b/localcontroller/internal/controller/scheduling_test.go
@@ -542,6 +542,38 @@ func TestLocalSchedulingDeniesUntrustedSelectionBeforeBackendAndBoundsCapacity(t
 	}
 }
 
+func TestLocalSchedulingAcceptsValidatedSourceURLFragment(t *testing.T) {
+	store, _ := openTestStore(t, &fakeClock{value: time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)}, 1)
+	handler := NewHTTPHandlerWithServices(store, nil, nil, nil, testScheduler(t, store, schedulingTestToken))
+	body := testAdmissionBody(t, "https://identity.example.test", "subject-1", "development", "work")
+	var admission map[string]any
+	if err := json.Unmarshal(body, &admission); err != nil {
+		t.Fatal(err)
+	}
+	const sourceURL = "https://github.com/acme/widget/issues/7#issuecomment-5304285434"
+	admission["work"].(map[string]any)["url"] = sourceURL
+	response := scheduleRequest(t, handler, http.MethodPost, "/v1/schedules/github/admissions", mustJSON(t, admission), schedulingTestToken)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("fragment source URL admission = %d %s", response.Code, response.Body.String())
+	}
+}
+
+func TestScheduleSourceURLRejectsUnsafeFragments(t *testing.T) {
+	for name, sourceURL := range map[string]string{
+		"encoded newline": "https://github.example/acme/widget/issues/7#issuecomment%0a7",
+		"encoded null":    "https://github.example/acme/widget/issues/7#issuecomment%007",
+		"invalid escape":  "https://github.example/acme/widget/issues/7#issuecomment%zz7",
+		"userinfo":        "https://user@github.example/acme/widget/issues/7#issuecomment-7",
+		"insecure scheme": "http://github.example/acme/widget/issues/7#issuecomment-7",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if validScheduleURL(sourceURL) {
+				t.Fatalf("unsafe source URL was accepted: %q", sourceURL)
+			}
+		})
+	}
+}
+
 func testScheduler(t *testing.T, store *Store, token string) *Scheduler {
 	t.Helper()
 	directory := t.TempDir()

--- a/protocol/local-controller.md
+++ b/protocol/local-controller.md
@@ -165,6 +165,11 @@ capability, or egress setting. The authenticated policy maps the workflow to an
 exact authorized profile before the shared resolver runs, so denial happens
 before durable state or Docker resources exist.
 
+The optional work source URL is bounded HTTPS provenance and is never fetched
+by the controller. Query strings and validated fragments are accepted unchanged
+so producers can retain an exact comment anchor; userinfo, malformed escapes,
+and percent-decoded fragment control characters are rejected.
+
 The idempotency key and local run ID are deterministic hashes of the schedule,
 administrator producer identity, and producer work ID. An identical retry
 returns HTTP 202 with `duplicate-work`; serialized active-run capacity returns


### PR DESCRIPTION
## Summary
- allow validated URL fragments in local schedule work-source URLs
- preserve exact GitHub comment anchors while retaining HTTPS, host, userinfo, size, and control-character validation
- document the inert provenance boundary and add admission-level regression coverage

## Tests
- `cd localcontroller && go test ./...`

## Compatibility
Kubernetes scheduling and producer payloads are unchanged. The local controller only broadens its source-URL validator to accept safe fragments that the producer already sends.