### PR TITLE
docs(runtime): clarify mediated GitHub access checks

### DIFF
--- a/runtime/core/write-agent-instructions.sh
+++ b/runtime/core/write-agent-instructions.sh
@@ -155,6 +155,10 @@ if command -v gh-auth >/dev/null 2>&1 && command -v github-watch >/dev/null 2>&1
 
 Use `gh-auth` for GitHub CLI operations. It injects the configured provider
 token for the target repository, so do not run `gh auth login`.
+Do not use `gh-auth auth status` to test access: mediated grants may be scoped
+to repository endpoints and intentionally deny account identity probes. Run the
+required `gh-auth` repository command with an explicit `--repo OWNER/REPO`
+instead, even when an auth-status probe would fail.
 
 Create a PR with `gh-auth pr create --repo OWNER/REPO --fill`, then register it:
 

--- a/tests/runtime/runtime_core_conformance_test.go
+++ b/tests/runtime/runtime_core_conformance_test.go
@@ -104,6 +104,8 @@ func TestWriteAgentInstructionsIncludesGitHubPRWorkflowWhenToolsAreAvailable(t *
 	required := []string{
 		"## GitHub PR Workflow",
 		"Use `gh-auth` for GitHub CLI operations.",
+		"Do not use `gh-auth auth status` to test access",
+		"even when an auth-status probe would fail.",
 		"gh-auth pr create --repo OWNER/REPO --fill",
 		"github-watch register --repo OWNER/REPO --number PR_NUMBER --label work",
 		"Registered dynamic watches auto-remove after the PR is merged or closed by",


### PR DESCRIPTION
## Summary

- tell runtime agents not to use `gh-auth auth status` as a mediated-access probe
- direct agents to run the required repository-scoped command with an explicit `--repo`
- pin the generated guidance in the runtime conformance test

## Tests

- `cd tests/runtime && go test -count=1 -run TestWriteAgentInstructionsIncludesGitHubPRWorkflowWhenToolsAreAvailable ./...`
- attempted the complete `tests/runtime` suite locally; unrelated macOS host limitations remain (`flock` is unavailable and tmux socket paths exceed the platform limit). The canonical Linux suite runs in CI.
