### PR TITLE
fix: grant local agents workflow write access

### DIFF
--- a/localplatform/config/render.go
+++ b/localplatform/config/render.go
@@ -475,7 +475,7 @@ func repositoryGrant(provider, preset string, repositories []string) resolvedrun
 	grant := resolvedrun.BrokerGrant{Provider: provider, Repositories: repositories, Capabilities: []string{"injection.headers"}, Materialization: "header-inject", EgressHosts: hosts, Git: true}
 	if preset == "github-app" {
 		grant.Preparations = []string{"identity"}
-		grant.Permissions = map[string]string{"contents": "write"}
+		grant.Permissions = map[string]string{"contents": "write", "workflows": "write"}
 	}
 	return grant
 }

--- a/localplatform/config/render_test.go
+++ b/localplatform/config/render_test.go
@@ -140,6 +140,9 @@ func TestRenderValidManifestUsesContainerPrivateFilesAndNativePolicy(t *testing.
 			if strings.Join(grant.EgressHosts, ",") != "github.com:443,api.github.com:443" {
 				t.Fatalf("GitHub grant omitted the API injection route: %#v", grant)
 			}
+			if grant.Permissions["contents"] != "write" || grant.Permissions["workflows"] != "write" {
+				t.Fatalf("GitHub grant omitted repository or workflow write access: %#v", grant)
+			}
 		}
 	}
 	if !githubGrantFound {


### PR DESCRIPTION
Summary: include workflows write in generated local GitHub App grants and cover it with a render test. Tests: cd localplatform && go test ./config; git diff --check.