### PR TITLE
local: support GitHub issues permission

### DIFF
--- a/localplatform/config/render_test.go
+++ b/localplatform/config/render_test.go
@@ -400,12 +400,12 @@ profiles:
 	}
 }
 
-func TestExplicitWorkflowWriteRendersForGitHubApp(t *testing.T) {
+func TestExplicitGitHubPermissionsRenderForGitHubApp(t *testing.T) {
 	raw, err := os.ReadFile("../manifest/testdata/valid.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
-	input := strings.Replace(string(raw), "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        contents: write\n        pull_requests: write\n        workflows: write\n  infrastructure:", 1)
+	input := strings.Replace(string(raw), "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        contents: write\n        issues: write\n        pull_requests: write\n        workflows: write\n  infrastructure:", 1)
 	decoded, err := manifest.Decode(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)
@@ -423,8 +423,8 @@ func TestExplicitWorkflowWriteRendersForGitHubApp(t *testing.T) {
 		t.Fatal(err)
 	}
 	for label, rendered := range map[string][]byte{"broker": broker, "controller": controller} {
-		if !bytes.Contains(rendered, []byte(`"workflows":"write"`)) {
-			t.Fatalf("%s omitted explicit workflow write: %s", label, rendered)
+		if !bytes.Contains(rendered, []byte(`"issues":"write"`)) || !bytes.Contains(rendered, []byte(`"workflows":"write"`)) {
+			t.Fatalf("%s omitted explicit GitHub permission: %s", label, rendered)
 		}
 	}
 }

--- a/localplatform/manifest/manifest.go
+++ b/localplatform/manifest/manifest.go
@@ -855,7 +855,7 @@ func validateRepository(value Repository, accounts map[string]Account, providers
 			return errors.New("repository access permissions must not be empty")
 		}
 		for permission, level := range value.Access.Permissions {
-			if !oneOf(permission, "contents", "pull_requests", "workflows") || !oneOf(level, "read", "write") {
+			if !oneOf(permission, "contents", "issues", "pull_requests", "workflows") || !oneOf(level, "read", "write") {
 				return errors.New("repository access has an unsupported permission or level")
 			}
 		}

--- a/localplatform/manifest/manifest_test.go
+++ b/localplatform/manifest/manifest_test.go
@@ -704,7 +704,7 @@ func TestRepositoryAccessValidationAndCompilation(t *testing.T) {
 		t.Fatal(err)
 	}
 	base := string(raw)
-	withAccess := strings.Replace(base, "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        contents: write\n        pull_requests: write\n        workflows: write\n  infrastructure:", 1)
+	withAccess := strings.Replace(base, "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        contents: write\n        issues: write\n        pull_requests: write\n        workflows: write\n  infrastructure:", 1)
 	decoded, err := Decode(strings.NewReader(withAccess))
 	if err != nil {
 		t.Fatal(err)
@@ -713,14 +713,16 @@ func TestRepositoryAccessValidationAndCompilation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := compiled.Broker.Repositories[1].Permissions["workflows"]; got != "write" {
-		t.Fatalf("compiled workflow permission = %q", got)
+	permissions := compiled.Broker.Repositories[1].Permissions
+	if permissions["issues"] != "write" || permissions["workflows"] != "write" {
+		t.Fatalf("compiled repository permissions = %#v", permissions)
 	}
 
 	for name, mutation := range map[string]string{
 		"unknown permission":             strings.Replace(withAccess, "workflows: write", "administration: write", 1),
 		"invalid level":                  strings.Replace(withAccess, "workflows: write", "workflows: admin", 1),
 		"contradictory workflow write":   strings.Replace(withAccess, "contents: write", "contents: read", 1),
+		"issues without checkout":        strings.Replace(base, "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        issues: write\n  infrastructure:", 1),
 		"pull requests without checkout": strings.Replace(base, "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        pull_requests: write\n  infrastructure:", 1),
 		"workflow read without checkout": strings.Replace(base, "    account: github\n  infrastructure:", "    account: github\n    access:\n      permissions:\n        workflows: read\n  infrastructure:", 1),
 	} {

--- a/protocol/local-manifest.md
+++ b/protocol/local-manifest.md
@@ -120,14 +120,16 @@ same URL-validated owner in both broker and controller projections.
 
 GitHub repository authority is declared independently from credential
 acquisition with `repositories.<name>.access.permissions`. Supported permission
-names are `contents`, `pull_requests`, and `workflows`; supported levels are
-`read` and `write`. When `access` is omitted, the pre-1.0 least-privilege
+names are `contents`, `issues`, `pull_requests`, and `workflows`; supported
+levels are `read` and `write`. When `access` is omitted, the pre-1.0 least-privilege
 default is `contents: write` plus `pull_requests: write`. Workflow-file writes
 are never implicit: they require an explicit `workflows: write` declaration,
-which also requires `contents: write`. Every explicit access declaration must
-include at least `contents: read` because checkout is mandatory. Empty access maps, unknown permissions,
-unknown levels, access on an uncredentialed or non-GitHub repository, and
-contradictory workflow-write declarations fail validation.
+which also requires `contents: write`. Creating, editing, or commenting on issues
+requires an explicit `issues: write` declaration. Every explicit access
+declaration must include at least `contents: read` because checkout is mandatory.
+Empty access maps, unknown permissions, unknown levels, access on an
+uncredentialed or non-GitHub repository, and contradictory workflow-write
+declarations fail validation.
 
 For a GitHub App account, the compiler places the exact requested permissions
 in each agent grant and computes the provider ceiling from the union of the
@@ -149,6 +151,7 @@ repositories:
     access:
       permissions:
         contents: write
+        issues: write
         pull_requests: write
         workflows: write
 ```


### PR DESCRIPTION
## Summary

- allow repository grants to request GitHub `issues` read/write permission
- project the permission through local broker and controller configuration
- document its explicit, repository-scoped behavior and upstream GitHub App ceiling
- cover compilation, rendering, and checkout validation

## Checks

- `go test -race -count=1 ./...` (from `localplatform`)
- `go vet ./...` (from `localplatform`)
- `git diff --check`
