### PR TITLE
docs: simplify public documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Open an issue before starting a large feature or contract change. Small fixes
+can go directly to a focused pull request.
+
+## Development
+
+1. Create a branch from current `main`.
+2. Keep changes within the existing component boundaries.
+3. Run the tests named in [AGENTS.md](AGENTS.md) for the code you changed.
+4. Do not commit credentials, generated local state, or personal configuration.
+
+## Pull requests
+
+- Use a concise title such as `feat:`, `fix:`, `docs:`, or `refactor:`.
+- Explain the behavior changed and why.
+- List the tests or checks run.
+- Keep generated files and documentation aligned with the implementation.
+
+By intentionally submitting a contribution for inclusion in this project, you
+agree that it is licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 <img src="assets/branding/nvt-agent-mark-512.png" alt="NVT Agent feather and sun mark" width="112">
 
-`nvt-agent` runs coding agents in isolated, reproducible environments. It works
-locally with Docker Compose and in Kubernetes through an operator.
+`nvt-agent` runs coding agents in isolated, reproducible environments. It uses
+Docker Compose for local development and a Kubernetes operator for production.
 
-Each agent gets a workspace, a terminal coding CLI, optional code-server access,
-runtime plugins, and its own Docker daemon. Codex and Claude Code are supported,
-but the runtime contract is CLI-agnostic.
+Each agent receives a workspace, a terminal coding CLI, optional code-server
+access, runtime plugins, and its own Docker daemon. Codex and Claude Code are
+supported, while the runtime contract remains CLI-agnostic.
 
-## How It Fits Together
+## Architecture
 
 ```mermaid
 flowchart LR
@@ -36,23 +36,22 @@ flowchart LR
     B --> E
 ```
 
-The components have deliberately narrow jobs:
-
 | Component | Responsibility |
 | --- | --- |
 | Runtime | Starts the coding CLI, workspace services, and plugins |
 | `agentd` | Queues prompts, interacts with the terminal session, and records events |
-| Operator | Creates and reconciles agent workloads in Kubernetes |
+| Operator | Reconciles agent workloads in Kubernetes |
 | Broker | Owns credentials, policy, refresh, and audit |
-| `egressd` | Applies broker-approved credentials at the network edge |
-| Gateway | Lists running agents and routes browser sessions |
-| Producers | Turn external work, such as GitHub comments, into agent runs |
+| `egressd` | Applies approved credentials at the network boundary |
+| Gateway | Lists agents and routes browser sessions |
+| Producers | Turn external work into agent runs |
 
-## Mediated Credentials
+## Mediated credentials
 
-In mediated mode, the agent receives placeholders rather than real provider
-credentials. Network traffic crosses a trusted egress boundary where the broker
-authorizes the request and `egressd` injects the credential.
+Mediated mode keeps real provider credentials outside the agent. File-based
+tools receive inert placeholders; other requests can leave the agent without a
+credential. Traffic passes through a trusted egress boundary, where `egressd`
+asks the broker what may be injected for the selected provider and destination.
 
 ```mermaid
 sequenceDiagram
@@ -62,25 +61,20 @@ sequenceDiagram
     participant Broker as Broker
     participant API as External API
 
-    Agent->>Capture: Request with inert placeholder
+    Agent->>Capture: Ordinary or placeholder request
     Capture->>Egress: Captured outbound request
-    Egress->>Broker: Provider, agent, host, method, path
-    Broker-->>Egress: Approved headers and expiry
-    Egress->>API: TLS request with real credential
+    Egress->>Broker: Agent, provider, destination, operation
+    Broker-->>Egress: Approved credential material
+    Egress->>API: Request with injected credential
     API-->>Egress: Response
     Egress-->>Agent: Response without credential material
 ```
 
-The broker is the only long-lived credential owner. It refreshes OAuth tokens,
-supports scoped GitHub App and token providers, records audit events, and can
-revoke grants while a run is active.
+Direct mode remains available for local development and integrations that are
+not mediated. Kubernetes deployments can enforce capture with NetworkPolicy
+and use a hardened `RuntimeClass`, including Kata Containers.
 
-Mediation is optional. Direct mode remains available for local development and
-tools that have not been moved behind broker-backed providers. Kubernetes can
-add NetworkPolicy enforcement and a hardened `RuntimeClass`, including Kata
-Containers.
-
-## Local Quick Start
+## Run locally
 
 Requirements: Docker with Compose, Make, and a browser.
 
@@ -89,52 +83,33 @@ cp nvt.local.example.yaml nvt.local.yaml
 make local-images local-init local-up
 ```
 
-Open:
+Open `http://nvt.agent.localhost:4090`.
 
-```text
-http://nvt.agent.localhost:4090
-```
+The local manifest defines profiles, repositories, workstations, workflows,
+accounts, broker providers, and producers. Secret inputs stay in the ignored
+`.nvt-local/secrets/` directory. Codex and Claude OAuth accounts are enrolled
+through **Manage credentials** in the gateway.
 
-`nvt.local.yaml` is the only local configuration entry point. It defines
-profiles, repositories, retention policies, persistent workstations, workflows,
-accounts, routes, broker grants, and producers. Secret files are referenced beneath the ignored
-`.nvt-local/secrets/` directory; Codex and Claude OAuth accounts are enrolled
-through the local portal. See [Native local workstations](docs/local-development-agent.md).
+See [Local development](docs/local-development-agent.md) for lifecycle and
+configuration details.
 
-## Kubernetes
+## Deploy to Kubernetes
 
-The Helm chart installs the operator, broker, CRDs, and optional gateway. A
-producer or another trusted client submits work to an `AgentSchedule`; the
-operator creates an `AgentRun` and reconciles its Pods, Services, policy, status,
-and cleanup.
+The Helm chart installs the CRDs, operator, broker, and optional gateway,
+credential portal, and GitHub comments producer. A trusted producer submits
+work to an `AgentSchedule`; the operator creates an `AgentRun` and reconciles
+its Pods, storage, Services, routes, policy, status, and cleanup.
 
-```mermaid
-flowchart TD
-    S[AgentSchedule] --> O[Operator admission]
-    O --> R[AgentRun CR]
-    R --> AP[Agent Pod]
-    R --> EP[Trusted egress service]
-    R --> NP[NetworkPolicies]
-    R --> SV[Services and gateway route]
-    AP --> EP
-    EP --> B[Broker]
-    EP --> NET[Approved external destinations]
-```
+See the [Helm chart guide](charts/nvt/README.md) for installation and production
+configuration.
 
-The local Compose backend is intended for development. Kubernetes is the
-production lifecycle and isolation model.
-
-## Extensibility
+## Extend nvt
 
 Runtime plugins are executables with small configuration contracts. They can
 check out repositories, expose tools, react to events, publish lifecycle
-signals, or integrate with external systems. Exported tools run inside the
-untrusted agent container, so secret-bearing operations should use broker-backed
-providers.
-
-Operator extensions are a separate concern: they influence scheduling,
-placement, provisioning, routing, and policy rather than behavior inside an
-agent session.
+signals, or integrate with external systems. Secret-bearing operations should
+use broker-backed providers because exported tools run in the untrusted agent
+container.
 
 See [Runtime plugins](runtime/plugins/README.md) and the contracts under
 [`protocol/`](protocol/).
@@ -142,29 +117,11 @@ See [Runtime plugins](runtime/plugins/README.md) and the contracts under
 ## Documentation
 
 - [Documentation map](docs/README.md)
-- [Local development agent](docs/local-development-agent.md)
-- [Codex authentication](docs/codex-auth.md)
-- [Claude authentication](docs/claude-auth.md)
-- [Transparent egress architecture](docs/transparent-egress-architecture.md)
-- [Local GitHub producer](docs/local-kind-github-producer.md)
-- [Helm charts and versioning](charts/README.md)
-- [`agentd` protocol](protocol/agentd.md)
+- [Transparent mediated egress](docs/transparent-egress-architecture.md)
+- [AgentRun API](operator/docs/agentrun.md)
+- [AgentSchedule API](operator/docs/agentschedule.md)
 - [Broker protocol](protocol/broker.md)
-- [Local controller protocol](protocol/local-controller.md)
-- [Local route metadata](protocol/local-routes.md)
-
-## Project Status
-
-The repository includes the local Compose runtime, Kubernetes operator,
-capability broker, mediated egress, agent gateway, GitHub comment producer, and
-Codex/Claude OAuth providers. Security-sensitive features remain opt-in so they
-can be introduced per workload and provider.
-
-Repository contribution and test guidance is in [AGENTS.md](AGENTS.md).
-
-## Acknowledgements
-
-Thanks to [agentdp](https://github.com/martinothamar/agentdp) for the inspiration.
+- [Contributing](CONTRIBUTING.md)
 
 ## License
 

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -114,31 +114,6 @@ is projected by Kubernetes for code-server, while the gateway must be restarted
 to reload its in-memory validated assets. Leave `existingConfigMap` empty to
 use the built-in branding.
 
-## Upgrading image values from 0.1
-
-Version 0.2 replaces scalar image values with repository/tag/pullPolicy maps.
-Migrate saved values before upgrading:
-
-```yaml
-# 0.1 (no longer accepted)
-operator:
-  image: nvt-operator:latest
-
-# 0.2
-operator:
-  image:
-    repository: ghcr.io/mirkosekulic/nvt-operator
-    tag: 0.2.0-943d5ba
-    pullPolicy: IfNotPresent
-```
-
-The same shape applies to runtime, broker, gateway, producer, egressd, and
-captured. A legacy scalar fails rendering with an explicit migration error.
-Do not use `--reuse-values` across this boundary; migrate the values file or
-reset stored values before the 0.2 upgrade. `make producer-kind-install` uses
-`--reset-values` and treats `PRODUCER_VALUES` as a complete consolidated-chart
-values file for this reason.
-
 ## GitHub comments producer
 
 The producer is integrated under `producer` and disabled by default. It keeps
@@ -567,12 +542,7 @@ Set it only when the cluster CNI enforces NetworkPolicy. The enforced kind
 smoke uses Calico because default kind networking does not prove the boundary.
 
 Forward-proxy transport remains available for clients that honor
-`HTTP(S)_PROXY`. For the pre-1.0 migration, replace
-`spec.egressForwardProxy: true` with `spec.egressTransport: forward-proxy`;
-remove a false legacy field or select `redirect` explicitly. The consolidated
-CRD retains a deprecated rejection-only tombstone so either legacy value fails
-loudly instead of being pruned. The tombstone has no behavior and may be removed
-in a later pre-1.0 release; migrate stored manifests before upgrading the chart.
+`HTTP(S)_PROXY`.
 
 `allowInsecureUpstreams` permits explicitly marked plain-HTTP fixtures for
 hermetic tests. Leave it false in real deployments; plaintext would expose an
@@ -865,21 +835,11 @@ callback. No repository permission or scope is needed for the current-user
 identity lookup. Owner matching uses only exact normalized issuer and immutable
 subject from `AgentRun.spec.profileProvenance.principal`; login/display name and
 requested-by annotations are ignored. See the [gateway
-README](../../gateway/README.md) for the OAuth2 trust boundary and the exact
-0.3 `github.*` to 0.4 `oauth2.*` migration.
+README](../../gateway/README.md) for the OAuth2 trust boundary.
 
 OAuth2 does not provide OIDC's cryptographically verified issuer/ID-token
 identity contract. Trusted operator configuration defines the issuer namespace
 and identity endpoint; prefer OIDC when available.
-
-Chart 0.4 removes the provider-specific 0.3 surface. Change
-`gateway.auth.mode: github` to `oauth2`, move `gateway.auth.github.credentials`,
-`callbackPath`, `issuer`, `authorizationURL`, and `tokenURL` beneath
-`gateway.auth.oauth2`, and replace `github.userURL` with
-`oauth2.identity.endpoint`. Add the endpoint's exact `allowedHosts` entry plus
-`subjectPath` and optional `displayNamePath`. Existing Secret names and key
-names may be retained. Old values fail validation; there is no automatic
-fallback.
 
 ### Path routing
 

--- a/charts/nvt/README.md
+++ b/charts/nvt/README.md
@@ -114,6 +114,31 @@ is projected by Kubernetes for code-server, while the gateway must be restarted
 to reload its in-memory validated assets. Leave `existingConfigMap` empty to
 use the built-in branding.
 
+## Upgrading image values from 0.1
+
+Version 0.2 replaces scalar image values with repository/tag/pullPolicy maps.
+Migrate saved values before upgrading:
+
+```yaml
+# 0.1 (no longer accepted)
+operator:
+  image: nvt-operator:latest
+
+# 0.2
+operator:
+  image:
+    repository: ghcr.io/mirkosekulic/nvt-operator
+    tag: 0.2.0-943d5ba
+    pullPolicy: IfNotPresent
+```
+
+The same shape applies to runtime, broker, gateway, producer, egressd, and
+captured. A legacy scalar fails rendering with an explicit migration error.
+Do not use `--reuse-values` across this boundary; migrate the values file or
+reset stored values before the 0.2 upgrade. `make producer-kind-install` uses
+`--reset-values` and treats `PRODUCER_VALUES` as a complete consolidated-chart
+values file for this reason.
+
 ## GitHub comments producer
 
 The producer is integrated under `producer` and disabled by default. It keeps
@@ -542,7 +567,12 @@ Set it only when the cluster CNI enforces NetworkPolicy. The enforced kind
 smoke uses Calico because default kind networking does not prove the boundary.
 
 Forward-proxy transport remains available for clients that honor
-`HTTP(S)_PROXY`.
+`HTTP(S)_PROXY`. For the pre-1.0 migration, replace
+`spec.egressForwardProxy: true` with `spec.egressTransport: forward-proxy`;
+remove a false legacy field or select `redirect` explicitly. The consolidated
+CRD retains a deprecated rejection-only tombstone so either legacy value fails
+loudly instead of being pruned. The tombstone has no behavior and may be removed
+in a later pre-1.0 release; migrate stored manifests before upgrading the chart.
 
 `allowInsecureUpstreams` permits explicitly marked plain-HTTP fixtures for
 hermetic tests. Leave it false in real deployments; plaintext would expose an
@@ -835,11 +865,21 @@ callback. No repository permission or scope is needed for the current-user
 identity lookup. Owner matching uses only exact normalized issuer and immutable
 subject from `AgentRun.spec.profileProvenance.principal`; login/display name and
 requested-by annotations are ignored. See the [gateway
-README](../../gateway/README.md) for the OAuth2 trust boundary.
+README](../../gateway/README.md) for the OAuth2 trust boundary and the exact
+0.3 `github.*` to 0.4 `oauth2.*` migration.
 
 OAuth2 does not provide OIDC's cryptographically verified issuer/ID-token
 identity contract. Trusted operator configuration defines the issuer namespace
 and identity endpoint; prefer OIDC when available.
+
+Chart 0.4 removes the provider-specific 0.3 surface. Change
+`gateway.auth.mode: github` to `oauth2`, move `gateway.auth.github.credentials`,
+`callbackPath`, `issuer`, `authorizationURL`, and `tokenURL` beneath
+`gateway.auth.oauth2`, and replace `github.userURL` with
+`oauth2.identity.endpoint`. Add the endpoint's exact `allowedHosts` entry plus
+`subjectPath` and optional `displayNamePath`. Existing Secret names and key
+names may be retained. Old values fail validation; there is no automatic
+fallback.
 
 ### Path routing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,61 +1,70 @@
 # Documentation
 
-Start with the repository [README](../README.md) for the system overview and
-local quick start. The documents below are the maintained sources of truth.
+Start with the repository [README](../README.md). Use this page to find the
+maintained guide or contract for a specific task.
 
-## Guides
+## Get started
 
-- [Native local workstations](local-development-agent.md): configure reusable
-  local profiles/workflows, persistent workstations, and producer schedules.
-- [Local Kubernetes GitHub producer](local-kind-github-producer.md): run
-  the operator, broker, producer, and real AgentRun Pods in kind.
-- [Claude authentication](claude-auth.md): direct and mediated Claude Code
-  authentication through the broker.
-- [Codex authentication](codex-auth.md): broker-managed Codex authentication
-  and the real mediated proof.
+- [Local development](local-development-agent.md): configure and operate local
+  workstations and producers.
+- [Local credentials](local-credential-portal.md): enroll Codex or Claude
+  accounts through the local gateway.
+- [Kubernetes installation](../charts/nvt/README.md): install and configure the
+  Helm chart.
+- [Local kind environment](local-kind-github-producer.md): run the Kubernetes
+  stack and GitHub producer in kind.
 
-## Architecture
+## Credentials and access
 
-- [OAuth2/OIDC login eligibility](oauth-eligibility.md): shared bounded claim
-  enrichment and default-deny array/scalar policy for gateway and portal.
-- [Transparent mediated egress](transparent-egress-architecture.md): current
-  trust boundaries, traffic paths, enforcement, and limitations.
-- [AgentRun API](../operator/docs/agentrun.md): workload specification and
-  lifecycle.
-- [AgentSchedule API](../operator/docs/agentschedule.md): admission,
-  parallelism, and duplicate-work behavior.
-- [Runtime plugins](../runtime/plugins/README.md): plugin contracts, tools,
-  events, and lifecycle hooks.
+- [Credential portal](credential-portal.md): self-service credential custody
+  and enrollment.
+- [Codex authentication](codex-auth.md): direct and mediated Codex modes.
+- [Claude authentication](claude-auth.md): API key and subscription OAuth
+  modes, including refresh behavior.
+- [OAuth2/OIDC eligibility](oauth-eligibility.md): login claim enrichment and
+  admission policy.
+- [Transparent mediated egress](transparent-egress-architecture.md): trust
+  boundaries, capture, injection, and enforcement.
+
+## Kubernetes APIs
+
+- [AgentRun](../operator/docs/agentrun.md): workload, runtime, workspace,
+  credentials, lifecycle, and status.
+- [AgentSchedule](../operator/docs/agentschedule.md): producer admission,
+  profiles, parallelism, and duplicate work.
+
+## Runtime and extension
+
+- [Runtime](../runtime/README.md): session startup, continuation, and prompt
+  recovery.
+- [Runtime plugins](../runtime/plugins/README.md): executable plugins, exported
+  tools, events, and lifecycle hooks.
+- [Gateway](../gateway/README.md): browser routing, login, and owner access.
+- [GitHub comments producer](../producers/github-comments/README.md): commands,
+  scheduling, and reactions.
 
 ## Protocols
 
 Files under [`protocol/`](../protocol/) are normative contracts:
 
-- [`agentd`](../protocol/agentd.md): session I/O and prompt queueing.
-- [Resolved agent runs](../protocol/resolved-agent-run.md): trusted,
-  provider-neutral local desired-run value.
-- [Local controller](../protocol/local-controller.md): trusted local run API,
-  durable cleanup-gated lifecycle state, and swappable Docker execution backend.
-- [Local route metadata](../protocol/local-routes.md): bounded controller-to-gateway
-  session/readiness and host exposure contract.
-- [Runtime session continuation](../runtime/README.md): optional generic fresh/resume commands, durable startup state, and pending-prompt recovery.
-- [Events](../protocol/events.md): JSONL event format.
-- [Broker](../protocol/broker.md): identities, grants, and provider material.
-- [Injection](../protocol/injection.md): mediated credential injection.
-- [Transparent egress](../protocol/transparent-egress.md): capture-to-egressd
-  transport.
+- [`agentd`](../protocol/agentd.md)
+- [Events](../protocol/events.md)
+- [Local manifest](../protocol/local-manifest.md)
+- [Resolved agent runs](../protocol/resolved-agent-run.md)
+- [Local controller](../protocol/local-controller.md)
+- [Local routes](../protocol/local-routes.md)
+- [Broker](../protocol/broker.md)
+- [Broker providers](../protocol/broker-provider.md)
+- [Prepared provider metadata](../protocol/prepared-provider-metadata.md)
+- [Credential injection](../protocol/injection.md)
+- [Transparent egress](../protocol/transparent-egress.md)
 
-## Operations And Testing
+## Testing
 
-- [CI coverage](ci-coverage.md): automated suites for supported paths.
-- [Kubernetes smoke tests](../tests/operator/kind/README.md): kind test cases.
-- [Helm chart](../charts/nvt/README.md): installation and production values.
-- [Gateway](../gateway/README.md): browser routing and OIDC authorization.
+- [CI coverage](ci-coverage.md)
+- [Kubernetes smoke tests](../tests/operator/kind/README.md)
+- [Kata smoke tests](../tests/operator/kata/README.md)
 
-Component READMEs explain only how to build, configure, or operate that
-component. If a component README conflicts with a protocol or API reference,
-the protocol or API reference is authoritative.
-
-Completed implementation plans are intentionally not retained in the active
-documentation tree. Git history and merged pull requests preserve that design
-history; maintained docs describe the system as it exists now.
+Protocol and API references take precedence over component READMEs. Git history
+and merged pull requests preserve completed design work; active documentation
+describes the current system.

--- a/docs/local-credential-portal.md
+++ b/docs/local-credential-portal.md
@@ -2,7 +2,7 @@
 
 Declaring a `codex-oauth` or `claude-oauth` account in `nvt.local.yaml`
 automatically enables the local credential portal. Start with `make local-up`,
-open `http://localhost:4090/agents`, and choose **Manage credentials**.
+open `http://nvt.agent.localhost:4090`, and choose **Manage credentials**.
 
 The manifest owns account names and presets. Slot names, portal configuration,
 runner/session keys, broker provider paths, and seed handoff are generated in

--- a/docs/local-development-agent.md
+++ b/docs/local-development-agent.md
@@ -1,10 +1,9 @@
-# Native local workstations
+# Local development
 
-The local backend is reproduced from one non-secret `nvt.local.yaml`, optional
-files beneath `.nvt-local/`, and broker-managed OAuth enrollment. Generated
-configuration, identities, admission credentials, databases, workspaces,
-runtime homes, Docker data, and sessions live in exactly labeled Docker
-volumes. There is no generated host Compose file or local `.env` file.
+The local platform is defined by `nvt.local.yaml`, private inputs beneath
+`.nvt-local/`, and broker-managed OAuth enrollment. Generated configuration,
+credentials, workspaces, Docker data, and sessions live in labeled Docker
+volumes. No generated Compose or `.env` file is written to the host.
 
 ## Configure and start
 
@@ -16,7 +15,11 @@ make local-up
 make local-status
 ```
 
-Open `http://localhost:4090/agents`. A workstation keeps its `/workspace`,
+Before `local-init`, replace the example repository and create the referenced
+PAT file. NVT scopes injection to that repository; the token's upstream
+permissions remain the outer limit.
+
+Open `http://nvt.agent.localhost:4090`. A workstation keeps its `/workspace`,
 runtime home, nested Docker data, and agent session across controller, Docker,
 Docker Desktop, and laptop restarts. The runtime resumes through its existing
 generic resume command.
@@ -30,8 +33,12 @@ Secret inputs must be regular, current-user-owned files below
 
 ```sh
 install -d -m 0700 .nvt-local/secrets/github
-install -m 0600 /safe/source/main-app.pem .nvt-local/secrets/github/main-app.pem
+install -m 0600 /safe/source/token .nvt-local/secrets/github/token
 ```
+
+A PAT is sufficient for workstation and workflow repository access. The
+built-in GitHub comments producer uses a GitHub App account instead; see its
+[configuration guide](../producers/github-comments/README.md).
 
 Declaring a Codex or Claude OAuth account enables **Manage credentials** in the
 gateway. Enroll it there; the broker imports it into canonical private storage.
@@ -52,22 +59,6 @@ gateway. Enroll it there; the broker imports it into canonical private storage.
 
 Removing a workstation from the manifest is non-destructive. Immutable drift
 for an existing workstation fails closed.
-
-## Clean-break upgrade
-
-There is no compatibility fallback or automatic migration from the former
-local layout.
-
-1. Preserve externally supplied PEM or PAT files you still need.
-2. Create `nvt.local.yaml` and copy those files into private paths below
-   `.nvt-local/secrets/`.
-3. Run `make local-images local-init local-up`, then enroll Codex or Claude
-   OAuth credentials through **Manage credentials**.
-4. Verify workstations and producers, then explicitly remove the old local
-   containers and volumes with the old checkout's Compose teardown. After
-   preserving any externally supplied files you still need, remove the legacy
-   `.broker/` directory. The new lifecycle never reads, adopts, or deletes
-   those resources for you.
 
 ## Troubleshooting
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -420,30 +420,6 @@ are discarded before session creation. The identity endpoint host must be
 explicitly allowlisted. Principals from different issuers are never guessed or
 linked; any account correlation requires an external explicit mapping.
 
-### Migration from chart 0.3
-
-Chart 0.4 removes `auth.mode=github` and `auth.github.*`. Migrate saved values
-to `auth.mode=oauth2` and the explicit `auth.oauth2.*` fields shown above. The
-old GitHub defaults are intentionally configuration now: issuer,
-authorization/token URLs, identity endpoint, host allowlist, and JSON paths
-must all be declared. Rename the credentials block but the referenced Secret
-and its `client-id`/`client-secret` keys may remain unchanged. There is no
-automatic compatibility fallback.
-
-| Chart 0.3 | Chart 0.4 |
-| --- | --- |
-| `auth.mode: github` | `auth.mode: oauth2` |
-| `auth.github.credentials` | `auth.oauth2.credentials` |
-| `auth.github.callbackPath` | `auth.oauth2.callbackPath` |
-| `auth.github.issuer` | `auth.oauth2.issuer` |
-| `auth.github.authorizationURL` | `auth.oauth2.authorizationURL` |
-| `auth.github.tokenURL` | `auth.oauth2.tokenURL` |
-| `auth.github.userURL` | `auth.oauth2.identity.endpoint` |
-
-Also set `auth.oauth2.clientAuthMethod`,
-`auth.oauth2.identity.allowedHosts`, `subjectPath`, and optional
-`displayNamePath`; these replace the removed adapter's implicit behavior.
-
 In path mode, `session.cookieDomain` must be empty so the gateway cookie is
 host-only, and its Path is scoped to the configured gateway base path. Secure
 session cookies are mandatory; do not broaden the cookie to `.altinn.studio`.

--- a/localcontroller/internal/controller/local_manifest_render_test.go
+++ b/localcontroller/internal/controller/local_manifest_render_test.go
@@ -45,10 +45,10 @@ func TestLocalManifestRendererProducesNativeWorkstations(t *testing.T) {
 		t.Fatal(err)
 	}
 	listed, err := store.List(context.Background(), 10, "")
-	if err != nil || len(listed.Runs) != 3 {
+	if err != nil || len(listed.Runs) != 1 {
 		t.Fatalf("rendered workstations = %#v, %v", listed, err)
 	}
-	for _, runID := range []string{"infra", "nvt", "studio"} {
+	for _, runID := range []string{"project"} {
 		snapshot, _, snapshotErr := store.ResolvedSnapshot(context.Background(), runID)
 		if snapshotErr != nil {
 			t.Fatal(snapshotErr)

--- a/localplatform/lifecycle/render_test.go
+++ b/localplatform/lifecycle/render_test.go
@@ -26,14 +26,7 @@ func TestRenderCompleteComposeWithoutHostAuthoredState(t *testing.T) {
 	if err := os.MkdirAll(secretDirectory, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(secretDirectory, "app.pem"), []byte("test-private-input"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	studioSecretDirectory := filepath.Join(root, ".nvt-local", "secrets", "studio")
-	if err := os.MkdirAll(studioSecretDirectory, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(studioSecretDirectory, "token"), []byte("test-static-token"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(secretDirectory, "token"), []byte("test-private-input"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, example, 0o600); err != nil {

--- a/nvt.local.example.yaml
+++ b/nvt.local.example.yaml
@@ -6,13 +6,6 @@ retentionPolicies:
       workspace: true
       runtimeState: true
       dockerData: true
-  retained:
-    persistence:
-      workspace: true
-      runtimeState: true
-      dockerData: true
-    ttl:
-      activeSeconds: 86400
   disposable:
     ttl:
       activeSeconds: 604800
@@ -21,51 +14,41 @@ retentionPolicies:
       runRetentionSeconds: 86400
 
 secrets:
-  github-key:
-    file: ./.nvt-local/secrets/github/app.pem
-  studio-token:
-    file: ./.nvt-local/secrets/studio/token
+  github-token:
+    file: ./.nvt-local/secrets/github/token
 
 accounts:
-  github:
-    preset: github-app
-    appId: "1"
-    privateKeySecret: github-key
-    installations:
-      mirkoSekulic: "1"
+  codex:
+    preset: codex-oauth
 
 brokerProviders:
-  studio:
+  github:
     plugin: token
     config:
-      injection-hosts: [altinn.studio]
+      injection-hosts: [github.com, api.github.com]
       injection-git: true
-      injection-basic-username: oauth2
-      target-mode: literal
+      injection-basic-username: x-access-token
+      target-mode: github
     secrets:
-      token-file: studio-token
+      token-file: github-token
     mediation:
-      hosts: [altinn.studio]
+      hosts: [github.com, api.github.com]
       materialization: header-inject
       git: true
-      username: oauth2
-      targetMode: literal
+      username: x-access-token
+      targetMode: github
 
 profiles:
   development:
     runtime:
-      preset: shell
+      preset: codex
       autonomy: trusted-local
+      account: codex
     editor:
       preset: code-server
-    accounts: [github]
-    credentialProviders: [studio]
+    accounts: [codex]
+    credentialProviders: [github]
     defaultCredentialProvider: github
-    egress:
-      domainPolicy:
-        defaultAction: deny
-        allow: [github.com, altinn.studio]
-        deny: [pastebin.com]
     plugins:
       - work-control
       - name: github-watcher
@@ -75,52 +58,28 @@ profiles:
           provider: github
 
 repositories:
-  nvt-agent:
-    github: mirkoSekulic/nvt-agent
-    account: github
-    access:
-      permissions:
-        contents: write
-        pull_requests: write
-        workflows: write
-  studio:
-    url: https://altinn.studio/repos/altinn/altinn-studio.git
-    checkoutTarget: altinn.studio/repos/altinn/altinn-studio
-    brokerRepository: altinn.studio/repos/altinn/altinn-studio
-    credentialProvider: studio
-  infrastructure:
-    github: Altinn/altinn-platform
+  project:
+    url: https://github.com/example-org/example-repo.git
+    checkoutTarget: github.com/example-org/example-repo
+    brokerRepository: example-org/example-repo
+    credentialProvider: github
 
 workstations:
-  - name: nvt
+  - name: project
     profile: development
-    repositories: [nvt-agent]
-  - name: studio
-    profile: development
-    repositories: [studio]
-  - name: infra
-    profile: development
-    repositories: [infrastructure]
+    repositories: [project]
 
 workflows:
-  nvt-development:
+  implement:
     profile: development
-    repository: nvt-agent
+    repository: project
     retention: disposable
     lifecycle:
       completeOn: [plugin.github.pr.merged, plugin.github.pr.closed]
-  nvt-review:
+  review:
     profile: development
-    repository: nvt-agent
+    repository: project
     retention: disposable
     lifecycle:
       completeOn: [plugin.work.completed]
       failOn: [plugin.work.failed]
-  studio-development:
-    profile: development
-    repository: studio
-    retention: disposable
-  infrastructure:
-    profile: development
-    repository: infrastructure
-    retention: retained

--- a/runtime/plugins/README.md
+++ b/runtime/plugins/README.md
@@ -281,7 +281,7 @@ runtime/plugins/my-plugin/
 To create a custom plugin for one agent:
 
 ```sh
-make plugin-init NAME=my-plugin DIR=.agents/frontend/custom-plugins
+make plugin-init NAME=my-plugin DIR=.nvt-local/plugins
 ```
 
 The generated `plugin.yaml` includes common plugin metadata:


### PR DESCRIPTION
## Summary

- make the README and documentation index shorter and easier to navigate
- replace obsolete migration guidance and stale paths with current usage
- provide a provider-neutral local example using mediated PAT access and OAuth runtime enrollment
- add concise contribution guidance

## Checks

- `go test ./manifest ./config ./lifecycle ./producer` from `localplatform/`
- relative Markdown link validation
- `git diff --check`

The full `localplatform` suite was also attempted. `TestPrivateSourceValidationRejectsTrailingJournalBytes` fails on macOS because its shell fixture uses GNU `stat -c`; the same failure was reproduced on untouched `origin/main`.