### PR TITLE
fix(local): restore Codex placeholder mediation

### DIFF
--- a/localplatform/config/render.go
+++ b/localplatform/config/render.go
@@ -336,7 +336,7 @@ func renderRepository(item manifest.ControllerRepositoryIntent, profile manifest
 }
 
 func runtimeGrant(provider, preset string) resolvedrun.BrokerGrant {
-	hosts := []string{"chatgpt.com:443"}
+	hosts := []string{"chatgpt.com:443", "api.openai.com:443", "auth.openai.com:443"}
 	if preset == "claude-oauth" {
 		hosts = []string{"api.anthropic.com:443", "mcp-proxy.anthropic.com:443"}
 	}
@@ -368,7 +368,13 @@ func Broker(compiled manifest.Compiled) ([]byte, error) {
 		switch account.Preset {
 		case "codex-oauth":
 			providers = append(providers, map[string]any{"name": named.Name, "plugin": "codex-oauth", "config": map[string]any{
-				"auth-file": "/private/portal/" + plancontract.CredentialSlotName(named.Name), "injection-hosts": []string{"chatgpt.com"},
+				"auth-file": "/private/portal/" + plancontract.CredentialSlotName(named.Name), "refresh-margin-seconds": 3600,
+				"injection-hosts": []string{"chatgpt.com", "api.openai.com", "auth.openai.com"},
+				"placeholder-file": map[string]any{
+					"path": ".codex/auth.json", "hosts": []string{"chatgpt.com", "api.openai.com", "auth.openai.com"},
+					"id-token-claims": []map[string]any{{"claim": "chatgpt_account_id", "claim-path": []string{"https://api.openai.com/auth", "chatgpt_account_id"}}},
+				},
+				"injection-claim-headers": []map[string]any{{"header": "ChatGPT-Account-ID", "claim-path": []string{"https://api.openai.com/auth", "chatgpt_account_id"}}},
 			}})
 		case "claude-oauth":
 			providers = append(providers, map[string]any{"name": named.Name, "plugin": "claude-oauth", "config": map[string]any{

--- a/localplatform/config/render_test.go
+++ b/localplatform/config/render_test.go
@@ -42,6 +42,9 @@ func TestRenderValidManifestUsesContainerPrivateFilesAndNativePolicy(t *testing.
 		[]byte(`"app-id":3912708`),
 		[]byte(`"installation-id":123`),
 		[]byte(`"auth-file":"/private/portal/` + plancontract.CredentialSlotName("codex") + `"`),
+		[]byte(`"injection-hosts":["chatgpt.com","api.openai.com","auth.openai.com"]`),
+		[]byte(`"path":".codex/auth.json"`),
+		[]byte(`"header":"ChatGPT-Account-ID"`),
 		[]byte(`"repositories":["dev.azure.com/example/platform/_git/infrastructure"]`),
 	} {
 		if !bytes.Contains(broker, expected) {
@@ -76,8 +79,14 @@ func TestRenderValidManifestUsesContainerPrivateFilesAndNativePolicy(t *testing.
 		trusted.Profiles[0].Egress.Transport != "transparent" || !trusted.Profiles[0].Egress.AllowInsecureBroker || trusted.Profiles[0].DefaultCredentialProvider != "github" {
 		t.Fatalf("local Docker or mediated transport policy missing: %#v", trusted.Profiles)
 	}
-	githubGrantFound := false
+	githubGrantFound, codexGrantFound := false, false
 	for _, grant := range trusted.Profiles[0].Broker.Grants {
+		if grant.Provider == "codex" {
+			codexGrantFound = true
+			if grant.Materialization != "placeholder-file" || strings.Join(grant.EgressHosts, ",") != "chatgpt.com:443,api.openai.com:443,auth.openai.com:443" {
+				t.Fatalf("Codex grant omitted placeholder mediation hosts: %#v", grant)
+			}
+		}
 		if grant.Provider == "github" {
 			githubGrantFound = true
 			if strings.Join(grant.EgressHosts, ",") != "github.com:443,api.github.com:443" {
@@ -87,6 +96,9 @@ func TestRenderValidManifestUsesContainerPrivateFilesAndNativePolicy(t *testing.
 	}
 	if !githubGrantFound {
 		t.Fatalf("GitHub repository grant is missing: %#v", trusted.Profiles[0].Broker.Grants)
+	}
+	if !codexGrantFound {
+		t.Fatalf("Codex runtime grant is missing: %#v", trusted.Profiles[0].Broker.Grants)
 	}
 	var agentConfig struct {
 		Runtime struct {


### PR DESCRIPTION
## Summary
- render the broker Codex placeholder file contract for local manifests
- include the complete mediated Codex host set and account claim header
- pin the generated runtime grant to the same hosts

## Verification
- `go test ./config` from `localplatform/`
- clean `local-init` / `local-up` with recovery upload
- all three local workstations reached `running`
- mediated Codex placeholder custody, GitHub/Azure Git access, generic egress, gateway routes, and full `local-down` / `local-up` recovery verified