### PR TITLE
fix(local): make credential enrollment reachable

### DIFF
--- a/compose.infra.yaml
+++ b/compose.infra.yaml
@@ -151,11 +151,19 @@ services:
     command: [runner, --listen, 0.0.0.0:8081, --auth-key-file, /private/runner.key]
     volumes:
       - local-credential-private:/private:ro
-    networks: [local-control-plane]
+    networks: [agents-proxy, local-control-plane]
     depends_on:
       credential-private-init: {condition: service_completed_successfully}
     read_only: true
     tmpfs: [/tmp]
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=agents-proxy
+      - traefik.http.routers.nvt-local-credentials.rule=Host(`localhost`) && PathPrefix(`/agents/credentials`)
+      - traefik.http.routers.nvt-local-credentials.entrypoints=web
+      - traefik.http.routers.nvt-local-credentials.priority=200
+      - traefik.http.routers.nvt-local-credentials.service=nvt-local-credentials
+      - traefik.http.services.nvt-local-credentials.loadbalancer.server.port=8080
     restart: unless-stopped
 
   credential-portal:
@@ -166,22 +174,15 @@ services:
       NVT_CREDENTIAL_PORTAL_PUBLIC_URL: http://localhost:${NVT_PROXY_PORT:-4090}/agents/credentials
       NVT_CREDENTIAL_PORTAL_SESSION_SECRET_FILE: /private/session.key
       NVT_CREDENTIAL_RUNNER_AUTH_KEY_FILE: /private/runner.key
-      NVT_CREDENTIAL_RUNNER_URL: http://credential-runner:8081
+      NVT_CREDENTIAL_RUNNER_URL: http://127.0.0.1:8081
     volumes:
       - ./.broker/credential-portal-local.json:/config/config.json:ro
       - local-credential-private:/private:ro
       - local-credential-seeds:/seed
-    networks: [agents-proxy, local-control-plane]
+    network_mode: service:credential-runner
     depends_on:
       credential-private-init: {condition: service_completed_successfully}
       credential-runner: {condition: service_started}
-    labels:
-      - traefik.enable=true
-      - traefik.docker.network=agents-proxy
-      - traefik.http.routers.nvt-local-credentials.rule=Host(`localhost`) && PathPrefix(`/agents/credentials`)
-      - traefik.http.routers.nvt-local-credentials.entrypoints=web
-      - traefik.http.routers.nvt-local-credentials.priority=100
-      - traefik.http.services.nvt-local-credentials.loadbalancer.server.port=8080
     read_only: true
     tmpfs: [/tmp]
     restart: unless-stopped

--- a/scripts/infra-up.sh
+++ b/scripts/infra-up.sh
@@ -40,7 +40,6 @@ if [ -f "$broker_dir/local-controller.yaml" ] && [ -z "${NVT_LOCAL_CONTROLLER_CO
   export NVT_LOCAL_CONTROLLER_CONFIG=/broker-state/local-controller.yaml
 fi
 
-compose_profiles=()
 if [ "${NVT_CREDENTIAL_PORTAL_ENABLED:-false}" = "true" ]; then
   if [ ! -f "$broker_dir/credential-portal-local.json" ]; then
     cp "$templates_dir/credential-portal-local.json" "$broker_dir/credential-portal-local.json"
@@ -48,12 +47,11 @@ if [ "${NVT_CREDENTIAL_PORTAL_ENABLED:-false}" = "true" ]; then
   chmod 644 "$broker_dir/credential-portal-local.json"
   export NVT_GATEWAY_CREDENTIAL_PORTAL_URL=/agents/credentials
   export NVT_BROKER_CREDENTIAL_SEED_DIR=/portal-seed
-  compose_profiles=(--profile credentials)
+  docker compose -f "$repo_root/compose.infra.yaml" --profile credentials up -d
 else
   # Compose does not stop services from an omitted profile during `up`.
   # Remove only the optional containers; named credential volumes remain.
   docker compose -f "$repo_root/compose.infra.yaml" --profile credentials rm -sf \
     credential-portal credential-runner credential-private-init
+  docker compose -f "$repo_root/compose.infra.yaml" up -d
 fi
-
-docker compose -f "$repo_root/compose.infra.yaml" "${compose_profiles[@]}" up -d

--- a/tests/runtime/local_controller_compose_test.go
+++ b/tests/runtime/local_controller_compose_test.go
@@ -197,14 +197,17 @@ func TestLocalCredentialPortalComposeIsOptionalAndPrivate(t *testing.T) {
 		"local-credential-seeds:/seed", "local-credential-seeds:/portal-seed:ro",
 		"local-broker-private:/private", "NVT_BROKER_SEED_TARGET_DIR: portal",
 		"PathPrefix(`/agents/credentials`)", "NVT_GATEWAY_CREDENTIAL_PORTAL_URL:",
+		"traefik.http.routers.nvt-local-credentials.priority=200",
+		"traefik.http.routers.nvt-local-credentials.service=nvt-local-credentials",
 		"NVT_BROKER_SEED_DIR: ${NVT_BROKER_CREDENTIAL_SEED_DIR:-}",
+		"network_mode: service:credential-runner", "NVT_CREDENTIAL_RUNNER_URL: http://127.0.0.1:8081",
 		`if [ -n "$${NVT_BROKER_SEED_DIR:-}" ]; then`,
 	} {
 		if !strings.Contains(compose, required) {
 			t.Fatalf("local credential compose missing %q", required)
 		}
 	}
-	for _, forbidden := range []string{"CODEX_TOKEN=", "CLAUDE_TOKEN=", "credentials.json:"} {
+	for _, forbidden := range []string{"CODEX_TOKEN=", "CLAUDE_TOKEN=", "credentials.json:", "NVT_CREDENTIAL_RUNNER_URL: http://credential-runner"} {
 		if strings.Contains(compose, forbidden) {
 			t.Fatalf("compose exposes credential material via %q", forbidden)
 		}


### PR DESCRIPTION
## Summary
- colocate the local credential portal and runner so the runner client uses its required loopback transport
- route the shared network namespace through Traefik with deterministic priority over the gateway route
- make the optional-profile startup script compatible with macOS Bash 3

## Tests
- `docker compose -f compose.infra.yaml --profile credentials config --quiet`
- `bash -n scripts/infra-up.sh`
- `cd tests/runtime && go test -count=1 -run 'TestLocalCredentialPortalComposeIsOptionalAndPrivate|TestInfraUpDisabledRemovesCredentialContainersAndPreservesVolumes' ./...`\n- live local request through `http://localhost:4090/agents/credentials/`