### PR TITLE
fix: recover persistent local workstations

### DIFF
--- a/localcontroller/internal/controller/scheduling_test.go
+++ b/localcontroller/internal/controller/scheduling_test.go
@@ -165,6 +165,46 @@ func TestConfiguredWorkstationsBootstrapIdempotentlyAndRejectDrift(t *testing.T)
 	}
 }
 
+func TestConfiguredWorkstationRestartsFromTerminalState(t *testing.T) {
+	clock := &fakeClock{value: time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)}
+	store, _ := openTestStore(t, clock, 4)
+	document := testNativeConfiguration()
+	document.Workstations = []workstationConfig{testWorkstation("nvt", "NVT")}
+	path := filepath.Join(t.TempDir(), "local-controller.yaml")
+	if err := os.WriteFile(path, mustJSON(t, document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	scheduler, err := LoadScheduler(path, store)
+	if err != nil || scheduler.BootstrapWorkstations(context.Background()) != nil {
+		t.Fatalf("bootstrap workstation: %v", err)
+	}
+	backend := newFakeBackend()
+	reconciler, _ := NewReconciler(store, backend, "controller", 30*time.Second, log.New(io.Discard, "", 0))
+	run, err := store.Get(context.Background(), "nvt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconcileToRunning(t, reconciler, store, run.RunID)
+	if _, err := store.Cancel(context.Background(), run.RunID); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Get(context.Background(), run.RunID)
+	if err != nil || failed.State != StateFailed {
+		t.Fatalf("terminal workstation = %#v, %v", failed, err)
+	}
+
+	if err := scheduler.BootstrapWorkstations(context.Background()); err != nil {
+		t.Fatalf("restart workstation: %v", err)
+	}
+	restarted, err := store.Get(context.Background(), run.RunID)
+	if err != nil || restarted.State != StatePending || restarted.LastReason != "workstation-restart-requested" || restarted.TerminalExpiresAt != nil {
+		t.Fatalf("restarted workstation = %#v, %v", restarted, err)
+	}
+}
+
 func TestPersistentWorkstationDesiredConfigurationRollsOutAtomically(t *testing.T) {
 	clock := &fakeClock{value: time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)}
 	store, _ := openTestStore(t, clock, 4)

--- a/localcontroller/internal/controller/scheduling_test.go
+++ b/localcontroller/internal/controller/scheduling_test.go
@@ -205,6 +205,65 @@ func TestConfiguredWorkstationRestartsFromTerminalState(t *testing.T) {
 	}
 }
 
+func TestConfiguredWorkstationAppliesCompatibleUpdateWhileRestartingFromTerminalState(t *testing.T) {
+	clock := &fakeClock{value: time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)}
+	store, _ := openTestStore(t, clock, 4)
+	document := testNativeConfiguration()
+	document.Workstations = []workstationConfig{testWorkstation("nvt", "NVT")}
+	path := filepath.Join(t.TempDir(), "local-controller.yaml")
+	if err := os.WriteFile(path, mustJSON(t, document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	scheduler, err := LoadScheduler(path, store)
+	if err != nil || scheduler.BootstrapWorkstations(context.Background()) != nil {
+		t.Fatalf("bootstrap workstation: %v", err)
+	}
+	backend := newFakeBackend()
+	reconciler, _ := NewReconciler(store, backend, "controller", 30*time.Second, log.New(io.Discard, "", 0))
+	reconcileToRunning(t, reconciler, store, "nvt")
+	if _, err := store.Cancel(context.Background(), "nvt"); err != nil {
+		t.Fatal(err)
+	}
+	if err := reconciler.Reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	_, _, ownershipBefore, cursorBefore, _, err := store.backendSnapshot(context.Background(), "nvt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	document.Workflows[0].WorkspaceInstructions = "updated after terminal state"
+	if err := os.WriteFile(path, mustJSON(t, document), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	updatedScheduler, err := LoadScheduler(path, store)
+	if err != nil || updatedScheduler.BootstrapWorkstations(context.Background()) != nil {
+		t.Fatalf("restart updated workstation: %v", err)
+	}
+	restarted, err := store.Get(context.Background(), "nvt")
+	if err != nil || restarted.State != StatePending || restarted.LastReason != "workstation-restart-with-configuration-requested" {
+		t.Fatalf("restarted workstation = %#v, %v", restarted, err)
+	}
+	snapshot, _, ownershipAfter, cursorAfter, rollout, err := store.backendSnapshot(context.Background(), "nvt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolvedrun.DecodeResolvedAgentRun(snapshot)
+	if err != nil || resolved.WorkspaceInstructions.Workflow != "updated after terminal state" {
+		t.Fatalf("updated snapshot = %#v, %v", resolved, err)
+	}
+	if ownershipAfter != ownershipBefore || cursorAfter != cursorBefore || rollout {
+		t.Fatalf("restart changed stable state: ownership %q -> %q, cursor %q -> %q, rollout=%t", ownershipBefore, ownershipAfter, cursorBefore, cursorAfter, rollout)
+	}
+	reconcileToRunning(t, reconciler, store, "nvt")
+	backend.mu.Lock()
+	lastEnsure := backend.ensuredRuns[len(backend.ensuredRuns)-1]
+	backend.mu.Unlock()
+	if lastEnsure.ConfigurationRollout || lastEnsure.PreviousResolved != nil || lastEnsure.Resolved.WorkspaceInstructions.Workflow != "updated after terminal state" {
+		t.Fatalf("restart used the wrong backend desired state: %#v", lastEnsure)
+	}
+}
+
 func TestPersistentWorkstationDesiredConfigurationRollsOutAtomically(t *testing.T) {
 	clock := &fakeClock{value: time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)}
 	store, _ := openTestStore(t, clock, 4)

--- a/localcontroller/internal/controller/store.go
+++ b/localcontroller/internal/controller/store.go
@@ -435,6 +435,7 @@ func (store *Store) createBatch(ctx context.Context, inputs []CreateInput, recla
 	newIndexes := make([]int, 0, len(prepared))
 	updateIndexes := make([]int, 0, len(prepared))
 	cancelIndexes := make([]int, 0, len(prepared))
+	restartIndexes := make([]int, 0, len(prepared))
 	for index, candidate := range prepared {
 		existing, found, queryErr := queryByIdempotency(ctx, tx, candidate.input.IdempotencyKey)
 		if queryErr != nil {
@@ -467,6 +468,8 @@ func (store *Store) createBatch(ctx context.Context, inputs []CreateInput, recla
 			}
 		} else if len(existing.pendingSnapshot) != 0 {
 			cancelIndexes = append(cancelIndexes, index)
+		} else if reclaimCleanupCapacity && existing.view.State.terminal() {
+			restartIndexes = append(restartIndexes, index)
 		}
 		results[index] = CreateResult{Run: existing.view, Created: false}
 	}
@@ -496,7 +499,7 @@ AND state IN ('pending','preparing','running','stopping')`, group, group).Scan(&
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM local_runs WHERE deleted_at IS NULL AND state IN `+activeStates).Scan(&active); err != nil {
 		return nil, ErrStoreUnavailable
 	}
-	if active+len(newIndexes) > store.maxActiveRuns {
+	if active+len(newIndexes)+len(restartIndexes) > store.maxActiveRuns {
 		return nil, ErrCapacityExceeded
 	}
 	for _, index := range newIndexes {
@@ -538,6 +541,19 @@ run_id,idempotency_key,active_group,request_digest,snapshot,snapshot_digest,owne
 	for _, index := range cancelIndexes {
 		candidate := prepared[index]
 		result, updateErr := tx.ExecContext(ctx, `UPDATE local_runs SET pending_snapshot=snapshot,pending_snapshot_digest=snapshot_digest,state='preparing',revision=revision+1,updated_at=?,last_reason='configuration-rollback-requested',reconcile_owner=NULL,reconcile_until=NULL WHERE idempotency_key=? AND pending_snapshot IS NOT NULL`,
+			formatTimestamp(now), candidate.input.IdempotencyKey)
+		if updateErr != nil || rowsAffected(result) != 1 {
+			return nil, ErrStoreUnavailable
+		}
+		updated, found, queryErr := queryByIdempotency(ctx, tx, candidate.input.IdempotencyKey)
+		if queryErr != nil || !found {
+			return nil, ErrStoreUnavailable
+		}
+		results[index] = CreateResult{Run: updated.view, Created: false}
+	}
+	for _, index := range restartIndexes {
+		candidate := prepared[index]
+		result, updateErr := tx.ExecContext(ctx, `UPDATE local_runs SET state='pending',revision=revision+1,updated_at=?,terminal_expires_at=NULL,reconcile_owner=NULL,reconcile_until=NULL,last_reason='workstation-restart-requested',terminal_target='' WHERE idempotency_key=? AND deleted_at IS NULL AND state IN ('completed','failed')`,
 			formatTimestamp(now), candidate.input.IdempotencyKey)
 		if updateErr != nil || rowsAffected(result) != 1 {
 			return nil, ErrStoreUnavailable

--- a/localcontroller/internal/controller/store.go
+++ b/localcontroller/internal/controller/store.go
@@ -436,6 +436,7 @@ func (store *Store) createBatch(ctx context.Context, inputs []CreateInput, recla
 	updateIndexes := make([]int, 0, len(prepared))
 	cancelIndexes := make([]int, 0, len(prepared))
 	restartIndexes := make([]int, 0, len(prepared))
+	restartUpdateIndexes := make([]int, 0, len(prepared))
 	for index, candidate := range prepared {
 		existing, found, queryErr := queryByIdempotency(ctx, tx, candidate.input.IdempotencyKey)
 		if queryErr != nil {
@@ -459,16 +460,19 @@ func (store *Store) createBatch(ctx context.Context, inputs []CreateInput, recla
 		}
 		if existing.requestDigest != candidate.digest {
 			active, decodeErr := resolvedrun.DecodeResolvedAgentRun(existing.snapshot)
-			if decodeErr != nil || !workstationUpdateCompatible(active, candidate.resolved) || existing.view.DeleteRequested ||
-				existing.view.State != StateRunning && !(existing.view.State == StatePreparing && len(existing.pendingSnapshot) != 0) {
+			if decodeErr != nil || !workstationUpdateCompatible(active, candidate.resolved) || existing.view.DeleteRequested {
 				return nil, ErrConflict
 			}
-			if existing.pendingDigest != candidate.digest {
+			if reclaimCleanupCapacity && (existing.view.State == StateCompleted || existing.view.State == StateFailed) {
+				restartUpdateIndexes = append(restartUpdateIndexes, index)
+			} else if existing.view.State != StateRunning && !(existing.view.State == StatePreparing && len(existing.pendingSnapshot) != 0) {
+				return nil, ErrConflict
+			} else if existing.pendingDigest != candidate.digest {
 				updateIndexes = append(updateIndexes, index)
 			}
 		} else if len(existing.pendingSnapshot) != 0 {
 			cancelIndexes = append(cancelIndexes, index)
-		} else if reclaimCleanupCapacity && existing.view.State.terminal() {
+		} else if reclaimCleanupCapacity && (existing.view.State == StateCompleted || existing.view.State == StateFailed) {
 			restartIndexes = append(restartIndexes, index)
 		}
 		results[index] = CreateResult{Run: existing.view, Created: false}
@@ -499,7 +503,7 @@ AND state IN ('pending','preparing','running','stopping')`, group, group).Scan(&
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM local_runs WHERE deleted_at IS NULL AND state IN `+activeStates).Scan(&active); err != nil {
 		return nil, ErrStoreUnavailable
 	}
-	if active+len(newIndexes)+len(restartIndexes) > store.maxActiveRuns {
+	if active+len(newIndexes)+len(restartIndexes)+len(restartUpdateIndexes) > store.maxActiveRuns {
 		return nil, ErrCapacityExceeded
 	}
 	for _, index := range newIndexes {
@@ -555,6 +559,19 @@ run_id,idempotency_key,active_group,request_digest,snapshot,snapshot_digest,owne
 		candidate := prepared[index]
 		result, updateErr := tx.ExecContext(ctx, `UPDATE local_runs SET state='pending',revision=revision+1,updated_at=?,terminal_expires_at=NULL,reconcile_owner=NULL,reconcile_until=NULL,last_reason='workstation-restart-requested',terminal_target='' WHERE idempotency_key=? AND deleted_at IS NULL AND state IN ('completed','failed')`,
 			formatTimestamp(now), candidate.input.IdempotencyKey)
+		if updateErr != nil || rowsAffected(result) != 1 {
+			return nil, ErrStoreUnavailable
+		}
+		updated, found, queryErr := queryByIdempotency(ctx, tx, candidate.input.IdempotencyKey)
+		if queryErr != nil || !found {
+			return nil, ErrStoreUnavailable
+		}
+		results[index] = CreateResult{Run: updated.view, Created: false}
+	}
+	for _, index := range restartUpdateIndexes {
+		candidate := prepared[index]
+		result, updateErr := tx.ExecContext(ctx, `UPDATE local_runs SET snapshot=?,snapshot_digest=?,request_digest=?,pending_snapshot=NULL,pending_snapshot_digest='',state='pending',revision=revision+1,updated_at=?,terminal_expires_at=NULL,reconcile_owner=NULL,reconcile_until=NULL,last_reason='workstation-restart-with-configuration-requested',terminal_target='' WHERE idempotency_key=? AND deleted_at IS NULL AND state IN ('completed','failed')`,
+			candidate.snapshot, candidate.digest, candidate.digest, formatTimestamp(now), candidate.input.IdempotencyKey)
 		if updateErr != nil || rowsAffected(result) != 1 {
 			return nil, ErrStoreUnavailable
 		}

--- a/localcontroller/internal/dockerbackend/backend.go
+++ b/localcontroller/internal/dockerbackend/backend.go
@@ -307,7 +307,7 @@ func (backend *Backend) Ensure(ctx context.Context, desired controller.BackendRu
 		if err != nil {
 			return controller.BackendObservation{}, errors.New("egress configuration unavailable")
 		}
-		if err := backend.seedVolume(operationContext, names.egressPrivate, map[string]seedFile{
+		if err := backend.seedManagedFiles(operationContext, names.egressPrivate, map[string]seedFile{
 			"egressd.json": {content: egressConfig, mode: 0o600}, "broker-token": {content: []byte(tokens.egress), mode: 0o400},
 		}, labels); err != nil {
 			return controller.BackendObservation{}, controller.ErrBackendRetryable
@@ -850,10 +850,34 @@ type seedFile struct {
 }
 
 func (backend *Backend) seedVolume(ctx context.Context, volume string, files map[string]seedFile, labels ownedLabels) error {
+	return backend.seedVolumeWithCleanup(ctx, volume, files, labels, []string{"find /seed -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +"})
+}
+
+// seedManagedFiles replaces only controller-owned files. The same private
+// volume also holds the durable egress CA key, which must survive controller
+// restarts and configuration reconciliation.
+func (backend *Backend) seedManagedFiles(ctx context.Context, volume string, files map[string]seedFile, labels ownedLabels) error {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		if name == "" || filepath.Base(name) != name || strings.Contains(name, "..") {
+			return errors.New("invalid seed path")
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	cleanup := []string{"rm -f -- \"$@\"", "nvt-seed-managed"}
+	for _, name := range names {
+		cleanup = append(cleanup, "/seed/"+name)
+	}
+	return backend.seedVolumeWithCleanup(ctx, volume, files, labels, cleanup)
+}
+
+func (backend *Backend) seedVolumeWithCleanup(ctx context.Context, volume string, files map[string]seedFile, labels ownedLabels, cleanup []string) error {
 	arguments := []string{"create", "--entrypoint", "/bin/sh", "-v", volume + ":/seed"}
 	arguments = append(arguments, labelArguments(labels)...)
 	arguments = append(arguments, "--label", seedHelperLabel+"="+seedHelperValue)
-	arguments = append(arguments, backend.config.SeedImage, "-c", "find /seed -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +")
+	arguments = append(arguments, backend.config.SeedImage, "-c")
+	arguments = append(arguments, cleanup...)
 	created, err := backend.docker.Run(ctx, nil, arguments...)
 	if err != nil {
 		return err

--- a/localcontroller/internal/dockerbackend/backend_test.go
+++ b/localcontroller/internal/dockerbackend/backend_test.go
@@ -416,6 +416,37 @@ func TestDockerBackendRendersCompleteIdempotentZeroSecretStack(t *testing.T) {
 	}
 }
 
+func TestMediatedSeedPreservesDurableCAState(t *testing.T) {
+	backend, docker, run, _ := testBackend(t)
+	desired := controller.BackendRun{Resolved: run, SnapshotDigest: strings.Repeat("d", 64)}
+	if observation, err := backend.Ensure(context.Background(), desired); err != nil || !observation.Ready {
+		t.Fatalf("ensure = %#v %v", observation, err)
+	}
+
+	names := namesFor(backend.config, run.RunID, desired.SnapshotDigest)
+	found := false
+	for _, command := range docker.commands {
+		if len(command) == 0 || command[0] != "create" || !contains(command, names.egressPrivate+":/seed") {
+			continue
+		}
+		found = true
+		joined := strings.Join(command, " ")
+		for _, required := range []string{`rm -f -- "$@"`, "/seed/broker-token", "/seed/egressd.json"} {
+			if !strings.Contains(joined, required) {
+				t.Fatalf("managed egress seed omitted %q: %v", required, command)
+			}
+		}
+		for _, forbidden := range []string{"find /seed", "/seed/ca.key", "/seed/ca.key.rotation"} {
+			if strings.Contains(joined, forbidden) {
+				t.Fatalf("managed egress seed can remove durable CA state %q: %v", forbidden, command)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("managed egress seed helper was not created")
+	}
+}
+
 func TestSeedHelperIdentityIsVerified(t *testing.T) {
 	backend, docker, run, _ := testBackend(t)
 	labels := ownedLabels{Owner: backend.config.Owner, RunID: run.RunID, Digest: strings.Repeat("a", 64)}


### PR DESCRIPTION
## Summary

- preserve the durable mediated-egress CA key when refreshing controller-managed egress files
- restart configured persistent workstations from terminal state on controller startup while retaining deletion tombstones
- cover CA-safe seeding and terminal workstation recovery

## Verification

- `cd localcontroller && go vet ./...`
- `cd localcontroller && go test -race -count=1 ./...`
- live local restart recovery: `nvt`, `studio`, and `infra` are running and healthy with retained tmux sessions and gateway routes
- `cd localplatform && go test ./...` (all packages pass except pre-existing macOS-only `/bin/sh` incompatibility in `TestPrivateSourceValidationRejectsTrailingJournalBytes`; it uses GNU `stat -c`)
